### PR TITLE
sixtom v1.4 — marquee fix + Playwright e2e + test-email bypass

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,5 +11,8 @@ SMTP_PORT=""
 CONTACT_FORM_MIN_SUBMIT_MS="3000"
 CONTACT_FORM_RATE_LIMIT_WINDOW_MS="60000"
 CONTACT_FORM_RATE_LIMIT_MAX_REQUESTS="5"
+# E2E only — must be empty in production. If set, submissions whose email
+# exactly matches this value return success without invoking SMTP.
+CONTACT_FORM_TEST_EMAIL=""
 CAL_API_KEY=""
 CAL_USERNAME=""

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,7 @@ vite.config.js.timestamp-*
 vite.config.ts.timestamp-*
 
 *storybook.log
+
+/test-results/
+/playwright-report/
+/playwright/.cache/

--- a/e2e/constants.ts
+++ b/e2e/constants.ts
@@ -1,0 +1,3 @@
+// Shared between playwright.config (sets webServer.env) and the spec (uses it in fixtures).
+// `*.local` is a non-routable RFC-6762 TLD so a leak doesn't point at a real inbox.
+export const TEST_EMAIL = 'e2e@test.sixtom.local'

--- a/e2e/notify-form.spec.ts
+++ b/e2e/notify-form.spec.ts
@@ -1,19 +1,12 @@
 import { test, expect } from '@playwright/test'
-
-const TEST_EMAIL = 'e2e@test.sixtom.local'
+import { TEST_EMAIL } from './constants'
 
 test.describe('Notify form — progressive enhancement', () => {
-	test('JS-enhanced path: inline "Sending…" then inline success without page reload', async ({
-		page
-	}) => {
+	test('JS-enhanced path: inline result without page reload', async ({ page }) => {
 		await page.goto('/')
 
-		// Wait for the lazy enhancement script to have stamped formStartedAt.
 		await expect(page.locator('[data-form-started-at]')).toHaveAttribute('value', /^\d+$/)
 		await expect(page.locator('[data-form-enhanced]')).toHaveAttribute('value', '1')
-
-		// Time-trap requires >= 3s between page load and submit.
-		await page.waitForTimeout(3200)
 
 		const url = page.url()
 		await page.fill('input[type="email"]', TEST_EMAIL)
@@ -23,8 +16,6 @@ test.describe('Notify form — progressive enhancement', () => {
 			page.click('button[type="submit"]')
 		])
 		expect(response.status()).toBe(200)
-
-		// No navigation should have happened — the script intercepted submit.
 		expect(page.url()).toBe(url)
 
 		await expect(page.locator('[data-enhance-result] p')).toHaveText(/you're on the list/i)
@@ -45,16 +36,15 @@ test.describe('Notify form — progressive enhancement', () => {
 			page.locator('button[type="submit"]').click({ force: true })
 		])
 
-		// With JS off the time-trap is skipped (enhanced flag isn't set) — request reaches the action.
 		await expect(page.locator('[data-enhance-result] p')).toHaveText(/you're on the list/i)
 		await context.close()
 	})
 
 	test('honeypot: filled `company` returns silent success', async ({ page }) => {
 		await page.goto('/')
-		await page.waitForTimeout(3200)
 
-		await page.fill('input[type="email"]', TEST_EMAIL)
+		// Non-bypass email so we exercise the honeypot path itself, not the test-email shortcut.
+		await page.fill('input[type="email"]', 'real-looking@example.com')
 		await page.locator('input[name="company"]').evaluate((el: HTMLInputElement) => {
 			el.value = 'AcmeCorp'
 		})
@@ -70,9 +60,7 @@ test.describe('Notify form — progressive enhancement', () => {
 
 	test('malformed email: server rejects with inline error', async ({ page }) => {
 		await page.goto('/')
-		await page.waitForTimeout(3200)
 
-		// Override the input type so the browser's HTML5 validation lets us submit a bad value.
 		await page.locator('input[type="email"]').evaluate((el: HTMLInputElement) => {
 			el.setAttribute('type', 'text')
 		})
@@ -86,10 +74,13 @@ test.describe('Notify form — progressive enhancement', () => {
 		await expect(page.locator('[data-enhance-result] p')).toHaveText(/invalid/i)
 	})
 
-	test('all 5 marquee copies are rendered (no empty space on wide viewports)', async ({ page }) => {
+	test('marquee renders multiple copies for seamless tiling on wide viewports', async ({
+		page
+	}) => {
 		await page.setViewportSize({ width: 2400, height: 800 })
 		await page.goto('/')
-		const tracks = page.locator('.marquee-track > div')
-		await expect(tracks).toHaveCount(6)
+		const copies = page.locator('[data-marquee-copy]')
+		// At least 4 covers most laptop viewports; the component picks the exact count.
+		await expect(copies).toHaveCount(6)
 	})
 })

--- a/e2e/notify-form.spec.ts
+++ b/e2e/notify-form.spec.ts
@@ -1,0 +1,95 @@
+import { test, expect } from '@playwright/test'
+
+const TEST_EMAIL = 'e2e@test.sixtom.local'
+
+test.describe('Notify form — progressive enhancement', () => {
+	test('JS-enhanced path: inline "Sending…" then inline success without page reload', async ({
+		page
+	}) => {
+		await page.goto('/')
+
+		// Wait for the lazy enhancement script to have stamped formStartedAt.
+		await expect(page.locator('[data-form-started-at]')).toHaveAttribute('value', /^\d+$/)
+		await expect(page.locator('[data-form-enhanced]')).toHaveAttribute('value', '1')
+
+		// Time-trap requires >= 3s between page load and submit.
+		await page.waitForTimeout(3200)
+
+		const url = page.url()
+		await page.fill('input[type="email"]', TEST_EMAIL)
+
+		const [response] = await Promise.all([
+			page.waitForResponse((r) => r.url().includes('/?/notify') && r.request().method() === 'POST'),
+			page.click('button[type="submit"]')
+		])
+		expect(response.status()).toBe(200)
+
+		// No navigation should have happened — the script intercepted submit.
+		expect(page.url()).toBe(url)
+
+		await expect(page.locator('[data-enhance-result] p')).toHaveText(/you're on the list/i)
+	})
+
+	test('no-JS path: native form POST renders server-side success on reload', async ({
+		browser
+	}) => {
+		const context = await browser.newContext({ javaScriptEnabled: false })
+		const page = await context.newPage()
+		await page.goto('/', { waitUntil: 'domcontentloaded' })
+
+		await page.fill('input[type="email"]', TEST_EMAIL)
+		// force:true because the marquee CSS animation can briefly trip Playwright's
+		// stability check; the button itself is interactable.
+		await Promise.all([
+			page.waitForLoadState('load'),
+			page.locator('button[type="submit"]').click({ force: true })
+		])
+
+		// With JS off the time-trap is skipped (enhanced flag isn't set) — request reaches the action.
+		await expect(page.locator('[data-enhance-result] p')).toHaveText(/you're on the list/i)
+		await context.close()
+	})
+
+	test('honeypot: filled `company` returns silent success', async ({ page }) => {
+		await page.goto('/')
+		await page.waitForTimeout(3200)
+
+		await page.fill('input[type="email"]', TEST_EMAIL)
+		await page.locator('input[name="company"]').evaluate((el: HTMLInputElement) => {
+			el.value = 'AcmeCorp'
+		})
+
+		const [response] = await Promise.all([
+			page.waitForResponse((r) => r.url().includes('/?/notify')),
+			page.click('button[type="submit"]')
+		])
+		expect(response.status()).toBe(200)
+
+		await expect(page.locator('[data-enhance-result] p')).toHaveText(/you're on the list/i)
+	})
+
+	test('malformed email: server rejects with inline error', async ({ page }) => {
+		await page.goto('/')
+		await page.waitForTimeout(3200)
+
+		// Override the input type so the browser's HTML5 validation lets us submit a bad value.
+		await page.locator('input[type="email"]').evaluate((el: HTMLInputElement) => {
+			el.setAttribute('type', 'text')
+		})
+		await page.fill('input[name="email"]', 'not-an-email')
+
+		await Promise.all([
+			page.waitForResponse((r) => r.url().includes('/?/notify')),
+			page.click('button[type="submit"]')
+		])
+
+		await expect(page.locator('[data-enhance-result] p')).toHaveText(/invalid/i)
+	})
+
+	test('all 5 marquee copies are rendered (no empty space on wide viewports)', async ({ page }) => {
+		await page.setViewportSize({ width: 2400, height: 800 })
+		await page.goto('/')
+		const tracks = page.locator('.marquee-track > div')
+		await expect(tracks).toHaveCount(6)
+	})
+})

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -37,7 +37,8 @@ export default defineConfig(
 						'eslint.config.js',
 						'svelte.config.js',
 						'playwright.config.ts',
-						'e2e/*.spec.ts'
+						'e2e/constants.ts',
+						'e2e/notify-form.spec.ts'
 					]
 				},
 				extraFileExtensions: ['.svelte'],
@@ -55,7 +56,8 @@ export default defineConfig(
 						'eslint.config.js',
 						'svelte.config.js',
 						'playwright.config.ts',
-						'e2e/*.spec.ts'
+						'e2e/constants.ts',
+						'e2e/notify-form.spec.ts'
 					]
 				},
 				extraFileExtensions: ['.svelte'],

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -14,7 +14,9 @@ export default defineConfig(
 			'.vercel/**',
 			'node_modules/**',
 			'coverage/**',
-			'static/**'
+			'static/**',
+			'playwright-report/**',
+			'test-results/**'
 		]
 	},
 	js.configs.recommended,
@@ -31,7 +33,12 @@ export default defineConfig(
 			},
 			parserOptions: {
 				projectService: {
-					allowDefaultProject: ['eslint.config.js', 'svelte.config.js']
+					allowDefaultProject: [
+						'eslint.config.js',
+						'svelte.config.js',
+						'playwright.config.ts',
+						'e2e/*.spec.ts'
+					]
 				},
 				extraFileExtensions: ['.svelte'],
 				tsconfigRootDir: import.meta.dirname
@@ -44,7 +51,12 @@ export default defineConfig(
 			parserOptions: {
 				parser: ts.parser,
 				projectService: {
-					allowDefaultProject: ['eslint.config.js', 'svelte.config.js']
+					allowDefaultProject: [
+						'eslint.config.js',
+						'svelte.config.js',
+						'playwright.config.ts',
+						'e2e/*.spec.ts'
+					]
 				},
 				extraFileExtensions: ['.svelte'],
 				tsconfigRootDir: import.meta.dirname

--- a/package.json
+++ b/package.json
@@ -12,10 +12,12 @@
 		"lint": "prettier --check . && eslint .",
 		"test": "vitest --run",
 		"test:unit": "vitest",
+		"test:e2e": "playwright test",
 		"cal:sync": "tsx scripts/sync-cal.ts"
 	},
 	"devDependencies": {
 		"@eslint/js": "10.0.1",
+		"@playwright/test": "1.60.0",
 		"@sveltejs/kit": "2.60.1",
 		"@sveltejs/vite-plugin-svelte": "7.1.2",
 		"@types/node": "25.8.0",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,4 +1,5 @@
 import { defineConfig, devices } from '@playwright/test'
+import { TEST_EMAIL } from './e2e/constants'
 
 const PORT = '4173'
 const BASE_URL = `http://127.0.0.1:${PORT}`
@@ -6,6 +7,8 @@ const inCI = process.env.CI === 'true' || process.env.CI === '1'
 
 export default defineConfig({
 	testDir: 'e2e',
+	// Sequential because processSubmission's rate-limit Map is process-global; parallel
+	// tests on the same dev IP would trigger 429 across tests.
 	fullyParallel: false,
 	forbidOnly: inCI,
 	retries: inCI ? 2 : 0,
@@ -16,14 +19,15 @@ export default defineConfig({
 	},
 	projects: [{ name: 'chromium', use: { ...devices['Desktop Chrome'] } }],
 	webServer: {
-		// pnpm preview serves the production build; matches what Lighthouse + production see.
 		command: `pnpm build && pnpm preview --port ${PORT} --host 127.0.0.1`,
 		url: BASE_URL,
-		timeout: 120_000,
+		timeout: 180_000,
 		reuseExistingServer: !inCI,
 		env: {
-			// Bypass SMTP for the form-action test; processSubmission honors this env var.
-			CONTACT_FORM_TEST_EMAIL: 'e2e@test.sixtom.local'
+			CONTACT_FORM_TEST_EMAIL: TEST_EMAIL,
+			// 1ms keeps the time-trap path live (still a real check) without forcing each
+			// test to wait 3s. The unit test asserts the trap fires at the threshold.
+			CONTACT_FORM_MIN_SUBMIT_MS: '1'
 		}
 	}
 })

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,29 @@
+import { defineConfig, devices } from '@playwright/test'
+
+const PORT = '4173'
+const BASE_URL = `http://127.0.0.1:${PORT}`
+const inCI = process.env.CI === 'true' || process.env.CI === '1'
+
+export default defineConfig({
+	testDir: 'e2e',
+	fullyParallel: false,
+	forbidOnly: inCI,
+	retries: inCI ? 2 : 0,
+	reporter: 'list',
+	use: {
+		baseURL: BASE_URL,
+		trace: 'on-first-retry'
+	},
+	projects: [{ name: 'chromium', use: { ...devices['Desktop Chrome'] } }],
+	webServer: {
+		// pnpm preview serves the production build; matches what Lighthouse + production see.
+		command: `pnpm build && pnpm preview --port ${PORT} --host 127.0.0.1`,
+		url: BASE_URL,
+		timeout: 120_000,
+		reuseExistingServer: !inCI,
+		env: {
+			// Bypass SMTP for the form-action test; processSubmission honors this env var.
+			CONTACT_FORM_TEST_EMAIL: 'e2e@test.sixtom.local'
+		}
+	}
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -56,6 +56,9 @@ importers:
       '@eslint/js':
         specifier: 10.0.1
         version: 10.0.1(eslint@10.4.0(jiti@2.7.0))
+      '@playwright/test':
+        specifier: 1.60.0
+        version: 1.60.0
       '@sveltejs/kit':
         specifier: 2.60.1
         version: 2.60.1(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.55.7(@typescript-eslint/types@8.59.3))(vite@8.0.13(@types/node@25.8.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.47.1)(tsx@4.22.1)(yaml@2.9.0)))(svelte@5.55.7(@typescript-eslint/types@8.59.3))(typescript@6.0.3)(vite@8.0.13(@types/node@25.8.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.47.1)(tsx@4.22.1)(yaml@2.9.0))
@@ -1950,6 +1953,11 @@ packages:
 
   '@oxc-project/types@0.130.0':
     resolution: {integrity: sha512-ibD2usx9JRu7f5pu2tMKMI4cpA4NgXJQoYRP4pQ7Pxmn1l6k/53qWtQWZayhYy3X4QZkt90Ot+mJEaeXouio6Q==}
+
+  '@playwright/test@1.60.0':
+    resolution: {integrity: sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   '@pnpm/config.env-replace@1.1.0':
     resolution: {integrity: sha512-htyl8TWnKL7K/ESFa1oW2UB5lVDxuF5DpM7tBi6Hu2LNL3mWkIzNLG6N4zoCUP1lCKNxWy/3iu8mS8MvToGd6w==}
@@ -3888,6 +3896,11 @@ packages:
       react-dom:
         optional: true
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -4856,6 +4869,16 @@ packages:
 
   player.style@0.3.4:
     resolution: {integrity: sha512-5O9bkbq0APQIkhptyZwp0gUgheCeImGPFo4hvPF2M5xBmgsUYzsUPHCfMye2xyeRE1zvQBKtziaC3jPgnHE1tw==}
+
+  playwright-core@1.60.0:
+    resolution: {integrity: sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.60.0:
+    resolution: {integrity: sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   pluralize-esm@9.0.5:
     resolution: {integrity: sha512-Kb2dcpMsIutFw2hYrN0EhsAXOUJTd6FVMIxvNAkZCMQLVt9NGZqQczvGpYDxNWCZeCWLHUPxQIBudWzt1h7VVA==}
@@ -7986,6 +8009,10 @@ snapshots:
 
   '@oxc-project/types@0.130.0': {}
 
+  '@playwright/test@1.60.0':
+    dependencies:
+      playwright: 1.60.0
+
   '@pnpm/config.env-replace@1.1.0': {}
 
   '@pnpm/network.ca-file@1.0.2':
@@ -10242,6 +10269,9 @@ snapshots:
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
@@ -11139,6 +11169,14 @@ snapshots:
       media-chrome: 4.19.0(react@19.2.6)
     transitivePeerDependencies:
       - react
+
+  playwright-core@1.60.0: {}
+
+  playwright@1.60.0:
+    dependencies:
+      playwright-core: 1.60.0
+    optionalDependencies:
+      fsevents: 2.3.2
 
   pluralize-esm@9.0.5: {}
 

--- a/src/app.css
+++ b/src/app.css
@@ -54,7 +54,7 @@ html {
 }
 
 .marquee-track {
-	animation: marquee 40s linear infinite;
+	animation: marquee 60s linear infinite;
 }
 
 @keyframes marquee {
@@ -62,7 +62,8 @@ html {
 		transform: translateX(0);
 	}
 	to {
-		transform: translateX(-50%);
+		/* Move by exactly one copy's width so loop is seamless. */
+		transform: translateX(calc(-100% / var(--marquee-copies, 2)));
 	}
 }
 

--- a/src/app.css
+++ b/src/app.css
@@ -62,8 +62,8 @@ html {
 		transform: translateX(0);
 	}
 	to {
-		/* Move by exactly one copy's width so loop is seamless. */
-		transform: translateX(calc(-100% / var(--marquee-copies, 2)));
+		/* One copy's width — caller must set --marquee-copies on the element. */
+		transform: translateX(calc(-100% / var(--marquee-copies)));
 	}
 }
 

--- a/src/lib/components/LeadCapture.svelte
+++ b/src/lib/components/LeadCapture.svelte
@@ -72,30 +72,25 @@
 		class="w-full overflow-hidden border-t border-neutral-800 bg-black py-6"
 		aria-label="Mission marquee"
 	>
-		<div class="marquee-track flex w-max items-center gap-12 text-lg whitespace-nowrap">
-			<span class="font-semibold text-neutral-100">we just want to build cool shit</span>
-			<span class="text-coin" aria-hidden="true">★</span>
-			<a
-				href={site.gardenUrl}
-				data-umami-event="cta_garden_link"
-				class="hover:text-coin font-semibold text-neutral-100 transition-colors"
-				rel="noopener noreferrer"
-				target="_blank">more at the garden →</a
-			>
-			<span class="text-coin" aria-hidden="true">★</span>
-			<span class="font-semibold text-neutral-100" aria-hidden="true"
-				>we just want to build cool shit</span
-			>
-			<span class="text-coin" aria-hidden="true">★</span>
-			<a
-				href={site.gardenUrl}
-				class="hover:text-coin font-semibold text-neutral-100 transition-colors"
-				aria-hidden="true"
-				tabindex="-1"
-				rel="noopener noreferrer"
-				target="_blank">more at the garden →</a
-			>
-			<span class="text-coin" aria-hidden="true">★</span>
+		<div
+			class="marquee-track flex w-max items-center text-lg whitespace-nowrap"
+			style="--marquee-copies: 6"
+		>
+			{#each Array(6), i (i)}
+				<div class="flex items-center gap-12 pr-12" aria-hidden={i !== 0}>
+					<span class="font-semibold text-neutral-100">we just want to build cool shit</span>
+					<span class="text-coin">★</span>
+					<a
+						href={site.gardenUrl}
+						data-umami-event={i === 0 ? 'cta_garden_link' : undefined}
+						tabindex={i === 0 ? undefined : -1}
+						class="hover:text-coin font-semibold text-neutral-100 transition-colors"
+						rel="noopener noreferrer"
+						target="_blank">more at the garden →</a
+					>
+					<span class="text-coin">★</span>
+				</div>
+			{/each}
 		</div>
 	</div>
 </section>

--- a/src/lib/components/LeadCapture.svelte
+++ b/src/lib/components/LeadCapture.svelte
@@ -3,6 +3,9 @@
 	import type { FormResult } from '$lib/types'
 
 	let { form }: { form: FormResult | null } = $props()
+
+	// Enough copies that the seamless-loop tile covers wide viewports (4K still works).
+	const MARQUEE_COPIES = 6
 </script>
 
 <section class="snap-section relative !justify-between bg-neutral-950">
@@ -74,10 +77,10 @@
 	>
 		<div
 			class="marquee-track flex w-max items-center text-lg whitespace-nowrap"
-			style="--marquee-copies: 6"
+			style="--marquee-copies: {MARQUEE_COPIES}"
 		>
-			{#each Array(6), i (i)}
-				<div class="flex items-center gap-12 pr-12" aria-hidden={i !== 0}>
+			{#each Array(MARQUEE_COPIES), i (i)}
+				<div data-marquee-copy class="flex items-center gap-12 pr-12" aria-hidden={i !== 0}>
 					<span class="font-semibold text-neutral-100">we just want to build cool shit</span>
 					<span class="text-coin">★</span>
 					<a

--- a/src/lib/components/umami-events.test.ts
+++ b/src/lib/components/umami-events.test.ts
@@ -24,7 +24,13 @@ describe('Umami CRO event instrumentation', () => {
 	for (const { event, file } of CLIENT_EVENTS) {
 		it(`fires "${event}" via data-attr in ${file}`, () => {
 			const contents = readFileSync(resolve(COMPONENT_DIR, file), 'utf-8')
-			expect(contents).toContain(`data-umami-event="${event}"`)
+			// Match either a literal data-umami-event="<event>" or a dynamic
+			// data-umami-event={...'<event>'...} expression so the test
+			// survives ternaries / snippet refactors.
+			const literalForm = `data-umami-event="${event}"`
+			const dynamicForm = new RegExp(`data-umami-event=\\{[^}]*['"]${event}['"]`)
+			const hit = contents.includes(literalForm) || dynamicForm.test(contents)
+			expect(hit, `${file} should reference "${event}" on a data-umami-event attr`).toBe(true)
 		})
 	}
 

--- a/src/lib/server/contact-form.test.ts
+++ b/src/lib/server/contact-form.test.ts
@@ -132,4 +132,19 @@ describe('processSubmission — protection layers', () => {
 		const result = await processSubmission(makeFormData(), event)
 		expect(result.ok).toBe(true)
 	})
+
+	it('bypasses SMTP when email matches CONTACT_FORM_TEST_EMAIL env var', async () => {
+		const { env } = await import('$env/dynamic/private')
+		const original = env.CONTACT_FORM_TEST_EMAIL
+		env.CONTACT_FORM_TEST_EMAIL = 'e2e@test.sixtom.local'
+		try {
+			const result = await processSubmission(
+				makeFormData({ email: 'e2e@test.sixtom.local' }),
+				mockEvent({ ip: '10.0.0.51' })
+			)
+			expect(result.ok).toBe(true)
+		} finally {
+			env.CONTACT_FORM_TEST_EMAIL = original
+		}
+	})
 })

--- a/src/lib/server/contact-form.ts
+++ b/src/lib/server/contact-form.ts
@@ -78,9 +78,11 @@ export type SubmissionResult =
 	| { ok: true; message: string }
 	| { ok: false; status: number; message: string }
 
+export const SUCCESS_MESSAGE = "You're on the list."
+
 // Honeypot + time-trap silently 200 so attackers can't learn which layer filtered them.
 function suspicious(): SubmissionResult {
-	return { ok: true, message: "You're on the list." }
+	return { ok: true, message: SUCCESS_MESSAGE }
 }
 
 let cachedTransporter: Transporter | null = null
@@ -144,11 +146,10 @@ export async function processSubmission(
 		return { ok: false, status: 429, message: 'Too many requests. Please try again shortly.' }
 	}
 
-	// E2E + load testing: env-opt-in bypass that returns success without sending.
-	// Unset in production (env var never set), so a leaked address grants nothing.
-	const testEmail = env.CONTACT_FORM_TEST_EMAIL?.trim()
-	if (testEmail && email === testEmail) {
-		return { ok: true, message: "You're on the list." }
+	// E2E bypass; env var unset in production, exact-match comparison.
+	const testEmail = env.CONTACT_FORM_TEST_EMAIL?.trim() ?? ''
+	if (testEmail !== '' && email === testEmail) {
+		return { ok: true, message: SUCCESS_MESSAGE }
 	}
 
 	const transporter = getTransporter()
@@ -168,7 +169,7 @@ export async function processSubmission(
 
 	try {
 		await Promise.all([transporter.sendMail(confirmation), transporter.sendMail(notification)])
-		return { ok: true, message: "You're on the list." }
+		return { ok: true, message: SUCCESS_MESSAGE }
 	} catch (error) {
 		console.error('send-email failed:', error instanceof Error ? error.message : 'unknown')
 		return { ok: false, status: 500, message: 'Error sending message. Please try again later.' }

--- a/src/lib/server/contact-form.ts
+++ b/src/lib/server/contact-form.ts
@@ -144,6 +144,13 @@ export async function processSubmission(
 		return { ok: false, status: 429, message: 'Too many requests. Please try again shortly.' }
 	}
 
+	// E2E + load testing: env-opt-in bypass that returns success without sending.
+	// Unset in production (env var never set), so a leaked address grants nothing.
+	const testEmail = env.CONTACT_FORM_TEST_EMAIL?.trim()
+	if (testEmail && email === testEmail) {
+		return { ok: true, message: "You're on the list." }
+	}
+
 	const transporter = getTransporter()
 	const confirmation = {
 		from: env.SMTP_EMAIL,

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,5 +4,8 @@ import tailwindcss from '@tailwindcss/vite'
 import type { PluginOption } from 'vite'
 
 export default defineConfig({
-	plugins: [sveltekit(), tailwindcss() as PluginOption]
+	plugins: [sveltekit(), tailwindcss() as PluginOption],
+	test: {
+		exclude: ['**/node_modules/**', '**/dist/**', '**/.svelte-kit/**', 'e2e/**']
+	}
 })


### PR DESCRIPTION
## Summary

Two changes on top of v1.3:

**1. Marquee bug fix (`dfeb238`)**
The brand marquee was rendering 2 copies + `translateX(-50%)` and leaving empty space on viewports wider than ~2× the content (i.e., most modern displays). Now renders 6 copies via `{#each}` and drives the keyframe off a `--marquee-copies` CSS variable — `translateX(calc(-100% / 6))` advances by exactly one copy per loop, seamless on any viewport up to ~6× single-copy width.

**2. Playwright e2e + env-gated test-email bypass (`bec3114`)**
Closes the verification gap left in v1.3 — the lazy `enhance-form.js` script, the no-JS form-action path, and the protection layers were all unit-tested but never exercised end-to-end in a browser.

Server-side adds `CONTACT_FORM_TEST_EMAIL` env var; if set and the submitted email matches, the action returns success without invoking SMTP. Unset in production; Playwright sets it via `webServer.env`. Comparison is exact-match `===` after both sides trimmed; runs after honeypot/time-trap/rate-limit, before SMTP.

5 e2e specs:
- JS-enhanced path: inline "Sending…" → inline success without page reload
- No-JS path: native form POST with `javaScriptEnabled: false`, server-rendered success on reload (verifies the silent-failure fix from v1.3)
- Honeypot: filled `company` field returns silent success (uses non-bypass email)
- Malformed email: server rejects with inline error
- Marquee renders 6 copies at 2400px viewport (regression guard)

**3. Review fixes (`c4c0f53`)**
Convergent findings from 5 parallel reviewers (reuse / quality / efficiency / code-review / security). No CRITICAL. Applied: single-source MARQUEE_COPIES const, SUCCESS_MESSAGE constant (was duplicated 4×), TEST_EMAIL in shared file, `[data-marquee-copy]` selector instead of class-coupled, `fullyParallel: false` documented, `webServer.timeout` 120s→180s, `CONTACT_FORM_MIN_SUBMIT_MS=1` in webServer env so e2e drops 3× `waitForTimeout(3200)` (suite ~12s faster), `.env.example` documents the bypass var, multi-line comments trimmed.

Final confirmatory review: **ship it**.

## Test plan

- [x] `pnpm format && pnpm lint && pnpm check && pnpm test` all green
- [x] `pnpm test:e2e` — 5/5 pass (~42s including build)
- [x] `pnpm audit` clean
- [ ] Visually verify the marquee scrolls continuously on the Vercel preview (no empty space at the right edge)
- [ ] Confirm `CONTACT_FORM_TEST_EMAIL` is NOT set in Vercel production env

🤖 Generated with [Claude Code](https://claude.com/claude-code)