### PR TITLE
Dots in marquee, no default shadows, subtle hover glow

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -83,24 +83,27 @@
 	color: var(--color-on-accent);
 	border-radius: 0.375rem;
 	font-weight: 500;
-	transition: opacity 0.15s;
-	box-shadow: var(--shadow-accent);
+	transition:
+		opacity 0.15s,
+		box-shadow 0.2s;
+}
+.btn-accent:hover {
+	box-shadow: 0 0 12px color-mix(in oklch, var(--color-accent) 50%, transparent);
 }
 
 @utility eyebrow {
 	color: var(--color-accent);
 	letter-spacing: 0.1em;
 	text-transform: uppercase;
-	text-shadow: var(--shadow-accent);
 }
 
 @utility text-accent {
 	color: var(--color-accent);
-	text-shadow: var(--shadow-accent);
 }
 
-/* Marquee bar uses the display font + letter-spacing the t★h★r★e★e★s★a★m treatment.
- * `user-select: none` prevents drag-to-select on the animated track. */
+/* Marquee bar uses the display font + letter-spacing the T•H•R•E•E•S•A•M treatment.
+ * `user-select: none` prevents drag-to-select on the animated track.
+ * Hover lifts a subtle teal glow on the bar to match the color shift. */
 .marquee-link .marquee-track {
 	font-family: var(--font-display);
 	letter-spacing: 0.4em;
@@ -108,6 +111,12 @@
 .marquee-link {
 	user-select: none;
 	-webkit-user-select: none;
+	transition:
+		color 0.25s,
+		text-shadow 0.25s;
+}
+.marquee-link:hover {
+	text-shadow: 0 0 8px color-mix(in oklch, var(--color-accent) 40%, transparent);
 }
 
 html {

--- a/src/lib/components/LeadCapture.svelte
+++ b/src/lib/components/LeadCapture.svelte
@@ -85,7 +85,7 @@
 			style="--marquee-copies: {MARQUEE_COPIES};"
 		>
 			{#each Array(MARQUEE_COPIES), i (i)}
-				<div data-marquee-copy class="pr-4" aria-hidden="true">T ★ H ★ R ★ E ★ E ★ S ★ A ★ M ★</div>
+				<div data-marquee-copy class="pr-4" aria-hidden="true">T • H • R • E • E • S • A • M •</div>
 			{/each}
 		</div>
 	</a>


### PR DESCRIPTION
Stars→dots, drop dangling text-shadows (refs to deleted --shadow-accent), add subtle hover glow on btn-accent + marquee-link only.