### PR TITLE
sixtom v1.29 — footer + /privacy + /terms

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -59,22 +59,6 @@
 	font-family: var(--font-display);
 }
 
-/* Re-establish the dark palette inside a .surface-uv parent (marquee bar).
- * Only the vars that .surface-uv actually changes need restating; the rest
- * (--gradient-accent, --color-on-accent, --color-error) inherit from @theme. */
-.surface-dark {
-	--color-surface: oklch(14.5% 0 0);
-	--color-fg: oklch(97% 0 0);
-	--color-fg-muted: oklch(70.8% 0 0);
-	--color-fg-subtle: oklch(60% 0 0);
-	--color-border: oklch(26.9% 0 0);
-	--color-border-strong: oklch(37.1% 0 0);
-	--shadow-accent: 0 0 0 transparent;
-	background: var(--color-surface);
-	color: var(--color-fg);
-	font-family: var(--font-sans);
-}
-
 /* Register --gradient-angle as <angle> so CSS can interpolate it on transition.
  * Without @property, the gradient would swap instantly instead of rotating. */
 @property --gradient-angle {
@@ -118,18 +102,6 @@
 	color: var(--color-accent);
 }
 
-/* Marquee bar uses the display font + letter-spacing the T•H•R•E•E•S•A•M treatment.
- * `user-select: none` prevents drag-to-select on the animated track. */
-.marquee-link .marquee-track {
-	font-family: var(--font-display);
-	letter-spacing: 0.4em;
-}
-.marquee-link {
-	user-select: none;
-	-webkit-user-select: none;
-	transition: color 0.25s;
-}
-
 html {
 	color: var(--color-fg);
 	background: var(--color-surface);
@@ -143,24 +115,4 @@ html {
 	display: flex;
 	flex-direction: column;
 	justify-content: center;
-}
-
-.marquee-track {
-	animation: marquee 60s linear infinite;
-}
-
-@keyframes marquee {
-	from {
-		transform: translateX(0);
-	}
-	to {
-		/* One copy's width — caller must set --marquee-copies on the element. */
-		transform: translateX(calc(-100% / var(--marquee-copies)));
-	}
-}
-
-@media (prefers-reduced-motion: reduce) {
-	.marquee-track {
-		animation: none;
-	}
 }

--- a/src/lib/components/LeadCapture.svelte
+++ b/src/lib/components/LeadCapture.svelte
@@ -4,8 +4,7 @@
 
 	let { form }: { form: FormResult | null } = $props()
 
-	// Enough copies that the seamless-loop tile covers wide viewports (4K still works).
-	const MARQUEE_COPIES = 6
+	const year = new Date().getFullYear()
 </script>
 
 <section class="snap-section bg-surface relative !justify-between">
@@ -71,22 +70,24 @@
 		</div>
 	</div>
 
-	<a
-		href={site.gardenUrl}
-		data-umami-event="cta_garden_link"
-		target="_blank"
-		rel="noopener noreferrer"
-		draggable="false"
-		aria-label="threesam.com — the garden"
-		class="surface-dark border-border text-fg hover:text-coin marquee-link block w-full overflow-hidden border-t py-6 transition-colors"
-	>
+	<footer class="border-border text-fg-subtle w-full border-t px-6 py-4 text-xs">
 		<div
-			class="marquee-track flex w-max items-center text-lg font-bold whitespace-nowrap"
-			style="--marquee-copies: {MARQUEE_COPIES};"
+			class="mx-auto flex w-full max-w-4xl flex-col items-center justify-between gap-2 sm:flex-row"
 		>
-			{#each Array(MARQUEE_COPIES), i (i)}
-				<div data-marquee-copy class="pr-2" aria-hidden="true">T • H • R • E • E • S • A • M •</div>
-			{/each}
+			<div class="flex items-center gap-4">
+				<span>© {year} sixtom</span>
+				<a href="/privacy" class="hover:text-fg transition-colors">privacy</a>
+				<a href="/terms" class="hover:text-fg transition-colors">terms</a>
+			</div>
+			<a
+				href={site.gardenUrl}
+				target="_blank"
+				rel="noopener noreferrer"
+				data-umami-event="cta_garden_link"
+				class="hover:text-coin transition-colors"
+			>
+				threesam.com →
+			</a>
 		</div>
-	</a>
+	</footer>
 </section>

--- a/src/routes/privacy/+page.svelte
+++ b/src/routes/privacy/+page.svelte
@@ -1,0 +1,61 @@
+<script lang="ts">
+	import { site } from '$lib/content'
+</script>
+
+<svelte:head>
+	<title>privacy — sixtom</title>
+	<meta name="description" content="What sixtom collects, what it doesn't, and how to get it deleted." />
+	<link rel="canonical" href={`${site.siteUrl}/privacy`} />
+</svelte:head>
+
+<div class="bg-surface min-h-screen">
+	<div class="mx-auto w-full max-w-3xl px-6 py-20">
+		<header class="mb-16">
+			<a
+				href="/"
+				class="eyebrow text-fg-subtle hover:text-coin text-xs transition-colors"
+				data-umami-event="legal_back_home"
+			>
+				← sixtom
+			</a>
+			<p class="eyebrow mt-12 text-sm">legal</p>
+			<h1 class="text-fg mt-2 text-4xl font-bold tracking-tight md:text-6xl">Privacy.</h1>
+			<p class="text-fg-muted mt-6 text-lg leading-relaxed">The short, honest version.</p>
+		</header>
+
+		<div class="text-fg-muted space-y-10 text-base leading-relaxed">
+			<section>
+				<h2 class="text-fg text-xl font-semibold tracking-tight">What I collect</h2>
+				<p class="mt-3">The email and message you submit through the contact or notify form.</p>
+				<p class="mt-3">
+					Anonymous traffic data via Umami, self-hosted at analytics.sixtom.com. No cookies, no
+					fingerprinting, no IP address storage.
+				</p>
+			</section>
+
+			<section>
+				<h2 class="text-fg text-xl font-semibold tracking-tight">What I do with it</h2>
+				<p class="mt-3">
+					Reply to you. Look at aggregate patterns — which pages get traffic, where it comes from.
+				</p>
+			</section>
+
+			<section>
+				<h2 class="text-fg text-xl font-semibold tracking-tight">What I don't do</h2>
+				<p class="mt-3">
+					Sell your data. Share it with a third party. Use it for retargeting. Pretend GDPR doesn't
+					exist.
+				</p>
+			</section>
+
+			<section>
+				<h2 class="text-fg text-xl font-semibold tracking-tight">Removal</h2>
+				<p class="mt-3">
+					Email the address you submitted from and I'll delete what I have on you within a week.
+				</p>
+			</section>
+
+			<p class="text-fg-subtle mt-16 text-xs tracking-widest uppercase">Last updated: May 2026</p>
+		</div>
+	</div>
+</div>

--- a/src/routes/privacy/+page.ts
+++ b/src/routes/privacy/+page.ts
@@ -1,0 +1,1 @@
+export const prerender = true

--- a/src/routes/sitemap.xml/+server.ts
+++ b/src/routes/sitemap.xml/+server.ts
@@ -18,6 +18,18 @@ export function GET(): Response {
 		<changefreq>weekly</changefreq>
 		<priority>0.8</priority>
 	</url>
+	<url>
+		<loc>${site.siteUrl}/privacy</loc>
+		<lastmod>${today}</lastmod>
+		<changefreq>yearly</changefreq>
+		<priority>0.3</priority>
+	</url>
+	<url>
+		<loc>${site.siteUrl}/terms</loc>
+		<lastmod>${today}</lastmod>
+		<changefreq>yearly</changefreq>
+		<priority>0.3</priority>
+	</url>
 </urlset>
 `
 	return new Response(body, {

--- a/src/routes/terms/+page.svelte
+++ b/src/routes/terms/+page.svelte
@@ -1,0 +1,74 @@
+<script lang="ts">
+	import { site } from '$lib/content'
+</script>
+
+<svelte:head>
+	<title>terms — sixtom</title>
+	<meta
+		name="description"
+		content="How engagement with sixtom works. Plain-English terms for the audit and async sprint."
+	/>
+	<link rel="canonical" href={`${site.siteUrl}/terms`} />
+</svelte:head>
+
+<div class="bg-surface min-h-screen">
+	<div class="mx-auto w-full max-w-3xl px-6 py-20">
+		<header class="mb-16">
+			<a
+				href="/"
+				class="eyebrow text-fg-subtle hover:text-coin text-xs transition-colors"
+				data-umami-event="legal_back_home"
+			>
+				← sixtom
+			</a>
+			<p class="eyebrow mt-12 text-sm">legal</p>
+			<h1 class="text-fg mt-2 text-4xl font-bold tracking-tight md:text-6xl">Terms.</h1>
+			<p class="text-fg-muted mt-6 text-lg leading-relaxed">How engagement works. Plain English.</p>
+		</header>
+
+		<div class="text-fg-muted space-y-10 text-base leading-relaxed">
+			<section>
+				<h2 class="text-fg text-xl font-semibold tracking-tight">Two things I sell</h2>
+				<p class="mt-3">
+					The {site.audit.name} — ${site.audit.priceUSD}. Send your repo + the thing you've been trying
+					to ship; I send back a 1-pager and a 15-min Loom within a week.
+				</p>
+				<p class="mt-3">
+					The {site.sprint.name} — ${site.sprint.priceUSD.toLocaleString()}. Two weeks, fixed scope
+					agreed up front, daily drops. Live in production day 10.
+				</p>
+			</section>
+
+			<section>
+				<h2 class="text-fg text-xl font-semibold tracking-tight">Refunds</h2>
+				<p class="mt-3">
+					Audit: non-refundable once I've started. Full refund if I haven't started within 7 days of
+					payment.
+				</p>
+				<p class="mt-3">
+					Sprint: if by day 5 we both agree it won't ship in scope, we stop. You keep what was built
+					and I refund 50%.
+				</p>
+			</section>
+
+			<section>
+				<h2 class="text-fg text-xl font-semibold tracking-tight">Code ownership</h2>
+				<p class="mt-3">
+					Code I write for you is yours, no strings. I retain the right to discuss approach and
+					outcomes publicly with names and identifying details removed, unless you say otherwise in
+					writing.
+				</p>
+			</section>
+
+			<section>
+				<h2 class="text-fg text-xl font-semibold tracking-tight">If something breaks</h2>
+				<p class="mt-3">
+					Email me. I'll fix what's mine. Implied warranties and indirect or consequential damages
+					are excluded, but I'm not going to be difficult about real problems.
+				</p>
+			</section>
+
+			<p class="text-fg-subtle mt-16 text-xs tracking-widest uppercase">Last updated: May 2026</p>
+		</div>
+	</div>
+</div>

--- a/src/routes/terms/+page.ts
+++ b/src/routes/terms/+page.ts
@@ -1,0 +1,1 @@
+export const prerender = true


### PR DESCRIPTION
## Summary
- Marquee → slim footer at the bottom of LeadCapture: copyright + privacy + terms + subtle threesam.com link (bottom-right)
- Footer is short enough to stay inside the LeadCapture snap section — no new scroll stop
- New /privacy and /terms scaffolds (prerendered), plain-English, site voice
- Sitemap includes both
- Dead CSS cleanup: surface-dark, marquee-link, marquee-track, @keyframes marquee

## Test plan
- [ ] Home: scroll to last section, see footer in place of marquee, contents visible without scroll
- [ ] /privacy and /terms render in dark surface with header link back to home
- [ ] sitemap.xml includes all 4 URLs

🤖 Generated with [Claude Code](https://claude.com/claude-code)