### PR TITLE
SEO: GSC/Bing placeholders + JSON-LD brand alternateName + sameAs

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -14,6 +14,11 @@
 		/>
 		<link rel="canonical" href="https://sixtom.com/" />
 
+		<!-- Search engine ownership verification. Tokens come from each console;
+		     leave the TODO values until you paste in real ones, then verify. -->
+		<meta name="google-site-verification" content="TODO_paste_from_search_console" />
+		<meta name="msvalidate.01" content="TODO_paste_from_bing_webmaster" />
+
 		<link rel="preconnect" href="https://analytics.sixtom.com" />
 		<link
 			rel="preload"

--- a/src/lib/seo/jsonld.test.ts
+++ b/src/lib/seo/jsonld.test.ts
@@ -9,6 +9,8 @@ describe('JSON-LD generators', () => {
 		expect(ld['@type']).toBe('Person')
 		expect(ld.name).toBe(site.operator.name)
 		expect(ld.jobTitle).toBe(site.operator.jobTitle)
+		expect(ld.alternateName).toContain('Sixtom')
+		expect(ld.sameAs).toContain(site.gardenUrl)
 		expect(ld.worksFor).toEqual({
 			'@type': 'Organization',
 			name: site.operator.currentEmployer

--- a/src/lib/seo/jsonld.ts
+++ b/src/lib/seo/jsonld.ts
@@ -9,19 +9,22 @@ export interface PersonLd {
 	'@context': 'https://schema.org'
 	'@type': 'Person'
 	name: string
+	alternateName: readonly string[]
 	jobTitle: string
 	worksFor: Org
 	alumniOf: Org
 	url: string
+	sameAs: readonly string[]
 }
 
 export interface ServiceLd {
 	'@context': 'https://schema.org'
 	'@type': 'ProfessionalService'
 	name: string
+	alternateName: readonly string[]
 	description: string
 	priceRange: string
-	provider: Omit<PersonLd, '@context' | 'url'>
+	provider: Omit<PersonLd, '@context' | 'url' | 'sameAs'>
 	offers: readonly {
 		'@type': 'Offer'
 		name: string
@@ -35,10 +38,12 @@ export function personJsonLd(): PersonLd {
 		'@context': 'https://schema.org',
 		'@type': 'Person',
 		name: site.operator.name,
+		alternateName: ['Sixtom', 'sixtom', 'threesam'],
 		jobTitle: site.operator.jobTitle,
 		worksFor: { '@type': 'Organization', name: site.operator.currentEmployer },
 		alumniOf: { '@type': 'Organization', name: site.operator.formerEmployer },
-		url: site.siteUrl
+		url: site.siteUrl,
+		sameAs: [site.gardenUrl]
 	}
 }
 
@@ -46,6 +51,7 @@ export function serviceJsonLd(): ServiceLd {
 	const provider = {
 		'@type': 'Person' as const,
 		name: site.operator.name,
+		alternateName: ['Sixtom', 'threesam'] as const,
 		jobTitle: site.operator.jobTitle,
 		worksFor: { '@type': 'Organization' as const, name: site.operator.currentEmployer },
 		alumniOf: { '@type': 'Organization' as const, name: site.operator.formerEmployer }
@@ -54,6 +60,7 @@ export function serviceJsonLd(): ServiceLd {
 		'@context': 'https://schema.org',
 		'@type': 'ProfessionalService',
 		name: 'SIXTOM',
+		alternateName: ['Sixtom', 'sixtom'],
 		description: site.hero.subhead,
 		priceRange: `$${String(site.audit.priceUSD)}–$${String(site.sprint.priceUSD)}`,
 		provider,


### PR DESCRIPTION
Wires up Search Console + Bing verification slots; enriches JSON-LD so Google links the SIXTOM/sixtom/threesam aliases to Sam and cross-links to threesam.com.