### PR TITLE
sixtom v1.39 — /log case study cards: centered title, max-w-3xl, scroll-then-nav

### DIFF
--- a/src/lib/components/LogHero.svelte
+++ b/src/lib/components/LogHero.svelte
@@ -2,6 +2,7 @@
 	import { goto } from '$app/navigation'
 
 	interface Props {
+		id?: string
 		href: string
 		title: string
 		eyebrow: string
@@ -12,6 +13,7 @@
 	}
 
 	let {
+		id,
 		href,
 		title,
 		eyebrow,
@@ -27,16 +29,16 @@
 		if (!clickable) return
 		if (e.metaKey || e.ctrlKey || e.shiftKey) return
 		e.preventDefault()
-		if (cardEl) {
-			cardEl.scrollIntoView({ behavior: 'smooth', block: 'start' })
-			await new Promise((r) => setTimeout(r, 500))
-		}
+		if (id) history.replaceState(null, '', `#${id}`)
+		cardEl?.scrollIntoView({ behavior: 'smooth', block: 'start' })
+		await new Promise((r) => setTimeout(r, 500))
 		await goto(href)
 	}
 </script>
 
 <a
 	bind:this={cardEl}
+	{id}
 	{href}
 	onclick={navigate}
 	class="log-hero-card relative block h-[35dvh] w-full overflow-hidden md:h-[45dvh]"
@@ -51,21 +53,21 @@
 		fetchpriority="high"
 	/>
 	<p
-		class="eyebrow absolute top-6 left-6 text-sm md:top-10 md:left-10"
+		class="eyebrow absolute top-6 left-1/2 z-10 -translate-x-1/2 text-sm md:top-8"
 		style="color: {accentColor}"
 	>
 		{eyebrow}
 	</p>
 	{#if headingLevel === 1}
 		<h1
-			class="pointer-events-none absolute bottom-6 left-6 z-10 font-mono text-4xl font-bold uppercase tracking-[0.08em] md:bottom-12 md:left-12 md:text-7xl"
+			class="pointer-events-none absolute inset-0 z-10 flex items-center justify-center px-6 text-center font-mono text-4xl font-bold tracking-[0.08em] uppercase md:text-7xl"
 			style="color: oklch(14.5% 0 0)"
 		>
 			{title}
 		</h1>
 	{:else}
 		<h2
-			class="pointer-events-none absolute bottom-6 left-6 z-10 font-mono text-4xl font-bold uppercase tracking-[0.08em] md:bottom-12 md:left-12 md:text-7xl"
+			class="pointer-events-none absolute inset-0 z-10 flex items-center justify-center px-6 text-center font-mono text-4xl font-bold tracking-[0.08em] uppercase md:text-7xl"
 			style="color: oklch(14.5% 0 0)"
 		>
 			{title}

--- a/src/routes/log/+page.svelte
+++ b/src/routes/log/+page.svelte
@@ -37,27 +37,32 @@
 </svelte:head>
 
 <!-- case studies -->
-{#each LOG_ENTRIES as entry (entry.slug)}
-	<article class="mb-12 md:mb-20">
-		<LogHero
-			href={`/log/${entry.slug}`}
-			title={entry.title}
-			eyebrow={entry.eyebrow}
-			heroImage={entry.heroImage}
-			clickable={true}
-			headingLevel={2}
-		/>
-		<div class="mx-auto w-full max-w-2xl px-6 py-6 md:py-8">
-			<p class="text-fg-muted text-base leading-relaxed md:text-lg">{entry.blurb}</p>
-			<a
-				href={`/log/${entry.slug}`}
-				class="text-accent mt-3 inline-block text-sm font-medium hover:underline"
-			>
-				read →
-			</a>
-		</div>
-	</article>
-{/each}
+<div class="bg-surface">
+	{#each LOG_ENTRIES as entry (entry.slug)}
+		<article class="mx-auto mb-12 w-full max-w-3xl px-6 pt-12 md:mb-20 md:pt-20">
+			<div class="overflow-hidden rounded-lg">
+				<LogHero
+					id={entry.slug}
+					href={`/log/${entry.slug}`}
+					title={entry.title}
+					eyebrow={entry.eyebrow}
+					heroImage={entry.heroImage}
+					clickable={true}
+					headingLevel={2}
+				/>
+			</div>
+			<div class="py-6 md:py-8">
+				<p class="text-fg-muted text-base leading-relaxed md:text-lg">{entry.blurb}</p>
+				<a
+					href={`/log/${entry.slug}`}
+					class="text-fg-subtle hover:text-coin mt-3 inline-block text-xs tracking-widest uppercase transition-colors"
+				>
+					read →
+				</a>
+			</div>
+		</article>
+	{/each}
+</div>
 
 <!-- linkedin feed -->
 <div class="bg-surface min-h-screen">


### PR DESCRIPTION
## Summary
- Case study card on /log now matches LinkedIn-post column width (max-w-3xl) with rounded card silhouette
- Title centered over the hero image (was bottom-left); eyebrow top-center for symmetry
- Click flow: sets URL hash to the case-study slug, scrolls the card into view (smooth), then navigates to the detail page

🤖 Generated with [Claude Code](https://claude.com/claude-code)