### PR TITLE
Review fixes for v1.13

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,6 +73,16 @@ Both confirmation + notification emails go through a module-level lazy-singleton
 
 Reads `site.calEvent` from the content layer, upserts the intro event in Cal.com via their v2 API. Operator runs `pnpm cal:sync` after editing `calEvent`. Not part of `pnpm build`.
 
+## Design system
+
+`src/app.css` defines semantic tokens via `@theme` and per-section overrides via `.surface-uv` (blacklight: white + black text + glowing accents) and `.surface-dark` (re-establishes the dark palette inside a `.surface-uv` parent — e.g. the marquee bar).
+
+Tokens: `--color-surface`, `--color-fg`, `--color-fg-muted`, `--color-fg-subtle`, `--color-border`, `--color-border-strong`, `--color-accent` (teal), `--gradient-accent` (subtle horizontal teal flow for `bg-accent`), `--color-on-accent`, `--color-error`, `--shadow-accent` (none on dark, glow on UV), `--font-sans` (Recursive + system mono fallback), `--font-display` (Space Grotesk + system sans fallback).
+
+Custom utilities: `.btn-accent` (gradient bg + dark text + shadow), `.eyebrow` (accent color + tracking + uppercase + shadow), `.text-accent` (accent text + shadow).
+
+Sections alternate D / UV / D / UV / D (marquee bar resets to dark). The visual rhythm is chromatic + typographic, not luminance — both halves are designed to read together.
+
 ## Voice & copy guardrails
 
 **Apply to every change that touches buyer-facing copy.** The operator's published voice (see his "Vibe coding insight" post — wry, observational, terse, _italics for genuine emphasis_, em-dashes only when earned) is the target.

--- a/src/app.css
+++ b/src/app.css
@@ -26,31 +26,28 @@
 @plugin '@tailwindcss/typography';
 
 @theme {
-	/* Recursive 400 with system-mono fallback chain. Only one weight downloaded
-	 * (~23 KB latin); `font-bold` and `font-semibold` synthesize from it. */
 	--font-sans:
 		'Recursive', ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Monaco, Consolas, monospace;
+	--font-display:
+		'Space Grotesk', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
 
-	/* Default (dark) tokens. `.surface-uv` and `.surface-dark` override locally. */
 	--color-surface: oklch(14.5% 0 0);
 	--color-fg: oklch(97% 0 0);
 	--color-fg-muted: oklch(70.8% 0 0);
 	--color-fg-subtle: oklch(60% 0 0);
 	--color-border: oklch(26.9% 0 0);
 	--color-border-strong: oklch(37.1% 0 0);
-	/* Teal accent (text + shadow base); the surface variant flows via gradient. */
 	--color-accent: oklch(70% 0.15 195);
 	--gradient-accent: linear-gradient(95deg, oklch(72% 0.15 200) 0%, oklch(64% 0.16 178) 100%);
 	--color-on-accent: oklch(14.5% 0 0);
 	--color-error: oklch(71.2% 0.194 13.428);
 
-	/* Glow only on UV surface. */
+	/* Glow only on UV surface; default surface keeps a no-op transparent shadow. */
 	--shadow-accent: 0 0 0 transparent;
 }
 
-/* Blacklight effect: WHITE surface, BLACK text, neon green accent that glows
- * via text-shadow / box-shadow — emulates how fluorescent objects appear
- * under UV light against a white wall. */
+/* Blacklight effect: white surface, black text, neon accents fluoresce via shadow.
+ * `font-family` swaps to display (sans) so the section reads as a different medium. */
 .surface-uv {
 	--color-surface: oklch(98% 0.005 85);
 	--color-fg: oklch(15% 0 0);
@@ -62,16 +59,12 @@
 		0 0 14px var(--color-accent), 0 0 36px color-mix(in oklch, var(--color-accent) 60%, transparent);
 	background: var(--color-surface);
 	color: var(--color-fg);
-	font-family:
-		'Space Grotesk',
-		system-ui,
-		-apple-system,
-		BlinkMacSystemFont,
-		'Segoe UI',
-		sans-serif;
+	font-family: var(--font-display);
 }
 
-/* Reset to default dark palette inside a .surface-uv parent (marquee bar). */
+/* Re-establish the dark palette inside a .surface-uv parent (marquee bar).
+ * Only the vars that .surface-uv actually changes need restating; the rest
+ * (--gradient-accent, --color-on-accent, --color-error) inherit from @theme. */
 .surface-dark {
 	--color-surface: oklch(14.5% 0 0);
 	--color-fg: oklch(97% 0 0);
@@ -87,6 +80,7 @@
 
 @utility btn-accent {
 	display: inline-block;
+	/* background-color is the fallback if --gradient-accent fails to parse. */
 	background-color: var(--color-accent);
 	background-image: var(--gradient-accent);
 	color: var(--color-on-accent);
@@ -103,8 +97,20 @@
 	text-shadow: var(--shadow-accent);
 }
 
-.text-accent {
+@utility text-accent {
+	color: var(--color-accent);
 	text-shadow: var(--shadow-accent);
+}
+
+/* Marquee bar uses the display font + letter-spacing the t★h★r★e★e★s★a★m treatment.
+ * `user-select: none` prevents drag-to-select on the animated track. */
+.marquee-link .marquee-track {
+	font-family: var(--font-display);
+	letter-spacing: 0.4em;
+}
+.marquee-link {
+	user-select: none;
+	-webkit-user-select: none;
 }
 
 html {

--- a/src/lib/components/LeadCapture.svelte
+++ b/src/lib/components/LeadCapture.svelte
@@ -76,15 +76,16 @@
 		data-umami-event="cta_garden_link"
 		target="_blank"
 		rel="noopener noreferrer"
+		draggable="false"
 		aria-label="threesam.com — the garden"
-		class="surface-dark border-border text-fg hover:text-accent block w-full overflow-hidden border-t py-6 transition-colors"
+		class="surface-dark border-border text-fg hover:text-accent marquee-link block w-full overflow-hidden border-t py-6 transition-colors"
 	>
 		<div
 			class="marquee-track flex w-max items-center text-lg font-bold whitespace-nowrap"
-			style="--marquee-copies: {MARQUEE_COPIES}; font-family: 'Space Grotesk', sans-serif; letter-spacing: 0.4em;"
+			style="--marquee-copies: {MARQUEE_COPIES};"
 		>
 			{#each Array(MARQUEE_COPIES), i (i)}
-				<div data-marquee-copy class="pr-12" aria-hidden={i !== 0}>
+				<div data-marquee-copy class="pr-12" aria-hidden="true">
 					t ★ h ★ r ★ e ★ e ★ s ★ a ★ m ★
 				</div>
 			{/each}


### PR DESCRIPTION
Addresses code-review + simplify findings on the merged design-system work. Two CRITICAL items fixed (marquee a11y + mis-click hazard) plus token deduplication, --font-display lift, AGENTS.md design-system docs.