### PR TITLE
sixtom v1.46 — /book qualification form (Hormozi BANTS)

### DIFF
--- a/src/lib/components/Hero.svelte
+++ b/src/lib/components/Hero.svelte
@@ -15,11 +15,9 @@
 		</p>
 		<div class="mt-12">
 			<a
-				href={site.bookingUrl}
+				href="/book"
 				data-umami-event="cta_hero_book"
 				class="btn-accent px-8 py-4 text-lg hover:opacity-90"
-				rel="noopener noreferrer"
-				target="_blank"
 			>
 				{site.hero.ctaPrimary} →
 			</a>

--- a/src/lib/components/OfferSection.svelte
+++ b/src/lib/components/OfferSection.svelte
@@ -25,11 +25,9 @@
 						${site.audit.priceUSD.toLocaleString()}. {site.audit.cadence}
 					</p>
 					<a
-						href={site.bookingUrl}
+						href="/book"
 						data-umami-event="cta_audit_book"
 						class="btn-accent mt-6 px-6 py-3 text-base hover:opacity-90"
-						rel="noopener noreferrer"
-						target="_blank"
 					>
 						start the audit →
 					</a>
@@ -62,11 +60,9 @@
 						</p>
 					{/if}
 					<a
-						href={site.bookingUrl}
+						href="/book"
 						data-umami-event="cta_sprint_book"
 						class="btn-accent mt-6 px-6 py-3 text-base hover:opacity-90"
-						rel="noopener noreferrer"
-						target="_blank"
 					>
 						book the call →
 					</a>

--- a/src/routes/book/+page.server.ts
+++ b/src/routes/book/+page.server.ts
@@ -70,12 +70,19 @@ export const actions = {
 		}
 
 		const formData = await event.request.formData()
-		const built = String(formData.get('built') ?? '').trim()
+		// Strip CRLF from single-line fields (and length-cap them) so they can't
+		// fabricate extra "field: value" lines in the email body Sam reads.
+		// Cap deliverable too so composedMessage stays under MAX_MESSAGE_LENGTH
+		// (5000) — a wall of text in deliverable + built would silently 400.
+		const stripNewlines = (s: string) => s.replace(/[\r\n]+/g, ' ').trim()
+		const normalizeNewlines = (s: string) => s.replace(/\r\n/g, '\n').trim()
+
+		const built = stripNewlines(String(formData.get('built') ?? '')).slice(0, 500)
 		const stage = String(formData.get('stage') ?? '')
-		const deliverable = String(formData.get('deliverable') ?? '').trim()
+		const deliverable = normalizeNewlines(String(formData.get('deliverable') ?? '')).slice(0, 4000)
 		const budget = String(formData.get('budget') ?? '')
 		const authority = String(formData.get('authority') ?? '')
-		const companyUrl = String(formData.get('company_url') ?? '').trim()
+		const companyUrl = stripNewlines(String(formData.get('company_url') ?? '')).slice(0, 500)
 
 		const missing =
 			!built || !stage || !deliverable || !budget || !authority || !companyUrl

--- a/src/routes/book/+page.server.ts
+++ b/src/routes/book/+page.server.ts
@@ -1,0 +1,142 @@
+import { fail } from '@sveltejs/kit'
+import { site } from '$lib/content'
+import { MAX_REQUEST_BYTES, processSubmission } from '$lib/server/contact-form'
+import type { Actions } from './$types'
+
+const STAGE_OPTIONS = [
+	{ value: 'demo-only', label: 'demo works for me only' },
+	{ value: 'few-users', label: 'a few real users on it' },
+	{ value: 'paying-breaking', label: 'paying customers but breaking' },
+	{ value: 'pre-build', label: 'pre-build, just an idea' }
+] as const
+
+const BUDGET_OPTIONS = [
+	{ value: 'under-1500', label: 'under $1,500' },
+	{ value: '1500-10k', label: '$1,500–$10,000' },
+	{ value: '10k-25k', label: '$10,000–$25,000' },
+	{ value: '25k+', label: '$25,000+' },
+	{ value: 'not-sure', label: 'not sure yet' }
+] as const
+
+const AUTHORITY_OPTIONS = [
+	{ value: 'yes', label: 'yes' },
+	{ value: 'no', label: "no, i'll need to bring someone in" }
+] as const
+
+// Stage that auto-disqualifies — sixtom isn't greenfield.
+const DISQUALIFY_STAGE = 'pre-build'
+
+function lookupLabel(
+	options: ReadonlyArray<{ value: string; label: string }>,
+	value: string
+): string {
+	return options.find((o) => o.value === value)?.label ?? value
+}
+
+function composeMessage(input: {
+	built: string
+	stage: string
+	deliverable: string
+	budget: string
+	authority: string
+	companyUrl: string
+	disqualified: boolean
+}): string {
+	const lines = [
+		input.disqualified ? '[stage = pre-build — auto-disqualified]' : null,
+		`built: ${input.built}`,
+		`stage: ${lookupLabel(STAGE_OPTIONS, input.stage)}`,
+		`30-day must-be-true: ${input.deliverable}`,
+		`budget: ${lookupLabel(BUDGET_OPTIONS, input.budget)}`,
+		`authority: ${lookupLabel(AUTHORITY_OPTIONS, input.authority)}`,
+		`company: ${input.companyUrl}`
+	].filter((line): line is string => line !== null)
+	return lines.join('\n\n')
+}
+
+function buildCalComUrl(input: { name: string; email: string; notes: string }): string {
+	const url = new URL(site.bookingUrl)
+	url.searchParams.set('name', input.name)
+	url.searchParams.set('email', input.email)
+	url.searchParams.set('notes', input.notes)
+	return url.toString()
+}
+
+export const actions = {
+	default: async (event) => {
+		const declaredLength = Number(event.request.headers.get('content-length'))
+		if (!Number.isFinite(declaredLength) || declaredLength > MAX_REQUEST_BYTES) {
+			return fail(413, { status: 'error' as const, message: 'Payload too large.' })
+		}
+
+		const formData = await event.request.formData()
+		const built = String(formData.get('built') ?? '').trim()
+		const stage = String(formData.get('stage') ?? '')
+		const deliverable = String(formData.get('deliverable') ?? '').trim()
+		const budget = String(formData.get('budget') ?? '')
+		const authority = String(formData.get('authority') ?? '')
+		const companyUrl = String(formData.get('company_url') ?? '').trim()
+
+		const missing =
+			!built || !stage || !deliverable || !budget || !authority || !companyUrl
+		if (missing) {
+			return fail(400, { status: 'error' as const, message: 'Missing required fields.' })
+		}
+
+		if (!STAGE_OPTIONS.some((o) => o.value === stage)) {
+			return fail(400, { status: 'error' as const, message: 'Invalid stage.' })
+		}
+		if (!BUDGET_OPTIONS.some((o) => o.value === budget)) {
+			return fail(400, { status: 'error' as const, message: 'Invalid budget.' })
+		}
+		if (!AUTHORITY_OPTIONS.some((o) => o.value === authority)) {
+			return fail(400, { status: 'error' as const, message: 'Invalid authority.' })
+		}
+
+		const disqualified = stage === DISQUALIFY_STAGE
+		const composedMessage = composeMessage({
+			built,
+			stage,
+			deliverable,
+			budget,
+			authority,
+			companyUrl,
+			disqualified
+		})
+
+		// processSubmission validates name/email/length/header-injection, runs
+		// honeypot + rate-limit + time-trap, and sends both the notification
+		// (to Sam) and the visitor confirmation. The booking form composes the
+		// qualifying answers into `message` so it threads through unchanged.
+		formData.set('message', composedMessage)
+
+		const result = await processSubmission(formData, event)
+		if (!result.ok) {
+			return fail(result.status, { status: 'error' as const, message: result.message })
+		}
+
+		if (disqualified) {
+			return {
+				status: 'success' as const,
+				disqualified: true,
+				message:
+					"sixtom is for people who've already built something with AI and need to make it production-grade. come back when you have a working demo and a thing that's not shipping — i'll be here."
+			}
+		}
+
+		const bookingUrl = buildCalComUrl({
+			name: String(formData.get('name') ?? '').trim(),
+			email: String(formData.get('email') ?? '').trim(),
+			notes: composedMessage
+		})
+
+		return {
+			status: 'success' as const,
+			disqualified: false,
+			bookingUrl,
+			message: "qualified. here's the booking link — i've pre-filled your context for the call."
+		}
+	}
+} satisfies Actions
+
+export { STAGE_OPTIONS, BUDGET_OPTIONS, AUTHORITY_OPTIONS }

--- a/src/routes/book/+page.server.ts
+++ b/src/routes/book/+page.server.ts
@@ -2,29 +2,12 @@ import { fail } from '@sveltejs/kit'
 import { site } from '$lib/content'
 import { MAX_REQUEST_BYTES, processSubmission } from '$lib/server/contact-form'
 import type { Actions } from './$types'
-
-const STAGE_OPTIONS = [
-	{ value: 'demo-only', label: 'demo works for me only' },
-	{ value: 'few-users', label: 'a few real users on it' },
-	{ value: 'paying-breaking', label: 'paying customers but breaking' },
-	{ value: 'pre-build', label: 'pre-build, just an idea' }
-] as const
-
-const BUDGET_OPTIONS = [
-	{ value: 'under-1500', label: 'under $1,500' },
-	{ value: '1500-10k', label: '$1,500–$10,000' },
-	{ value: '10k-25k', label: '$10,000–$25,000' },
-	{ value: '25k+', label: '$25,000+' },
-	{ value: 'not-sure', label: 'not sure yet' }
-] as const
-
-const AUTHORITY_OPTIONS = [
-	{ value: 'yes', label: 'yes' },
-	{ value: 'no', label: "no, i'll need to bring someone in" }
-] as const
-
-// Stage that auto-disqualifies — sixtom isn't greenfield.
-const DISQUALIFY_STAGE = 'pre-build'
+import {
+	AUTHORITY_OPTIONS,
+	BUDGET_OPTIONS,
+	DISQUALIFY_STAGE,
+	STAGE_OPTIONS
+} from './options'
 
 function lookupLabel(
 	options: ReadonlyArray<{ value: string; label: string }>,
@@ -145,5 +128,3 @@ export const actions = {
 		}
 	}
 } satisfies Actions
-
-export { STAGE_OPTIONS, BUDGET_OPTIONS, AUTHORITY_OPTIONS }

--- a/src/routes/book/+page.svelte
+++ b/src/routes/book/+page.svelte
@@ -2,7 +2,7 @@
 	import { enhance } from '$app/forms'
 	import { site } from '$lib/content'
 	import type { ActionData } from './$types'
-	import { STAGE_OPTIONS, BUDGET_OPTIONS, AUTHORITY_OPTIONS } from './+page.server'
+	import { STAGE_OPTIONS, BUDGET_OPTIONS, AUTHORITY_OPTIONS } from './options'
 
 	let { form }: { form: ActionData } = $props()
 

--- a/src/routes/book/+page.svelte
+++ b/src/routes/book/+page.svelte
@@ -8,6 +8,7 @@
 
 	let formStartedAt = $state('')
 	let enhanced = $state('')
+	let submitting = $state(false)
 	$effect(() => {
 		formStartedAt = String(Date.now())
 		enhanced = '1'
@@ -54,6 +55,14 @@
 				<div class="border-border rounded-lg border p-8">
 					<p class="eyebrow text-sm">not a fit, yet</p>
 					<p class="text-fg mt-4 text-lg leading-relaxed">{form.message}</p>
+					<a
+						href="/book"
+						data-sveltekit-reload
+						data-umami-event="book_disqualified_restart"
+						class="text-fg-subtle hover:text-coin mt-6 inline-block text-xs tracking-widest uppercase transition-colors"
+					>
+						start over →
+					</a>
 				</div>
 			{:else}
 				<div class="border-border-strong ring-border rounded-lg border p-8 ring-1">
@@ -73,7 +82,17 @@
 				</div>
 			{/if}
 		{:else}
-			<form method="post" use:enhance class="space-y-8">
+			<form
+				method="post"
+				use:enhance={() => {
+					submitting = true
+					return async ({ update }) => {
+						await update()
+						submitting = false
+					}
+				}}
+				class="space-y-8"
+			>
 				<div>
 					<label for="name" class={labelClass}>your name</label>
 					<input
@@ -108,6 +127,7 @@
 						name="company_url"
 						type="url"
 						required
+						maxlength="500"
 						placeholder="https://"
 						autocomplete="url"
 						class="{inputClass} mt-2"
@@ -121,6 +141,7 @@
 						name="built"
 						type="text"
 						required
+						maxlength="500"
 						placeholder="live URL, repo, Loom, or screenshot link"
 						class="{inputClass} mt-2"
 					/>
@@ -145,7 +166,7 @@
 						name="deliverable"
 						required
 						rows="4"
-						maxlength="5000"
+						maxlength="4000"
 						placeholder="scale to X users, pass SOC2 review, stop the 3am pages…"
 						class="{inputClass} mt-2"
 					></textarea>
@@ -186,14 +207,17 @@
 				<button
 					type="submit"
 					data-umami-event="book_submit"
+					disabled={submitting}
 					class="btn-accent w-full px-6 py-3 text-base hover:opacity-90 disabled:opacity-60"
 				>
-					send it →
+					{submitting ? 'sending…' : 'send it →'}
 				</button>
 
-				{#if form?.status === 'error'}
-					<p class="text-error text-sm">{form.message}</p>
-				{/if}
+				<div role="alert" aria-live="polite">
+					{#if form?.status === 'error'}
+						<p class="text-error text-sm">{form.message}</p>
+					{/if}
+				</div>
 			</form>
 		{/if}
 	</div>

--- a/src/routes/book/+page.svelte
+++ b/src/routes/book/+page.svelte
@@ -1,0 +1,200 @@
+<script lang="ts">
+	import { enhance } from '$app/forms'
+	import { site } from '$lib/content'
+	import type { ActionData } from './$types'
+	import { STAGE_OPTIONS, BUDGET_OPTIONS, AUTHORITY_OPTIONS } from './+page.server'
+
+	let { form }: { form: ActionData } = $props()
+
+	let formStartedAt = $state('')
+	let enhanced = $state('')
+	$effect(() => {
+		formStartedAt = String(Date.now())
+		enhanced = '1'
+	})
+
+	const inputClass =
+		'border-border bg-surface text-fg placeholder:text-fg-subtle focus:border-accent focus:ring-accent w-full rounded-md border px-4 py-3 text-base focus:ring-2 focus:outline-none disabled:opacity-60'
+	const labelClass = 'block text-fg text-sm'
+	const hintClass = 'text-fg-subtle mt-1 text-xs'
+</script>
+
+<svelte:head>
+	<title>book — sixtom</title>
+	<meta name="robots" content="noindex, nofollow" />
+	<meta
+		name="description"
+		content="qualify for an audit or sprint with sixtom. a few questions, then the booking link."
+	/>
+	<link rel="canonical" href={`${site.siteUrl}/book`} />
+</svelte:head>
+
+<div class="bg-surface min-h-screen">
+	<div class="mx-auto w-full max-w-2xl px-6 py-20">
+		<header class="mb-12">
+			<a
+				href="/"
+				class="eyebrow text-fg-subtle hover:text-coin text-xs transition-colors"
+				data-umami-event="book_back_home"
+			>
+				← sixtom
+			</a>
+			<p class="eyebrow mt-12 text-sm">step 0 — qualify</p>
+			<h1 class="text-fg mt-2 text-4xl font-bold tracking-tight md:text-5xl">
+				let's see if we're a fit.
+			</h1>
+			<p class="text-fg-muted mt-6 text-lg leading-relaxed">
+				a few questions, takes 60 seconds. if it's a match, you get the booking link with your
+				answers pre-filled on the call form.
+			</p>
+		</header>
+
+		{#if form?.status === 'success'}
+			{#if form.disqualified}
+				<div class="border-border rounded-lg border p-8">
+					<p class="eyebrow text-sm">not a fit, yet</p>
+					<p class="text-fg mt-4 text-lg leading-relaxed">{form.message}</p>
+				</div>
+			{:else}
+				<div class="border-border-strong ring-border rounded-lg border p-8 ring-1">
+					<p class="eyebrow text-sm">qualified</p>
+					<p class="text-fg mt-4 text-lg leading-relaxed">{form.message}</p>
+					{#if form.bookingUrl}
+						<a
+							href={form.bookingUrl}
+							data-umami-event="book_qualified_booking_click"
+							rel="noopener noreferrer"
+							target="_blank"
+							class="btn-accent mt-8 inline-block px-6 py-3 text-base hover:opacity-90"
+						>
+							book the call →
+						</a>
+					{/if}
+				</div>
+			{/if}
+		{:else}
+			<form method="post" use:enhance class="space-y-8">
+				<div>
+					<label for="name" class={labelClass}>your name</label>
+					<input
+						id="name"
+						name="name"
+						type="text"
+						required
+						maxlength="120"
+						autocomplete="name"
+						class="{inputClass} mt-2"
+					/>
+				</div>
+
+				<div>
+					<label for="email" class={labelClass}>work email</label>
+					<input
+						id="email"
+						name="email"
+						type="email"
+						required
+						maxlength="254"
+						autocomplete="email"
+						class="{inputClass} mt-2"
+					/>
+					<p class={hintClass}>personal Gmail counts; just expect a slower reply.</p>
+				</div>
+
+				<div>
+					<label for="company_url" class={labelClass}>company URL</label>
+					<input
+						id="company_url"
+						name="company_url"
+						type="url"
+						required
+						placeholder="https://"
+						autocomplete="url"
+						class="{inputClass} mt-2"
+					/>
+				</div>
+
+				<div>
+					<label for="built" class={labelClass}>what have you built? drop a link</label>
+					<input
+						id="built"
+						name="built"
+						type="text"
+						required
+						placeholder="live URL, repo, Loom, or screenshot link"
+						class="{inputClass} mt-2"
+					/>
+				</div>
+
+				<div>
+					<label for="stage" class={labelClass}>where are you?</label>
+					<select id="stage" name="stage" required class="{inputClass} mt-2">
+						<option value="">—</option>
+						{#each STAGE_OPTIONS as opt (opt.value)}
+							<option value={opt.value}>{opt.label}</option>
+						{/each}
+					</select>
+				</div>
+
+				<div>
+					<label for="deliverable" class={labelClass}>
+						what has to be true in 30 days for this to be worth your money?
+					</label>
+					<textarea
+						id="deliverable"
+						name="deliverable"
+						required
+						rows="4"
+						maxlength="5000"
+						placeholder="scale to X users, pass SOC2 review, stop the 3am pages…"
+						class="{inputClass} mt-2"
+					></textarea>
+				</div>
+
+				<div>
+					<label for="budget" class={labelClass}>budget set aside for fixing this</label>
+					<select id="budget" name="budget" required class="{inputClass} mt-2">
+						<option value="">—</option>
+						{#each BUDGET_OPTIONS as opt (opt.value)}
+							<option value={opt.value}>{opt.label}</option>
+						{/each}
+					</select>
+				</div>
+
+				<div>
+					<label for="authority" class={labelClass}>are you the one who signs off?</label>
+					<select id="authority" name="authority" required class="{inputClass} mt-2">
+						<option value="">—</option>
+						{#each AUTHORITY_OPTIONS as opt (opt.value)}
+							<option value={opt.value}>{opt.label}</option>
+						{/each}
+					</select>
+				</div>
+
+				<input type="hidden" name="message" value="" />
+				<input type="hidden" name="formStartedAt" bind:value={formStartedAt} />
+				<input type="hidden" name="enhanced" bind:value={enhanced} />
+				<input
+					type="text"
+					name="company"
+					tabindex="-1"
+					autocomplete="off"
+					aria-hidden="true"
+					class="absolute top-auto left-[-9999px] h-px w-px overflow-hidden"
+				/>
+
+				<button
+					type="submit"
+					data-umami-event="book_submit"
+					class="btn-accent w-full px-6 py-3 text-base hover:opacity-90 disabled:opacity-60"
+				>
+					send it →
+				</button>
+
+				{#if form?.status === 'error'}
+					<p class="text-error text-sm">{form.message}</p>
+				{/if}
+			</form>
+		{/if}
+	</div>
+</div>

--- a/src/routes/book/options.ts
+++ b/src/routes/book/options.ts
@@ -1,0 +1,22 @@
+export const STAGE_OPTIONS = [
+	{ value: 'demo-only', label: 'demo works for me only' },
+	{ value: 'few-users', label: 'a few real users on it' },
+	{ value: 'paying-breaking', label: 'paying customers but breaking' },
+	{ value: 'pre-build', label: 'pre-build, just an idea' }
+] as const
+
+export const BUDGET_OPTIONS = [
+	{ value: 'under-1500', label: 'under $1,500' },
+	{ value: '1500-10k', label: '$1,500–$10,000' },
+	{ value: '10k-25k', label: '$10,000–$25,000' },
+	{ value: '25k+', label: '$25,000+' },
+	{ value: 'not-sure', label: 'not sure yet' }
+] as const
+
+export const AUTHORITY_OPTIONS = [
+	{ value: 'yes', label: 'yes' },
+	{ value: 'no', label: "no, i'll need to bring someone in" }
+] as const
+
+// Stage that auto-disqualifies — sixtom isn't greenfield.
+export const DISQUALIFY_STAGE = 'pre-build'


### PR DESCRIPTION
Adds the qualification step Steve called out — both audit and sprint CTAs now route to /book, which collects 6 BANTS qualifying answers (built, stage, 30-day deliverable, budget, authority, contact). Pre-build stage auto-disqualifies; everything else reveals a Cal.com link with prefilled context.

🤖 Generated with [Claude Code](https://claude.com/claude-code)