### PR TITLE
sixtom v1.32 — fix nested-route CSS 404 (paths.relative=false)

### DIFF
--- a/svelte.config.js
+++ b/svelte.config.js
@@ -7,6 +7,9 @@ export default {
 	compilerOptions: { runes: true },
 	kit: {
 		adapter: adapter(),
+		// Default is relative URLs (./_app/...), which 404 from nested routes
+		// like /log when the inline style hand-off tries to load the external CSS.
+		paths: { relative: false },
 		prerender: { entries: ['/sanity', '/sitemap.xml', '/privacy', '/terms'] },
 		// Inline CSS chunks under 25 KB to drop the render-blocking
 		// <link rel="stylesheet"> round-trip on a fully prerendered page.


### PR DESCRIPTION
Hotfix: /log, /privacy, /terms were going unstyled after initial paint because the relative CSS URL doesn't work from non-root paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)