### PR TITLE
SIXTOM uppercase in brand wordmark surfaces

### DIFF
--- a/docs/site-copy.md
+++ b/docs/site-copy.md
@@ -14,7 +14,7 @@ If page and doc disagree, files win — re-export from those.
 ## 1. Hero (snap section, full screen, `bg-neutral-950`)
 
 ```
-sixtom — async sprints                   ← eyebrow, gold, uppercase tracking-widest
+SIXTOM — async sprints                   ← eyebrow, gold, uppercase tracking-widest
 
 AI ships demos. I ship products.         ← H1, huge bold neutral-100
 
@@ -118,7 +118,7 @@ we just want to build cool shit   ★   more at the garden →   ★   we…
 ## 5. Browser meta (`src/app.html`)
 
 ```
-<title>sixtom — async sprints with Sam D'Angelo</title>
+<title>SIXTOM — async sprints with Sam D'Angelo</title>
 
 <meta name="description"
       content="AI ships demos. I ship products. I run a fleet of agents in
@@ -126,16 +126,16 @@ we just want to build cool shit   ★   more at the garden →   ★   we…
 <meta name="author" content="Sam D'Angelo" />
 <link rel="canonical" href="https://sixtom.com/" />
 
-<meta property="og:title"        content="sixtom — async sprints with Sam D'Angelo" />
+<meta property="og:title"        content="SIXTOM — async sprints with Sam D'Angelo" />
 <meta property="og:description"  content="AI ships demos. I ship products.
                                           $750 audit. $7,500 sprint." />
 <meta property="og:image"        content="https://sixtom.com/og.png" />
 <meta property="og:image:width"  content="1200" />
 <meta property="og:image:height" content="630" />
-<meta property="og:image:alt"    content="sixtom — async sprints with Sam D'Angelo" />
+<meta property="og:image:alt"    content="SIXTOM — async sprints with Sam D'Angelo" />
 
 <meta name="twitter:card"        content="summary_large_image" />
-<meta name="twitter:title"       content="sixtom — async sprints with Sam D'Angelo" />
+<meta name="twitter:title"       content="SIXTOM — async sprints with Sam D'Angelo" />
 <meta name="twitter:description" content="AI ships demos. I ship products.
                                           $750 audit. $7,500 sprint." />
 ```
@@ -172,7 +172,7 @@ Intake questions:
 See `static/llms.txt` for the live version. Summary:
 
 ```
-sixtom — AI ships demos. I ship products. I run a fleet of AI agents in
+SIXTOM — AI ships demos. I ship products. I run a fleet of AI agents in
 parallel — agents type, I judge. Two weeks to a working version. $750 audit.
 $7,500 sprint. 1 client a month.
 ```

--- a/src/app.html
+++ b/src/app.html
@@ -7,7 +7,7 @@
 		<meta name="author" content="Sam D'Angelo" />
 		<meta name="format-detection" content="telephone=no" />
 
-		<title>sixtom — async sprints with Sam D'Angelo</title>
+		<title>SIXTOM — async sprints with Sam D'Angelo</title>
 		<meta
 			name="description"
 			content="AI ships demos. I ship products. I run a fleet of agents in parallel. $750 audit. $7,500 sprint. 1 client a month."
@@ -23,7 +23,7 @@
 			crossorigin
 		/>
 
-		<meta property="og:title" content="sixtom — async sprints with Sam D'Angelo" />
+		<meta property="og:title" content="SIXTOM — async sprints with Sam D'Angelo" />
 		<meta
 			property="og:description"
 			content="AI ships demos. I ship products. $750 audit. $7,500 sprint."
@@ -33,10 +33,10 @@
 		<meta property="og:image" content="https://sixtom.com/og.png" />
 		<meta property="og:image:width" content="1200" />
 		<meta property="og:image:height" content="630" />
-		<meta property="og:image:alt" content="sixtom — async sprints with Sam D'Angelo" />
+		<meta property="og:image:alt" content="SIXTOM — async sprints with Sam D'Angelo" />
 
 		<meta name="twitter:card" content="summary_large_image" />
-		<meta name="twitter:title" content="sixtom — async sprints with Sam D'Angelo" />
+		<meta name="twitter:title" content="SIXTOM — async sprints with Sam D'Angelo" />
 		<meta
 			name="twitter:description"
 			content="AI ships demos. I ship products. $750 audit. $7,500 sprint."

--- a/src/lib/components/Hero.svelte
+++ b/src/lib/components/Hero.svelte
@@ -4,7 +4,7 @@
 
 <section class="snap-section bg-surface">
 	<div class="mx-auto w-full max-w-4xl px-6">
-		<p class="eyebrow text-sm">sixtom — async sprints</p>
+		<p class="eyebrow text-sm">SIXTOM — async sprints</p>
 		<h1
 			class="text-fg mt-6 text-5xl leading-[1.02] font-bold tracking-tight md:text-7xl lg:text-8xl"
 		>

--- a/src/lib/seo/jsonld.ts
+++ b/src/lib/seo/jsonld.ts
@@ -53,7 +53,7 @@ export function serviceJsonLd(): ServiceLd {
 	return {
 		'@context': 'https://schema.org',
 		'@type': 'ProfessionalService',
-		name: 'Sixtom',
+		name: 'SIXTOM',
 		description: site.hero.subhead,
 		priceRange: `$${String(site.audit.priceUSD)}–$${String(site.sprint.priceUSD)}`,
 		provider,

--- a/src/lib/server/contact-form.ts
+++ b/src/lib/server/contact-form.ts
@@ -157,7 +157,7 @@ export async function processSubmission(
 	const confirmation = {
 		from: env.SMTP_EMAIL,
 		to: email,
-		subject: `Contact sixtom`,
+		subject: `Contact SIXTOM`,
 		text: 'Contact form submission received! We look forward to talking to you soon.'
 	}
 	const notification = {

--- a/static/llms.txt
+++ b/static/llms.txt
@@ -1,4 +1,4 @@
-# sixtom
+# SIXTOM
 
 > AI ships demos. I ship products. I run a fleet of AI agents in parallel — agents type, I judge. Two weeks to a working version. $750 audit. $7,500 sprint. 1 client a month.
 


### PR DESCRIPTION
Wordmark renders uppercase in every visible surface:
- Browser tab title + OG + Twitter meta + og:image:alt
- Hero eyebrow source ("SIXTOM — async sprints")
- Email subject ("Contact SIXTOM")
- JSON-LD ProfessionalService.name
- llms.txt heading
- docs/site-copy.md mirrors live

URLs stay lowercase (DNS canonical).