### PR TITLE
sixtom v1.43 — home page: lowercase voice

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,4 +27,4 @@ vite.config.ts.timestamp-*
 /playwright-report/
 /playwright/.cache/
 /.playwright-mcp/
-/log-*.png
+/*.png

--- a/src/app.html
+++ b/src/app.html
@@ -7,10 +7,10 @@
 		<meta name="author" content="Sam D'Angelo" />
 		<meta name="format-detection" content="telephone=no" />
 
-		<title>SIXTOM — async sprints with Sam D'Angelo</title>
+		<title>sixtom — async sprints with Sam D'Angelo</title>
 		<meta
 			name="description"
-			content="AI ships demos. I ship products. I run a fleet of agents in parallel. $1,500 audit. $10,000 sprint. 1 client a month."
+			content="AI ships demos. i ship products. i run a fleet of agents in parallel. $1,500 audit. $10,000 sprint. 1 client a month."
 		/>
 		<link rel="canonical" href="https://sixtom.com/" />
 
@@ -35,23 +35,23 @@
 			crossorigin
 		/>
 
-		<meta property="og:title" content="SIXTOM — async sprints with Sam D'Angelo" />
+		<meta property="og:title" content="sixtom — async sprints with Sam D'Angelo" />
 		<meta
 			property="og:description"
-			content="AI ships demos. I ship products. $1,500 audit. $10,000 sprint."
+			content="AI ships demos. i ship products. $1,500 audit. $10,000 sprint."
 		/>
 		<meta property="og:type" content="website" />
 		<meta property="og:url" content="https://sixtom.com/" />
 		<meta property="og:image" content="https://sixtom.com/og.png" />
 		<meta property="og:image:width" content="1200" />
 		<meta property="og:image:height" content="630" />
-		<meta property="og:image:alt" content="SIXTOM — async sprints with Sam D'Angelo" />
+		<meta property="og:image:alt" content="sixtom — async sprints with Sam D'Angelo" />
 
 		<meta name="twitter:card" content="summary_large_image" />
-		<meta name="twitter:title" content="SIXTOM — async sprints with Sam D'Angelo" />
+		<meta name="twitter:title" content="sixtom — async sprints with Sam D'Angelo" />
 		<meta
 			name="twitter:description"
-			content="AI ships demos. I ship products. $1,500 audit. $10,000 sprint."
+			content="AI ships demos. i ship products. $1,500 audit. $10,000 sprint."
 		/>
 		<meta name="twitter:image" content="https://sixtom.com/og.png" />
 

--- a/src/lib/components/Hero.svelte
+++ b/src/lib/components/Hero.svelte
@@ -4,7 +4,7 @@
 
 <section class="snap-section bg-surface">
 	<div class="mx-auto w-full max-w-4xl px-6">
-		<p class="eyebrow text-sm">SIXTOM — async sprints</p>
+		<p class="eyebrow text-sm">sixtom — async sprints</p>
 		<h1
 			class="text-fg mt-6 text-5xl leading-[1.02] font-bold tracking-tight md:text-7xl lg:text-8xl"
 		>
@@ -25,7 +25,7 @@
 			</a>
 		</div>
 		<p class="text-fg-subtle mt-12 text-xs tracking-widest uppercase">
-			@ {site.operator.currentEmployer} · Formerly @ {site.operator.formerEmployer}
+			@ {site.operator.currentEmployer} · formerly @ {site.operator.formerEmployer}
 		</p>
 	</div>
 </section>

--- a/src/lib/components/LeadCapture.svelte
+++ b/src/lib/components/LeadCapture.svelte
@@ -10,12 +10,12 @@
 <section class="snap-section bg-surface relative !justify-between">
 	<div class="flex w-full flex-1 items-center px-6 py-16">
 		<div class="mx-auto w-full max-w-2xl">
-			<p class="eyebrow text-sm">Not ready yet?</p>
+			<p class="eyebrow text-sm">not ready yet?</p>
 			<h2 class="text-fg mt-2 text-3xl font-bold tracking-tight md:text-5xl">
-				Heads-up when the next slot opens.
+				heads-up when the next slot opens.
 			</h2>
 			<p class="text-fg-muted mt-6 text-lg leading-relaxed">
-				One client a month. Drop your email and I'll let you know when I'm taking the next one.
+				one client a month. drop your email and i'll let you know when i'm taking the next one.
 			</p>
 
 			<form

--- a/src/lib/components/OfferSection.svelte
+++ b/src/lib/components/OfferSection.svelte
@@ -5,7 +5,7 @@
 <section id="offers" class="snap-section bg-surface">
 	<div class="mx-auto w-full max-w-4xl px-6 py-16 md:py-20">
 		<p class="eyebrow text-sm">two ways in</p>
-		<h2 class="text-fg mt-2 text-4xl font-bold tracking-tight md:text-6xl">Start small. Or go.</h2>
+		<h2 class="text-fg mt-2 text-4xl font-bold tracking-tight md:text-6xl">start small. or go.</h2>
 
 		<div
 			class="-mx-6 mt-12 flex snap-x snap-mandatory gap-6 overflow-x-auto scroll-px-6 px-6 pb-4 md:mx-0 md:grid md:grid-cols-2 md:gap-8 md:overflow-visible md:px-0 md:pb-0"
@@ -15,7 +15,7 @@
 			>
 				<p class="eyebrow text-xs">step 1 — start here</p>
 				<h3 class="text-fg mt-2 text-2xl font-bold tracking-tight md:text-3xl">
-					The {site.audit.name}.
+					the {site.audit.name}.
 				</h3>
 				<p class="text-fg mt-3 text-xl font-semibold">
 					${site.audit.priceUSD.toLocaleString()}. {site.audit.cadence}
@@ -31,7 +31,7 @@
 						rel="noopener noreferrer"
 						target="_blank"
 					>
-						Start the audit →
+						start the audit →
 					</a>
 				</div>
 			</article>
@@ -41,14 +41,14 @@
 			>
 				<p class="eyebrow text-xs">step 2 — when you're ready</p>
 				<h3 class="text-fg mt-2 text-2xl font-bold tracking-tight md:text-3xl">
-					The {site.sprint.name}.
+					the {site.sprint.name}.
 				</h3>
 				<p class="text-fg mt-3 text-xl font-semibold">
 					${site.sprint.priceUSD.toLocaleString()}. {site.sprint.cadence}
 				</p>
 				{#if site.sprint.introPriceUSD && site.sprint.introNote}
 					<p class="text-fg-subtle mt-1 text-sm">
-						Intro rate ${site.sprint.introPriceUSD.toLocaleString()} for the {site.sprint
+						intro rate ${site.sprint.introPriceUSD.toLocaleString()} for the {site.sprint
 							.introNote}.
 					</p>
 				{/if}
@@ -63,7 +63,7 @@
 						rel="noopener noreferrer"
 						target="_blank"
 					>
-						Book the call →
+						book the call →
 					</a>
 				</div>
 			</article>

--- a/src/lib/content/site.ts
+++ b/src/lib/content/site.ts
@@ -7,40 +7,40 @@ export const site: Site = {
 	bookingUrl: 'https://cal.com/sam-dangelo/sprint-intro',
 	gardenUrl: 'https://threesam.com',
 	tagline: 'we just want to build cool shit and help people chase their dreams',
-	thesis: 'Vibe coding is how you slowly become the intern of your own codebase.',
+	thesis: 'vibe coding is how you slowly become the intern of your own codebase.',
 	thesisBody:
-		'AI gets you to a demo. Agents do the typing. I do the judgment. Together we ship a product.',
+		'AI gets you to a demo. agents do the typing. i do the judgment. together we ship a product.',
 	hero: {
-		h1: 'AI ships demos. I ship products.',
+		h1: 'AI ships demos. i ship products.',
 		subhead:
-			'I run a fleet of agents in parallel. They type, I judge. Two weeks to a working version live in production. Daily drops. No calendar tetris.',
-		ctaPrimary: 'Book a 30-min intro call',
-		ctaSecondary: 'Notify me'
+			"i run a fleet of agents in parallel. they type, i judge. two weeks to a working version live in production. daily drops. no calendar tetris.",
+		ctaPrimary: 'book a 30-min intro call',
+		ctaSecondary: 'notify me'
 	},
 	operator: {
 		name: "Sam D'Angelo",
-		jobTitle: 'Lead Engineer',
+		jobTitle: 'lead engineer',
 		currentEmployer: 'Made In Cookware',
 		formerEmployer: 'Rhone',
-		credentialsChip: 'Lead engineer at Made In Cookware. Formerly at Rhone.'
+		credentialsChip: 'lead engineer at Made In Cookware. formerly at Rhone.'
 	},
 	audit: {
-		name: 'Audit',
+		name: 'audit',
 		longName: 'the audit',
 		priceUSD: 1500,
 		cadence: 'turnaround within a week.',
 		promise:
-			"Send me your repo and the thing you've been trying to ship. I send back a 1-pager and a 15-min Loom — what's blocking, what I'd do, whether a sprint makes sense. Credited toward a sprint if you book within 30 days."
+			"send me your repo and the thing you've been trying to ship. i send back a 1-pager and a 15-min Loom — what's blocking, what i'd do, whether a sprint makes sense. credited toward a sprint if you book within 30 days."
 	},
 	sprint: {
-		name: 'Async Sprint',
+		name: 'async sprint',
 		longName: 'async sprint',
 		priceUSD: 10000,
 		introPriceUSD: 7500,
 		introNote: 'first 3 clients',
 		cadence: '1 client a month, by appointment.',
 		promise:
-			'Two weeks. Agents do the typing — drafts, fixes, accessibility passes, the boring 10%. I do the judgment. Daily drops. Live in production on day 10.'
+			'two weeks. agents do the typing — drafts, fixes, accessibility passes, the boring 10%. i do the judgment. daily drops. live in production on day 10.'
 	},
 	process: [
 		{


### PR DESCRIPTION
Apply 'lowercase except proper nouns + acronyms' (already used on /log, /privacy, /terms) to the home page copy: hero, thesis, offers, lead-capture, footer credentials, meta description, og/twitter cards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)