### PR TITLE
sixtom v1.24 — /log feed + SEO touch-ups

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,3 +16,7 @@ CONTACT_FORM_RATE_LIMIT_MAX_REQUESTS="5"
 CONTACT_FORM_TEST_EMAIL=""
 CAL_API_KEY=""
 CAL_USERNAME=""
+# content-engine (LinkedIn/X post backend). /log reads from /api/posts.
+# CONTENT_ENGINE_URL is the public origin; STUDIO_TOKEN is the bearer.
+CONTENT_ENGINE_URL="https://studio.sixtom.com"
+STUDIO_TOKEN=""

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -5,7 +5,7 @@ const MARKETING_CSP = [
 	// 'unsafe-inline' covers the in-repo JSON-LD <script> block; no user input is reflected.
 	"script-src 'self' 'unsafe-inline' https://analytics.sixtom.com",
 	"style-src 'self' 'unsafe-inline'",
-	"img-src 'self' data:",
+	"img-src 'self' data: https://studio.sixtom.com",
 	"connect-src 'self' https://analytics.sixtom.com",
 	"font-src 'self'",
 	"frame-ancestors 'none'",

--- a/src/routes/log/+page.server.ts
+++ b/src/routes/log/+page.server.ts
@@ -21,6 +21,17 @@ interface RawPost {
 	meta: { pinned?: boolean } | null
 }
 
+// Strip anything that isn't a plain https:// URL — defense against a future
+// upstream returning `javascript:` or `data:` URIs that would execute on click.
+function safeHttpsUrl(url: string | null): string | null {
+	if (!url) return null
+	try {
+		return new URL(url).protocol === 'https:' ? url : null
+	} catch {
+		return null
+	}
+}
+
 export const load: PageServerLoad = async ({ fetch }) => {
 	const origin = env.CONTENT_ENGINE_URL
 	const token = env.STUDIO_TOKEN
@@ -42,8 +53,8 @@ export const load: PageServerLoad = async ({ fetch }) => {
 			id: p.id,
 			text: p.text,
 			publishedAt: p.publishedAt,
-			linkedinPermalink: p.linkedinPermalink,
-			imageUrl: p.imageUrl,
+			linkedinPermalink: safeHttpsUrl(p.linkedinPermalink),
+			imageUrl: safeHttpsUrl(p.imageUrl),
 			pinned: Boolean(p.meta?.pinned)
 		}))
 		posts.sort((a, b) => {

--- a/src/routes/log/+page.server.ts
+++ b/src/routes/log/+page.server.ts
@@ -1,0 +1,58 @@
+import { env } from '$env/dynamic/private'
+import type { PageServerLoad } from './$types'
+
+export const config = { isr: { expiration: 3600 } }
+
+export interface LogPost {
+	id: number
+	text: string
+	publishedAt: string | null
+	linkedinPermalink: string | null
+	imageUrl: string | null
+	pinned: boolean
+}
+
+interface RawPost {
+	id: number
+	text: string
+	publishedAt: string | null
+	linkedinPermalink: string | null
+	imageUrl: string | null
+	meta: { pinned?: boolean } | null
+}
+
+export const load: PageServerLoad = async ({ fetch }) => {
+	const origin = env.CONTENT_ENGINE_URL
+	const token = env.STUDIO_TOKEN
+	if (!origin || !token) {
+		console.warn('[/log] CONTENT_ENGINE_URL or STUDIO_TOKEN missing; rendering empty feed')
+		return { posts: [] }
+	}
+
+	try {
+		const res = await fetch(`${origin}/api/posts?status=published&limit=50`, {
+			headers: { authorization: `Bearer ${token}` }
+		})
+		if (!res.ok) {
+			console.error(`[/log] content-engine ${res.status} ${res.statusText}`)
+			return { posts: [] }
+		}
+		const body = (await res.json()) as { posts: RawPost[] }
+		const posts: LogPost[] = body.posts.map((p) => ({
+			id: p.id,
+			text: p.text,
+			publishedAt: p.publishedAt,
+			linkedinPermalink: p.linkedinPermalink,
+			imageUrl: p.imageUrl,
+			pinned: Boolean(p.meta?.pinned)
+		}))
+		posts.sort((a, b) => {
+			if (a.pinned !== b.pinned) return a.pinned ? -1 : 1
+			return (b.publishedAt ?? '').localeCompare(a.publishedAt ?? '')
+		})
+		return { posts }
+	} catch (err) {
+		console.error('[/log] fetch failed', err)
+		return { posts: [] }
+	}
+}

--- a/src/routes/log/+page.svelte
+++ b/src/routes/log/+page.svelte
@@ -1,0 +1,113 @@
+<script lang="ts">
+	import type { PageData } from './$types'
+	import type { LogPost } from './+page.server'
+	import { site } from '$lib/content'
+
+	let { data }: { data: PageData } = $props()
+
+	const dateFmt = new Intl.DateTimeFormat('en-US', {
+		year: 'numeric',
+		month: 'long',
+		day: 'numeric'
+	})
+	function formatDate(iso: string | null): string {
+		if (!iso) return ''
+		return dateFmt.format(new Date(iso))
+	}
+</script>
+
+{#snippet entry(post: LogPost)}
+	<article>
+		<div class="flex items-baseline gap-3">
+			{#if post.publishedAt}
+				<time
+					datetime={post.publishedAt}
+					class="text-fg-subtle group-hover:text-coin text-xs tracking-widest uppercase transition-colors"
+				>
+					{formatDate(post.publishedAt)}
+				</time>
+			{/if}
+			{#if post.pinned}
+				<span class="text-accent text-xs tracking-widest uppercase">pinned</span>
+			{/if}
+			{#if post.linkedinPermalink}
+				<span
+					aria-hidden="true"
+					class="text-fg-subtle group-hover:text-coin ml-auto text-xs transition-colors"
+				>→</span>
+			{/if}
+		</div>
+		<p
+			class="text-fg mt-4 text-base leading-relaxed break-words whitespace-pre-wrap"
+		>{post.text}</p>
+		{#if post.imageUrl}
+			<img
+				src={post.imageUrl}
+				alt=""
+				loading="lazy"
+				class="border-border mt-6 rounded-lg border"
+			/>
+		{/if}
+	</article>
+{/snippet}
+
+<svelte:head>
+	<title>log — sixtom</title>
+	<meta
+		name="description"
+		content="Everything I'm publishing on LinkedIn, mirrored here in one place."
+	/>
+	<link rel="canonical" href={`${site.siteUrl}/log`} />
+	<meta property="og:title" content="log — sixtom" />
+	<meta
+		property="og:description"
+		content="Everything I'm publishing on LinkedIn, mirrored here in one place."
+	/>
+	<meta property="og:url" content={`${site.siteUrl}/log`} />
+	<meta property="og:type" content="website" />
+</svelte:head>
+
+<div class="bg-surface min-h-screen">
+	<div class="mx-auto w-full max-w-3xl px-6 py-20">
+		<header class="mb-20">
+			<a
+				href="/"
+				class="eyebrow text-fg-subtle hover:text-coin text-xs transition-colors"
+				data-umami-event="log_back_home"
+			>
+				← sixtom
+			</a>
+			<p class="eyebrow mt-12 text-sm">the log</p>
+			<h1 class="text-fg mt-2 text-4xl font-bold tracking-tight md:text-6xl">
+				What I'm shipping, in public.
+			</h1>
+			<p class="text-fg-muted mt-6 text-lg leading-relaxed">
+				Posts as they hit LinkedIn. Notes, builds, opinions, the occasional rant.
+			</p>
+		</header>
+
+		{#if data.posts.length === 0}
+			<p class="text-fg-subtle text-base">No posts yet. Check back soon.</p>
+		{:else}
+			<ul class="m-0 list-none p-0">
+				{#each data.posts as post (post.id)}
+					<li class="border-border border-t py-10">
+						{#if post.linkedinPermalink}
+							<a
+								href={post.linkedinPermalink}
+								target="_blank"
+								rel="noopener noreferrer"
+								data-umami-event="log_entry_click"
+								class="group block"
+							>
+								{@render entry(post)}
+							</a>
+						{:else}
+							{@render entry(post)}
+						{/if}
+					</li>
+				{/each}
+			</ul>
+		{/if}
+	</div>
+</div>

--- a/src/routes/sitemap.xml/+server.ts
+++ b/src/routes/sitemap.xml/+server.ts
@@ -12,6 +12,12 @@ export function GET(): Response {
 		<changefreq>monthly</changefreq>
 		<priority>1.0</priority>
 	</url>
+	<url>
+		<loc>${site.siteUrl}/log</loc>
+		<lastmod>${today}</lastmod>
+		<changefreq>weekly</changefreq>
+		<priority>0.8</priority>
+	</url>
 </urlset>
 `
 	return new Response(body, {


### PR DESCRIPTION
## Summary
- Adds /log index that mirrors LinkedIn posts via content-engine (studio.sixtom.com) with 1h ISR
- Each entry is clickable, opens the LinkedIn permalink in a new tab
- Pinned posts (meta.pinned=true) float to top
- Bundles prior SEO commit: GSC/Bing verification placeholders + alternateName/sameAs on Person JSON-LD

## Notes
- Page renders empty-feed gracefully if CONTENT_ENGINE_URL or STUDIO_TOKEN env vars are missing
- New env vars must be set on Vercel before /log shows real data: CONTENT_ENGINE_URL (default https://studio.sixtom.com) and STUDIO_TOKEN

## Test plan
- [ ] Confirm /log loads at preview URL (will show empty state until env is wired)
- [ ] Set CONTENT_ENGINE_URL + STUDIO_TOKEN in Vercel → confirm posts appear
- [ ] Click an entry → opens LinkedIn permalink in new tab
- [ ] Confirm /sitemap.xml includes /log entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)