### PR TITLE
Marquee: gold hover + tighter inter-copy gap

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -40,6 +40,7 @@
 	--color-accent: oklch(70% 0.15 195);
 	--gradient-accent: linear-gradient(95deg, oklch(72% 0.15 200) 0%, oklch(64% 0.16 178) 100%);
 	--color-on-accent: oklch(14.5% 0 0);
+	--color-coin: #e8a317;
 	--color-error: oklch(71.2% 0.194 13.428);
 }
 

--- a/src/lib/components/LeadCapture.svelte
+++ b/src/lib/components/LeadCapture.svelte
@@ -78,14 +78,14 @@
 		rel="noopener noreferrer"
 		draggable="false"
 		aria-label="threesam.com — the garden"
-		class="surface-dark border-border text-fg hover:text-accent marquee-link block w-full overflow-hidden border-t py-6 transition-colors"
+		class="surface-dark border-border text-fg hover:text-coin marquee-link block w-full overflow-hidden border-t py-6 transition-colors"
 	>
 		<div
 			class="marquee-track flex w-max items-center text-lg font-bold whitespace-nowrap"
 			style="--marquee-copies: {MARQUEE_COPIES};"
 		>
 			{#each Array(MARQUEE_COPIES), i (i)}
-				<div data-marquee-copy class="pr-4" aria-hidden="true">T • H • R • E • E • S • A • M •</div>
+				<div data-marquee-copy class="pr-2" aria-hidden="true">T • H • R • E • E • S • A • M •</div>
 			{/each}
 		</div>
 	</a>


### PR DESCRIPTION
Marquee hover → brand gold (#e8a317) via re-added --color-coin token. Inter-copy gap pr-4→pr-2 to match the letter-spacing rhythm between dots and letters.