### PR TITLE
sixtom v1.50 — re-anchor copy for non-engineer operator ICP

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -10,7 +10,7 @@
 		<title>sixtom — async sprints with Sam D'Angelo</title>
 		<meta
 			name="description"
-			content="AI ships demos. i ship solutions. two-week sprints from working prototype to live in production. 1 client a month."
+			content="AI ships demos. i ship solutions. two-week sprints from working prototype to live and stable. 1 client a month."
 		/>
 		<link rel="canonical" href="https://sixtom.com/" />
 
@@ -38,7 +38,7 @@
 		<meta property="og:title" content="sixtom — async sprints with Sam D'Angelo" />
 		<meta
 			property="og:description"
-			content="AI ships demos. i ship solutions. two-week sprints, fixed price, live in production day 10."
+			content="AI ships demos. i ship solutions. two-week sprints, fixed price, live and stable in 10 days."
 		/>
 		<meta property="og:type" content="website" />
 		<meta property="og:url" content="https://sixtom.com/" />
@@ -51,7 +51,7 @@
 		<meta name="twitter:title" content="sixtom — async sprints with Sam D'Angelo" />
 		<meta
 			name="twitter:description"
-			content="AI ships demos. i ship solutions. two-week sprints, fixed price, live in production day 10."
+			content="AI ships demos. i ship solutions. two-week sprints, fixed price, live and stable in 10 days."
 		/>
 		<meta name="twitter:image" content="https://sixtom.com/og.png" />
 

--- a/src/lib/components/VibeTaxCalculator.svelte
+++ b/src/lib/components/VibeTaxCalculator.svelte
@@ -78,7 +78,7 @@
 
 			<div>
 				<label for="vt-hours" class={labelClass}>
-					hours/week firefighting instead of shipping
+					hours/week firefighting instead of building new things
 				</label>
 				<input
 					id="vt-hours"
@@ -97,7 +97,7 @@
 			</div>
 
 			<div>
-				<label for="vt-cost" class={labelClass}>your hourly cost (or fully-loaded eng rate)</label>
+				<label for="vt-cost" class={labelClass}>your hourly rate (yours, or your team's)</label>
 				<input
 					id="vt-cost"
 					type="number"
@@ -124,11 +124,11 @@
 				</li>
 				<li>
 					<span class="text-fg font-semibold tabular-nums">{slowdown}×</span>
-					slowdown vs a production codebase
+					slower than it should be
 				</li>
 				<li>
 					<span class="text-fg font-semibold tabular-nums">{weeksUntilBlocked}</span>
-					weeks until your current stack blocks the goal
+					weeks until you'd have to start over
 				</li>
 			</ul>
 

--- a/src/lib/components/umami-events.test.ts
+++ b/src/lib/components/umami-events.test.ts
@@ -21,6 +21,7 @@ const CLIENT_EVENTS: readonly ClientEvent[] = [
 	{ event: 'cta_hero_garden', dir: 'component', path: 'Hero.svelte' },
 	{ event: 'cta_tax_calc', dir: 'route', path: '+page.svelte' },
 	{ event: 'cta_case_study', dir: 'route', path: '+page.svelte' },
+	{ event: 'cta_garden_link_why', dir: 'route', path: '+page.svelte' },
 	{ event: 'cta_final_book', dir: 'route', path: '+page.svelte' },
 	{ event: 'cta_notify_submit', dir: 'route', path: 'notify/+page.svelte' },
 	{ event: 'cta_calc_book', dir: 'component', path: 'VibeTaxCalculator.svelte' }

--- a/src/lib/content/site.ts
+++ b/src/lib/content/site.ts
@@ -13,7 +13,7 @@ export const site: Site = {
 	hero: {
 		h1: 'AI ships demos. i ship solutions.',
 		subhead:
-			"you shipped the demo. now you need it to scale, secure, survive real traffic — without you up at 2am. two weeks of reviewed builds, fixed price, live in production day 10.",
+			"you built it with AI. it works for you. now it has to work for your customers — every busy day, every security review, every weekend without you. two weeks. fixed price. live and stable in 10 days.",
 		ctaPrimary: 'book the working session',
 		ctaSecondary: 'notify me'
 	},
@@ -30,7 +30,7 @@ export const site: Site = {
 		priceUSD: 1500,
 		cadence: 'turnaround within a week.',
 		promise:
-			"send me your repo and the thing you've been stuck on. within a week i send back a 1-pager and a 15-min Loom — your X, my solve, what it's costing you to leave it as-is. credited toward a sprint if you book within 30 days."
+			"send me what you've built — link, login, however it's set up. within a week, i send back a written breakdown and a short video walkthrough: what's blocking you, what i'd do about it, what it's costing you to leave it as-is. credited toward the sprint if you book one within 30 days."
 	},
 	sprint: {
 		name: 'sprint',
@@ -41,7 +41,7 @@ export const site: Site = {
 		cadence: '1 client a month, by appointment.',
 		paymentPlan: '4 weekly payments of $2,500',
 		promise:
-			"the thing works in dev. you're scared to put real traffic on it. two weeks of reviewed builds — fixed scope, daily drops, live in production day 10. agents type; i review, judge, defend the architecture. shipped, not vibed."
+			"it works for you. you're not ready for real customers yet. two weeks. fixed scope agreed up front. you see progress every day. live and stable in 10 days. every change reviewed before it goes live. you own everything."
 	},
 	process: [
 		{

--- a/src/lib/content/site.ts
+++ b/src/lib/content/site.ts
@@ -28,9 +28,7 @@ export const site: Site = {
 		name: 'audit',
 		longName: 'the audit',
 		priceUSD: 1500,
-		cadence: 'turnaround within a week.',
-		promise:
-			"send me what you've built — link, login, however it's set up. within a week, i send back a written breakdown and a short video walkthrough: what's blocking you, what i'd do about it, what it's costing you to leave it as-is. credited toward the sprint if you book one within 30 days."
+		cadence: 'turnaround within a week.'
 	},
 	sprint: {
 		name: 'sprint',
@@ -39,9 +37,7 @@ export const site: Site = {
 		introPriceUSD: 7500,
 		introNote: 'first 3 clients',
 		cadence: '1 client a month, by appointment.',
-		paymentPlan: '4 weekly payments of $2,500',
-		promise:
-			"it works for you. you're not ready for real customers yet. two weeks. fixed scope agreed up front. you see progress every day. live and stable in 10 days. every change reviewed before it goes live. you own everything."
+		paymentPlan: '4 weekly payments of $2,500'
 	},
 	process: [
 		{

--- a/src/lib/content/types.ts
+++ b/src/lib/content/types.ts
@@ -18,7 +18,6 @@ export interface Offer {
 	longName: string
 	priceUSD: number
 	cadence: string
-	promise: string
 	introPriceUSD?: number
 	introNote?: string
 	paymentPlan?: string

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -13,10 +13,10 @@
 		<h2
 			class="text-fg mt-4 text-3xl leading-tight font-semibold tracking-tight md:text-5xl lg:text-6xl"
 		>
-			you already built it. it works in dev.
+			you already built it. it works when you use it.
 		</h2>
 		<p class="text-fg-muted mt-8 max-w-2xl text-lg leading-relaxed md:text-xl">
-			real users are going to break it. you know it. that's why you're here.
+			real customers are about to break it — or already are. you know it. that's why you're here.
 		</p>
 	</div>
 </section>
@@ -28,13 +28,13 @@
 		<h2
 			class="text-fg mt-4 text-3xl leading-tight font-semibold tracking-tight md:text-5xl lg:text-6xl"
 		>
-			safety. security. scalability. peace of mind.
+			uptime. security. scale. peace of mind.
 		</h2>
 		<ul class="text-fg-muted mt-10 space-y-4 text-lg leading-relaxed md:text-xl">
-			<li>— the 2am bug you can't reproduce.</li>
-			<li>— the SOC2 or SSO review you can't pass yet.</li>
-			<li>— traffic that breaks what worked yesterday.</li>
-			<li>— code you can't defend in a review.</li>
+			<li>— your biggest customer is asking about uptime you can't promise.</li>
+			<li>— a sale is stuck waiting on a security review you don't pass yet.</li>
+			<li>— you're afraid to launch new features because something always breaks.</li>
+			<li>— investors are asking how this scales and the answer is "we'll figure it out."</li>
 		</ul>
 	</div>
 </section>
@@ -46,11 +46,11 @@
 		<p
 			class="text-fg mt-4 text-3xl leading-tight font-semibold tracking-tight italic md:text-5xl lg:text-6xl"
 		>
-			every week you wait, the codebase grows past the wall.
+			every week you wait, it gets harder for anyone to touch — including the AI you built it with.
 		</p>
 		<p class="text-fg-muted mt-8 max-w-2xl text-lg leading-relaxed md:text-xl">
-			firefighting hours × your hourly rate × the slowdown multiplier. the number is usually six
-			figures a year, and it's quietly compounding.
+			your time fighting fires, times what your time is worth, times how much slower it gets every
+			month. usually six figures a year, compounding quietly.
 			<a
 				href="/tax"
 				data-umami-event="cta_tax_calc"
@@ -69,11 +69,12 @@
 		<h2
 			class="text-fg mt-4 text-3xl leading-tight font-semibold tracking-tight md:text-5xl lg:text-6xl"
 		>
-			a 2-week sprint. live in production day 10.
+			a 2-week sprint. live and stable in 10 days.
 		</h2>
 		<p class="text-fg-muted mt-8 text-lg leading-relaxed md:text-xl">
-			fixed scope agreed up front. daily drops. i sit alongside your existing workstream —
-			ride-along — scope what needs to ship, then ship it. you own the code.
+			fixed scope agreed up front — no surprises, no creep. you see progress every day. i sit
+			alongside whatever you've already built (yours, your contractor's, doesn't matter) and fix
+			what's blocking you. every change is reviewed before it goes live. you own everything.
 			<span class="text-fg font-semibold">${site.sprint.priceUSD.toLocaleString()} flat</span>
 			(or {site.sprint.paymentPlan}). 1 client a month, by appointment.
 		</p>
@@ -87,17 +88,29 @@
 		<p
 			class="text-fg mt-4 text-3xl leading-tight font-semibold tracking-tight md:text-5xl lg:text-6xl"
 		>
-			i ran this on my own site first.
+			i ship for a brand you know by day.
 		</p>
 		<p class="text-fg-muted mt-8 max-w-2xl text-lg leading-relaxed md:text-xl">
-			30,000 lines of React, ported to SvelteKit under tight review in ~5–6 hours of active build.
-			40% less code, every lighthouse score up.
+			lead engineer at Made In Cookware — multi-million visitors a month. i rebuilt my own creative
+			work on the same methods: 5 hours of actual build time, 40% smaller, every measurable score
+			went up.
+		</p>
+		<p class="mt-6 flex flex-wrap gap-6 text-sm">
+			<a
+				href={site.gardenUrl}
+				target="_blank"
+				rel="noopener noreferrer"
+				data-umami-event="cta_garden_link_why"
+				class="text-fg hover:text-coin underline underline-offset-4 transition-colors"
+			>
+				see the work →
+			</a>
 			<a
 				href="/log/garden-party"
 				data-umami-event="cta_case_study"
-				class="text-fg hover:text-coin underline underline-offset-4 transition-colors"
+				class="text-fg-muted hover:text-coin underline underline-offset-4 transition-colors"
 			>
-				the case study →
+				the writeup →
 			</a>
 		</p>
 		<blockquote
@@ -122,8 +135,9 @@
 				let's see if a sprint fits.
 			</h2>
 			<p class="text-fg-muted mt-8 text-lg leading-relaxed md:text-xl">
-				${site.audit.priceUSD.toLocaleString()} working session. you send your repo, i send back a
-				1-pager and a 15-min Loom — your X, my solve, what it's costing you to leave it as-is.
+				${site.audit.priceUSD.toLocaleString()} to look at what you've got. send me the link or
+				access, however your build is set up. within a week you get a written breakdown and a
+				short video walkthrough — what's broken, what i'd fix, what it's costing you to leave it.
 				credited toward the sprint if you book one within 30 days.
 			</p>
 			<a


### PR DESCRIPTION
Strips engineer jargon throughout. Reframes pain in operator dialect. Surfaces threesam.com 'see the work' link bigger. Hero h1 unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)