### PR TITLE
sixtom v1.27 — placeholder: Email you actually check

### DIFF
--- a/src/lib/components/LeadCapture.svelte
+++ b/src/lib/components/LeadCapture.svelte
@@ -32,7 +32,7 @@
 					type="email"
 					required
 					autocomplete="email"
-					placeholder="Where should the heads-up land?"
+					placeholder="Email you actually check"
 					class="border-border bg-surface text-fg placeholder:text-fg-subtle focus:border-accent focus:ring-accent flex-1 rounded-md border px-4 py-3 text-lg focus:ring-2 focus:outline-none disabled:opacity-60"
 				/>
 				<input type="hidden" name="name" value="Notify list signup" />


### PR DESCRIPTION
Swap soft-question placeholder for on-voice direct: 'Email you actually check' — addresses the burner-inbox objection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)