### PR TITLE
Remove color-scheme: dark

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -67,7 +67,6 @@
 html {
 	color: var(--color-fg);
 	background: var(--color-surface);
-	color-scheme: dark;
 	scroll-snap-type: y mandatory;
 	scroll-behavior: smooth;
 }


### PR DESCRIPTION
One-line revert of the color-scheme declaration added in v1.6 — was making Arc render its top-chrome blend at near-pure-black, which seamed against our page surface at oklch(14.5%). Form-control fallback to OS preference is acceptable since the email input has explicit token-based overrides.