### PR TITLE
sixtom v1.30 — fix prerender entries for /privacy + /terms

### DIFF
--- a/svelte.config.js
+++ b/svelte.config.js
@@ -7,7 +7,7 @@ export default {
 	compilerOptions: { runes: true },
 	kit: {
 		adapter: adapter(),
-		prerender: { entries: ['/sanity', '/sitemap.xml'] },
+		prerender: { entries: ['/sanity', '/sitemap.xml', '/privacy', '/terms'] },
 		// Inline CSS chunks under 25 KB to drop the render-blocking
 		// <link rel="stylesheet"> round-trip on a fully prerendered page.
 		inlineStyleThreshold: 25_000


### PR DESCRIPTION
Hotfix: v1.29 deploy failed because the SvelteKit prerenderer's crawl didn't reach the new legal pages (home page isn't a crawl entry).

🤖 Generated with [Claude Code](https://claude.com/claude-code)