### PR TITLE
sixtom v1.44 — landing page revision per Steve coaching

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -10,7 +10,7 @@
 		<title>sixtom — async sprints with Sam D'Angelo</title>
 		<meta
 			name="description"
-			content="AI ships demos. i ship products. i run a fleet of agents in parallel. $1,500 audit. $10,000 sprint. 1 client a month."
+			content="AI ships demos. i ship solutions. $1,500 audit. $10,000 sprint. 1 client a month."
 		/>
 		<link rel="canonical" href="https://sixtom.com/" />
 
@@ -38,7 +38,7 @@
 		<meta property="og:title" content="sixtom — async sprints with Sam D'Angelo" />
 		<meta
 			property="og:description"
-			content="AI ships demos. i ship products. $1,500 audit. $10,000 sprint."
+			content="AI ships demos. i ship solutions. $1,500 audit. $10,000 sprint."
 		/>
 		<meta property="og:type" content="website" />
 		<meta property="og:url" content="https://sixtom.com/" />
@@ -51,7 +51,7 @@
 		<meta name="twitter:title" content="sixtom — async sprints with Sam D'Angelo" />
 		<meta
 			name="twitter:description"
-			content="AI ships demos. i ship products. $1,500 audit. $10,000 sprint."
+			content="AI ships demos. i ship solutions. $1,500 audit. $10,000 sprint."
 		/>
 		<meta name="twitter:image" content="https://sixtom.com/og.png" />
 

--- a/src/lib/components/OfferSection.svelte
+++ b/src/lib/components/OfferSection.svelte
@@ -52,6 +52,11 @@
 							.introNote}.
 					</p>
 				{/if}
+				{#if site.sprint.paymentPlan}
+					<p class="text-fg-subtle mt-1 text-sm">
+						or {site.sprint.paymentPlan}.
+					</p>
+				{/if}
 				<p class="text-fg-muted mt-4 text-base leading-relaxed">
 					{site.sprint.promise}
 				</p>

--- a/src/lib/content/site.ts
+++ b/src/lib/content/site.ts
@@ -9,11 +9,11 @@ export const site: Site = {
 	tagline: 'we just want to build cool shit and help people chase their dreams',
 	thesis: 'vibe coding is how you slowly become the intern of your own codebase.',
 	thesisBody:
-		'AI gets you to a demo. agents do the typing. i do the judgment. together we ship a product.',
+		"AI gets you to a demo because the model can hold the whole thing in its head. once the codebase outgrows that window, the AI starts making it worse instead of better. that's the wall every vibe-coded project hits. it's also the thing i fix.",
 	hero: {
-		h1: 'AI ships demos. i ship products.',
+		h1: 'AI ships demos. i ship solutions.',
 		subhead:
-			"i run a fleet of agents in parallel. they type, i judge. two weeks to a working version live in production. daily drops. no calendar tetris.",
+			"you got to a working demo with AI. it falls over the moment a real user hits it. two weeks of guardrailed builds — fixed price, daily drops, live in production day 10.",
 		ctaPrimary: 'book a 30-min intro call',
 		ctaSecondary: 'notify me'
 	},
@@ -30,17 +30,18 @@ export const site: Site = {
 		priceUSD: 1500,
 		cadence: 'turnaround within a week.',
 		promise:
-			"send me your repo and the thing you've been trying to ship. i send back a 1-pager and a 15-min Loom — what's blocking, what i'd do, whether a sprint makes sense. credited toward a sprint if you book within 30 days."
+			"send me your repo and the thing you've been stuck on. within a week i send back a 1-pager and a 15-min Loom — what's blocking, what i'd do, and what it's costing you in opportunity to leave it as-is. credited toward a sprint if you book within 30 days."
 	},
 	sprint: {
-		name: 'async sprint',
+		name: 'sprint',
 		longName: 'async sprint',
 		priceUSD: 10000,
 		introPriceUSD: 7500,
 		introNote: 'first 3 clients',
 		cadence: '1 client a month, by appointment.',
+		paymentPlan: '4 weekly payments of $2,500',
 		promise:
-			'two weeks. agents do the typing — drafts, fixes, accessibility passes, the boring 10%. i do the judgment. daily drops. live in production on day 10.'
+			"you've built the thing with AI. it works in dev. you're scared to put real traffic on it. two weeks of guardrailed builds — fixed scope, daily drops, live in production day 10. i orchestrate the agents and review every change. you ship, you own it."
 	},
 	process: [
 		{

--- a/src/lib/content/types.ts
+++ b/src/lib/content/types.ts
@@ -21,6 +21,7 @@ export interface Offer {
 	promise: string
 	introPriceUSD?: number
 	introNote?: string
+	paymentPlan?: string
 }
 
 export interface ProcessStep {


### PR DESCRIPTION
## Summary
Applies action items from the May 21 coaching call with Steve.

- Hero: \"i ship products\" → \"i ship solutions\"; subhead rewritten pain-led, dropping the \"fleet of agents in parallel\" line.
- Thesis body: \"wall every vibe-coded project hits\" framing — names the failure mode (context window) explicitly.
- Sprint offer: name simplified \"async sprint\" → \"sprint\" (Steve: \"I know the word but it's not concrete\"); promise rewritten around prospect pain + outcome; new paymentPlan field surfaces \"4 weekly payments of \$2,500\".
- Audit promise: opportunity-cost framing added.
- Meta description updated for consistency.

## Out of scope (followup)
- Opportunity-cost calculator funnel
- Page video for rapport
- Downgrade-tier offshoot pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)