### PR TITLE
sixtom v1.26 — thesis eyebrow black, notify placeholder CRO-questiony

### DIFF
--- a/src/lib/components/LeadCapture.svelte
+++ b/src/lib/components/LeadCapture.svelte
@@ -32,7 +32,7 @@
 					type="email"
 					required
 					autocomplete="email"
-					placeholder="you@yourdomain.com"
+					placeholder="Where should the heads-up land?"
 					class="border-border bg-surface text-fg placeholder:text-fg-subtle focus:border-accent focus:ring-accent flex-1 rounded-md border px-4 py-3 text-lg focus:ring-2 focus:outline-none disabled:opacity-60"
 				/>
 				<input type="hidden" name="name" value="Notify list signup" />

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -12,7 +12,7 @@
 
 <section class="snap-section surface-uv">
 	<div class="mx-auto w-full max-w-4xl px-6">
-		<p class="eyebrow text-sm">— the thesis</p>
+		<p class="eyebrow text-fg text-sm">— the thesis</p>
 		<p
 			class="text-fg mt-4 text-3xl leading-tight font-semibold tracking-tight italic md:text-5xl lg:text-6xl"
 		>


### PR DESCRIPTION
## Summary
- Thesis eyebrow on light surface: override eyebrow's accent color to text-fg (black) — was rendering as faded blue/teal on cream
- Notify form placeholder: "you@yourdomain.com" → "Where should the heads-up land?" — reinforces the value prop, more conversational

## Test plan
- [ ] Preview thesis section — "— the thesis" eyebrow reads in near-black, not teal
- [ ] Preview LeadCapture — empty input shows new placeholder, focused/typing unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)