### PR TITLE
v1.58: multi-step book form + SIX|TO|M footer wordmark

### DIFF
--- a/src/lib/components/Hero.svelte
+++ b/src/lib/components/Hero.svelte
@@ -1,22 +1,17 @@
 <script lang="ts">
 	import { site } from '$lib/content'
-
-	// Split the h1 epigram so each sentence renders on its own line at every
-	// viewport — no awkward mid-sentence wraps. Source still lives in site.ts.
-	const heroLines = site.hero.h1
-		.split(/\.\s+/)
-		.map((line, i, arr) => (i < arr.length - 1 ? `${line}.` : line))
 </script>
 
 <section class="snap-section bg-surface">
 	<div class="mx-auto w-full max-w-4xl px-6">
 		<p class="eyebrow text-sm">sixtom</p>
 		<h1
-			class="text-fg border-border mt-6 border-b pb-8 text-5xl leading-[1.02] font-bold tracking-tight md:text-7xl lg:text-8xl"
+			class="text-fg mt-6 text-5xl leading-[1.02] font-bold tracking-tight md:text-7xl lg:text-8xl"
 		>
-			{#each heroLines as line, i (i)}
-				<span class="block">{line}</span>
-			{/each}
+			<span class="block">AI ships demos.</span>
+			<span class="block">
+				i ship <span class="border-accent border-b-4 pb-1 md:border-b-[6px]">solutions</span>.
+			</span>
 		</h1>
 		<p class="text-fg-muted mt-8 max-w-2xl text-base leading-relaxed md:text-xl">
 			{site.hero.subhead}

--- a/src/lib/components/Hero.svelte
+++ b/src/lib/components/Hero.svelte
@@ -9,7 +9,7 @@
 			class="text-fg mt-6 text-5xl leading-[1.02] font-bold tracking-tight md:text-7xl lg:text-8xl"
 		>
 			<span class="block">it works for you.</span>
-			<span class="block">it breaks for everyone else.</span>
+			<span class="block">it dies in production.</span>
 		</h1>
 		<p class="text-fg-muted mt-8 max-w-2xl text-base leading-relaxed md:text-xl">
 			the demo was the easy part. i ship <span class="text-fg">solutions</span>.

--- a/src/lib/components/Hero.svelte
+++ b/src/lib/components/Hero.svelte
@@ -12,7 +12,7 @@
 			<span class="block">it breaks for everyone else.</span>
 		</h1>
 		<p class="text-fg-muted mt-8 max-w-2xl text-base leading-relaxed md:text-xl">
-			AI ships demos. i ship <span class="text-fg">solutions</span>.
+			the demo was the easy part. i ship <span class="text-fg">solutions</span>.
 		</p>
 		<div class="mt-12">
 			<a

--- a/src/lib/components/Hero.svelte
+++ b/src/lib/components/Hero.svelte
@@ -8,13 +8,11 @@
 		<h1
 			class="text-fg mt-6 text-5xl leading-[1.02] font-bold tracking-tight md:text-7xl lg:text-8xl"
 		>
-			<span class="block">AI ships demos.</span>
-			<span class="block">
-				i ship <span class="border-accent border-b-4 pb-1 md:border-b-[6px]">solutions</span>.
-			</span>
+			<span class="block">it works for you.</span>
+			<span class="block">it breaks for everyone else.</span>
 		</h1>
 		<p class="text-fg-muted mt-8 max-w-2xl text-base leading-relaxed md:text-xl">
-			{site.hero.subhead}
+			AI ships demos. i ship <span class="text-fg">solutions</span>.
 		</p>
 		<div class="mt-12">
 			<a

--- a/src/lib/components/SiteFooter.svelte
+++ b/src/lib/components/SiteFooter.svelte
@@ -3,25 +3,35 @@
 	const year = new Date().getFullYear()
 </script>
 
-<footer class="border-border bg-surface text-fg-subtle w-full border-t px-6 py-4 text-xs">
+<footer class="border-border bg-surface w-full border-t px-6 py-8">
 	<div
-		class="mx-auto flex w-full max-w-2xl flex-col items-center justify-between gap-2 sm:flex-row"
+		class="mx-auto flex w-full max-w-3xl flex-col items-center gap-6 sm:flex-row sm:items-center sm:justify-between sm:gap-4"
 	>
-		<div class="flex items-center gap-4">
-			<span>© {year} sixtom</span>
+		<a
+			href="/"
+			aria-label="sixtom home"
+			data-umami-event="footer_home"
+			class="text-fg inline-flex items-center text-2xl leading-none font-bold tracking-tight uppercase"
+		>
+			<span>six</span><span class="bg-fg text-surface mx-2 px-2 py-1">to</span><span>m</span>
+		</a>
+		<div
+			class="text-fg-subtle flex flex-wrap items-center justify-center gap-x-5 gap-y-2 text-xs"
+		>
+			<span>© {year}</span>
 			<a href="/log" class="hover:text-fg transition-colors">log</a>
 			<a href="/notify" class="hover:text-fg transition-colors">notify</a>
 			<a href="/privacy" class="hover:text-fg transition-colors">privacy</a>
 			<a href="/terms" class="hover:text-fg transition-colors">terms</a>
+			<a
+				href={site.gardenUrl}
+				target="_blank"
+				rel="noopener noreferrer"
+				data-umami-event="cta_garden_link"
+				class="hover:text-coin transition-colors"
+			>
+				threesam.com →
+			</a>
 		</div>
-		<a
-			href={site.gardenUrl}
-			target="_blank"
-			rel="noopener noreferrer"
-			data-umami-event="cta_garden_link"
-			class="hover:text-coin transition-colors"
-		>
-			threesam.com →
-		</a>
 	</div>
 </footer>

--- a/src/lib/components/SiteFooter.svelte
+++ b/src/lib/components/SiteFooter.svelte
@@ -13,7 +13,7 @@
 			data-umami-event="footer_home"
 			class="text-fg inline-flex items-center text-2xl leading-none font-bold tracking-tight uppercase"
 		>
-			<span class="pr-1">six</span><span class="bg-fg text-surface px-1 py-1">to</span><span class="pl-1">m</span>
+			<span class="pr-1">six</span><span class="bg-fg text-surface p-1">to</span><span class="pl-1">m</span>
 		</a>
 		<div
 			class="text-fg-subtle flex flex-wrap items-center justify-center gap-x-5 gap-y-2 text-xs"

--- a/src/lib/components/SiteFooter.svelte
+++ b/src/lib/components/SiteFooter.svelte
@@ -5,7 +5,7 @@
 
 <footer class="border-border bg-surface w-full border-t px-6 py-8">
 	<div
-		class="mx-auto flex w-full max-w-3xl flex-col items-center gap-6 sm:flex-row sm:items-center sm:justify-between sm:gap-4"
+		class="mx-auto flex w-full max-w-3xl flex-col items-center gap-6 sm:flex-row sm:justify-between sm:gap-4"
 	>
 		<a
 			href="/"

--- a/src/lib/components/SiteFooter.svelte
+++ b/src/lib/components/SiteFooter.svelte
@@ -13,7 +13,7 @@
 			data-umami-event="footer_home"
 			class="text-fg inline-flex items-center text-2xl leading-none font-bold tracking-tight uppercase"
 		>
-			<span>six</span><span class="bg-fg text-surface mx-2 px-2 py-1">to</span><span>m</span>
+			<span class="pr-1">six</span><span class="bg-fg text-surface px-1 py-1">to</span><span class="pl-1">m</span>
 		</a>
 		<div
 			class="text-fg-subtle flex flex-wrap items-center justify-center gap-x-5 gap-y-2 text-xs"

--- a/src/lib/content/site.ts
+++ b/src/lib/content/site.ts
@@ -11,10 +11,9 @@ export const site: Site = {
 	thesisBody:
 		"AI gets you to a demo because the model can hold the whole thing in its head. once the codebase outgrows that window, the AI starts making it worse instead of better. that's the wall every vibe-coded project hits. it's also the thing i fix.",
 	hero: {
-		h1: 'AI ships demos. i ship solutions.',
-		subhead:
-			"you built it with AI. it works for you. now it has to work for everyone else.",
-		ctaPrimary: 'book the working session',
+		h1: 'it works for you. it breaks for everyone else.',
+		subhead: 'AI ships demos. i ship solutions.',
+		ctaPrimary: 'solve for X',
 		ctaSecondary: 'notify me'
 	},
 	operator: {

--- a/src/lib/content/site.ts
+++ b/src/lib/content/site.ts
@@ -11,7 +11,7 @@ export const site: Site = {
 	thesisBody:
 		"AI gets you to a demo because the model can hold the whole thing in its head. once the codebase outgrows that window, the AI starts making it worse instead of better. that's the wall every vibe-coded project hits. it's also the thing i fix.",
 	hero: {
-		h1: 'it works for you. it breaks for everyone else.',
+		h1: 'it works for you. it dies in production.',
 		subhead: 'the demo was the easy part. i ship solutions.',
 		ctaPrimary: 'solve for X',
 		ctaSecondary: 'notify me'

--- a/src/lib/content/site.ts
+++ b/src/lib/content/site.ts
@@ -12,8 +12,7 @@ export const site: Site = {
 		"AI gets you to a demo because the model can hold the whole thing in its head. once the codebase outgrows that window, the AI starts making it worse instead of better. that's the wall every vibe-coded project hits. it's also the thing i fix.",
 	hero: {
 		subhead: 'the demo was the easy part. i ship solutions.',
-		ctaPrimary: 'solve for X',
-		ctaSecondary: 'notify me'
+		ctaPrimary: 'solve for X'
 	},
 	operator: {
 		name: "Sam D'Angelo",

--- a/src/lib/content/site.ts
+++ b/src/lib/content/site.ts
@@ -12,7 +12,7 @@ export const site: Site = {
 		"AI gets you to a demo because the model can hold the whole thing in its head. once the codebase outgrows that window, the AI starts making it worse instead of better. that's the wall every vibe-coded project hits. it's also the thing i fix.",
 	hero: {
 		h1: 'it works for you. it breaks for everyone else.',
-		subhead: 'AI ships demos. i ship solutions.',
+		subhead: 'the demo was the easy part. i ship solutions.',
 		ctaPrimary: 'solve for X',
 		ctaSecondary: 'notify me'
 	},

--- a/src/lib/content/site.ts
+++ b/src/lib/content/site.ts
@@ -11,7 +11,6 @@ export const site: Site = {
 	thesisBody:
 		"AI gets you to a demo because the model can hold the whole thing in its head. once the codebase outgrows that window, the AI starts making it worse instead of better. that's the wall every vibe-coded project hits. it's also the thing i fix.",
 	hero: {
-		h1: 'it works for you. it dies in production.',
 		subhead: 'the demo was the easy part. i ship solutions.',
 		ctaPrimary: 'solve for X',
 		ctaSecondary: 'notify me'

--- a/src/lib/content/types.ts
+++ b/src/lib/content/types.ts
@@ -46,7 +46,6 @@ export interface Site {
 	thesis: string
 	thesisBody: string
 	hero: {
-		h1: string
 		subhead: string
 		ctaPrimary: string
 		ctaSecondary: string

--- a/src/lib/content/types.ts
+++ b/src/lib/content/types.ts
@@ -48,7 +48,6 @@ export interface Site {
 	hero: {
 		subhead: string
 		ctaPrimary: string
-		ctaSecondary: string
 	}
 	operator: Operator
 	audit: Offer

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -55,10 +55,12 @@
 		</p>
 		<p class="text-fg-muted mt-6 text-base leading-relaxed md:text-lg">
 			typical case: 1/mo × $50k × 12 = ~$600k/yr. plus the weekends. plus the sleep.
+		</p>
+		<p class="mt-6">
 			<a
 				href="/tax"
 				data-umami-event="cta_tax_calc"
-				class="text-fg hover:text-coin underline underline-offset-4 transition-colors"
+				class="text-fg hover:text-coin text-base underline underline-offset-4 transition-colors md:text-lg"
 			>
 				run yours →
 			</a>
@@ -69,14 +71,11 @@
 <!-- how this works -->
 <section id="offers" class="snap-section bg-surface">
 	<div class="mx-auto w-full max-w-3xl px-6">
-		<h2 class={h2Class}>how does this work?</h2>
-		<p class="text-fg mt-8 text-3xl font-bold tracking-tight md:text-5xl">2 weeks.</p>
-		<div class="text-fg-muted mt-8 space-y-2 text-base leading-relaxed md:text-lg">
-			<p>scope drawn day one.</p>
-			<p>drops daily.</p>
-			<p>live day ten.</p>
-			<p>nothing ships unreviewed.</p>
-			<p>you own everything.</p>
+		<h2 class={h2Class}>only two weeks?</h2>
+		<div class="text-fg-muted mt-10 space-y-2 text-base leading-relaxed md:text-lg">
+			<p>daily progress.</p>
+			<p>the answer when they ask.</p>
+			<p>your weekends back.</p>
 		</div>
 		<p class="text-fg-subtle mt-8 text-sm md:text-base">
 			${site.sprint.priceUSD.toLocaleString()} flat. or {site.sprint.paymentPlan}. 1 client a

--- a/src/routes/book/+page.server.ts
+++ b/src/routes/book/+page.server.ts
@@ -2,12 +2,7 @@ import { fail } from '@sveltejs/kit'
 import { site } from '$lib/content'
 import { MAX_REQUEST_BYTES, processSubmission } from '$lib/server/contact-form'
 import type { Actions } from './$types'
-import {
-	AUTHORITY_OPTIONS,
-	BUDGET_OPTIONS,
-	DISQUALIFY_STAGE,
-	STAGE_OPTIONS
-} from './options'
+import { BUDGET_OPTIONS, DISQUALIFY_STAGE, STAGE_OPTIONS } from './options'
 
 function lookupLabel(
 	options: ReadonlyArray<{ value: string; label: string }>,
@@ -21,7 +16,6 @@ function composeMessage(input: {
 	stage: string
 	deliverable: string
 	budget: string
-	authority: string
 	companyUrl: string
 	disqualified: boolean
 }): string {
@@ -31,7 +25,6 @@ function composeMessage(input: {
 		`stage: ${lookupLabel(STAGE_OPTIONS, input.stage)}`,
 		`30-day must-be-true: ${input.deliverable}`,
 		`budget: ${lookupLabel(BUDGET_OPTIONS, input.budget)}`,
-		`authority: ${lookupLabel(AUTHORITY_OPTIONS, input.authority)}`,
 		`company: ${input.companyUrl}`
 	].filter((line): line is string => line !== null)
 	return lines.join('\n\n')
@@ -71,11 +64,9 @@ export const actions = {
 		const stage = String(formData.get('stage') ?? '')
 		const deliverable = normalizeNewlines(String(formData.get('deliverable') ?? '')).slice(0, 4000)
 		const budget = String(formData.get('budget') ?? '')
-		const authority = String(formData.get('authority') ?? '')
 		const companyUrl = stripNewlines(String(formData.get('company_url') ?? '')).slice(0, 500)
 
-		const missing =
-			!built || !stage || !deliverable || !budget || !authority || !companyUrl
+		const missing = !built || !stage || !deliverable || !budget || !companyUrl
 		if (missing) {
 			return fail(400, { status: 'error' as const, message: 'Missing required fields.' })
 		}
@@ -86,9 +77,6 @@ export const actions = {
 		if (!BUDGET_OPTIONS.some((o) => o.value === budget)) {
 			return fail(400, { status: 'error' as const, message: 'Invalid budget.' })
 		}
-		if (!AUTHORITY_OPTIONS.some((o) => o.value === authority)) {
-			return fail(400, { status: 'error' as const, message: 'Invalid authority.' })
-		}
 
 		const disqualified = stage === DISQUALIFY_STAGE
 		const composedMessage = composeMessage({
@@ -96,7 +84,6 @@ export const actions = {
 			stage,
 			deliverable,
 			budget,
-			authority,
 			companyUrl,
 			disqualified
 		})

--- a/src/routes/book/+page.svelte
+++ b/src/routes/book/+page.svelte
@@ -2,9 +2,20 @@
 	import { enhance } from '$app/forms'
 	import { site } from '$lib/content'
 	import type { ActionData } from './$types'
-	import { STAGE_OPTIONS, BUDGET_OPTIONS, AUTHORITY_OPTIONS } from './options'
+	import { STAGE_OPTIONS, BUDGET_OPTIONS } from './options'
 
 	let { form }: { form: ActionData } = $props()
+
+	const TOTAL_STEPS = 3
+	let step = $state(1)
+
+	let stage = $state('')
+	let built = $state('')
+	let deliverable = $state('')
+	let budget = $state('')
+	let name = $state('')
+	let email = $state('')
+	let companyUrl = $state('')
 
 	let formStartedAt = $state('')
 	let enhanced = $state('')
@@ -14,10 +25,29 @@
 		enhanced = '1'
 	})
 
+	const isPreBuild = $derived(stage === 'pre-build')
+
+	function canAdvance(): boolean {
+		if (step === 1) return stage !== '' && !isPreBuild
+		if (step === 2) return built.trim() !== '' && deliverable.trim() !== '' && budget !== ''
+		return true
+	}
+
+	function next() {
+		if (!canAdvance()) return
+		step += 1
+	}
+
+	function back() {
+		if (step > 1) step -= 1
+	}
+
 	const inputClass =
 		'border-border bg-surface text-fg placeholder:text-fg-subtle focus:border-accent focus:ring-accent w-full rounded-md border px-4 py-3 text-base focus:ring-2 focus:outline-none disabled:opacity-60'
 	const labelClass = 'block text-fg text-sm'
 	const hintClass = 'text-fg-subtle mt-1 text-xs'
+	const stepEyebrowClass = 'eyebrow text-fg-subtle text-xs'
+	const stepHeadClass = 'text-fg mt-2 text-2xl font-semibold tracking-tight md:text-3xl'
 </script>
 
 <svelte:head>
@@ -25,13 +55,13 @@
 	<meta name="robots" content="noindex, nofollow" />
 	<meta
 		name="description"
-		content="qualify for an audit or sprint with sixtom. a few questions, then the booking link."
+		content="qualify for an audit or sprint with sixtom. 3 quick steps, then the booking link."
 	/>
 	<link rel="canonical" href={`${site.siteUrl}/book`} />
 </svelte:head>
 
 <div class="bg-surface min-h-screen">
-	<div class="mx-auto w-full max-w-2xl px-6 py-20">
+	<div class="mx-auto w-full max-w-xl px-6 py-20">
 		<header class="mb-12">
 			<a
 				href="/"
@@ -40,20 +70,18 @@
 			>
 				← sixtom
 			</a>
-			<p class="eyebrow mt-12 text-sm">step 0 — qualify</p>
-			<h1 class="text-fg mt-2 text-4xl font-bold tracking-tight md:text-5xl">
+			<h1 class="text-fg mt-12 text-4xl font-bold tracking-tight md:text-5xl">
 				let's see if we're a fit.
 			</h1>
-			<p class="text-fg-muted mt-6 text-lg leading-relaxed">
-				a few questions, takes 60 seconds. if it's a match, you get the booking link with your
-				answers pre-filled on the call form.
+			<p class="text-fg-muted mt-6 text-base leading-relaxed">
+				3 quick steps. ~60 seconds. you'll get the booking link with your context pre-filled.
 			</p>
 		</header>
 
 		{#if form?.status === 'success'}
 			{#if form.disqualified}
 				<div class="border-border rounded-lg border p-8">
-					<p class="eyebrow text-sm">not a fit, yet</p>
+					<p class="eyebrow text-sm">not yet</p>
 					<p class="text-fg mt-4 text-lg leading-relaxed">{form.message}</p>
 					<div class="mt-6 flex flex-col gap-3 sm:flex-row sm:gap-6">
 						<a
@@ -90,6 +118,32 @@
 					{/if}
 				</div>
 			{/if}
+		{:else if step === 1 && isPreBuild}
+			<!-- Pre-build disqualify is purely client-side: no email captured, no server hit. -->
+			<div class="border-border rounded-lg border p-8">
+				<p class="eyebrow text-sm">not yet</p>
+				<p class="text-fg mt-4 text-lg leading-relaxed">
+					sixtom is for things you've already built. come back when you have a working demo — i'll
+					be here.
+				</p>
+				<div class="mt-6 flex flex-col gap-3 sm:flex-row sm:gap-6">
+					<a
+						href="/notify"
+						data-umami-event="book_pre_build_notify"
+						class="text-fg-subtle hover:text-coin text-xs tracking-widest uppercase transition-colors"
+					>
+						get notified when ready →
+					</a>
+					<button
+						type="button"
+						onclick={() => (stage = '')}
+						data-umami-event="book_pre_build_restart"
+						class="text-fg-subtle hover:text-coin text-left text-xs tracking-widest uppercase transition-colors"
+					>
+						i picked the wrong one →
+					</button>
+				</div>
+			</div>
 		{:else}
 			<form
 				method="post"
@@ -100,105 +154,132 @@
 						submitting = false
 					}
 				}}
-				class="space-y-8"
 			>
-				<div>
-					<label for="name" class={labelClass}>your name</label>
-					<input
-						id="name"
-						name="name"
-						type="text"
-						required
-						maxlength="120"
-						autocomplete="name"
-						class="{inputClass} mt-2"
-					/>
-				</div>
-
-				<div>
-					<label for="email" class={labelClass}>work email</label>
-					<input
-						id="email"
-						name="email"
-						type="email"
-						required
-						maxlength="254"
-						autocomplete="email"
-						class="{inputClass} mt-2"
-					/>
-					<p class={hintClass}>personal Gmail counts; just expect a slower reply.</p>
-				</div>
-
-				<div>
-					<label for="company_url" class={labelClass}>company URL</label>
-					<input
-						id="company_url"
-						name="company_url"
-						type="url"
-						required
-						maxlength="500"
-						placeholder="https://"
-						autocomplete="url"
-						class="{inputClass} mt-2"
-					/>
-				</div>
-
-				<div>
-					<label for="built" class={labelClass}>what have you built? drop a link</label>
-					<input
-						id="built"
-						name="built"
-						type="text"
-						required
-						maxlength="500"
-						placeholder="live URL, repo, Loom, or screenshot link"
-						class="{inputClass} mt-2"
-					/>
-				</div>
-
-				<div>
-					<label for="stage" class={labelClass}>where are you?</label>
-					<select id="stage" name="stage" required class="{inputClass} mt-2">
-						<option value="">—</option>
+				<div class:hidden={step !== 1}>
+					<p class={stepEyebrowClass}>step 1 of {TOTAL_STEPS} — fit</p>
+					<h2 class={stepHeadClass}>where are you with this thing?</h2>
+					<fieldset class="mt-8 space-y-3">
+						<legend class="sr-only">stage</legend>
 						{#each STAGE_OPTIONS as opt (opt.value)}
-							<option value={opt.value}>{opt.label}</option>
+							<label
+								class="border-border bg-surface hover:border-fg-subtle flex cursor-pointer items-center gap-3 rounded-md border p-4 transition-colors {stage ===
+								opt.value
+									? 'border-accent ring-accent ring-1'
+									: ''}"
+							>
+								<input
+									type="radio"
+									name="stage"
+									value={opt.value}
+									bind:group={stage}
+									required
+									class="accent-accent"
+								/>
+								<span class="text-fg text-base">{opt.label}</span>
+							</label>
 						{/each}
-					</select>
+					</fieldset>
 				</div>
 
-				<div>
-					<label for="deliverable" class={labelClass}>
-						what has to be true in 30 days for this to be worth your money?
-					</label>
-					<textarea
-						id="deliverable"
-						name="deliverable"
-						required
-						rows="4"
-						maxlength="4000"
-						placeholder="scale to X users, pass SOC2 review, stop the 3am pages…"
-						class="{inputClass} mt-2"
-					></textarea>
+				<div class:hidden={step !== 2} class="space-y-8">
+					<div>
+						<p class={stepEyebrowClass}>step 2 of {TOTAL_STEPS} — the work</p>
+						<h2 class={stepHeadClass}>what does done look like?</h2>
+					</div>
+					<div>
+						<label for="built" class={labelClass}>link to what you've built</label>
+						<input
+							id="built"
+							name="built"
+							type="text"
+							required
+							maxlength="500"
+							bind:value={built}
+							placeholder="live URL, repo, or Loom"
+							class="{inputClass} mt-2"
+						/>
+					</div>
+					<div>
+						<label for="deliverable" class={labelClass}>
+							what has to be true in 30 days for this to be worth your money?
+						</label>
+						<textarea
+							id="deliverable"
+							name="deliverable"
+							required
+							rows="4"
+							maxlength="4000"
+							bind:value={deliverable}
+							placeholder="scale to X users, pass the security review, stop the 3am pages…"
+							class="{inputClass} mt-2"
+						></textarea>
+					</div>
+					<div>
+						<label for="budget" class={labelClass}>budget set aside for this</label>
+						<select
+							id="budget"
+							name="budget"
+							required
+							bind:value={budget}
+							class="{inputClass} mt-2"
+						>
+							<option value="">—</option>
+							{#each BUDGET_OPTIONS as opt (opt.value)}
+								<option value={opt.value}>{opt.label}</option>
+							{/each}
+						</select>
+					</div>
 				</div>
 
-				<div>
-					<label for="budget" class={labelClass}>budget set aside for fixing this</label>
-					<select id="budget" name="budget" required class="{inputClass} mt-2">
-						<option value="">—</option>
-						{#each BUDGET_OPTIONS as opt (opt.value)}
-							<option value={opt.value}>{opt.label}</option>
-						{/each}
-					</select>
-				</div>
-
-				<div>
-					<label for="authority" class={labelClass}>are you the one who signs off?</label>
-					<select id="authority" name="authority" required class="{inputClass} mt-2">
-						<option value="">—</option>
-						{#each AUTHORITY_OPTIONS as opt (opt.value)}
-							<option value={opt.value}>{opt.label}</option>
-						{/each}
-					</select>
+				<div class:hidden={step !== 3} class="space-y-8">
+					<div>
+						<p class={stepEyebrowClass}>step 3 of {TOTAL_STEPS} — last bit</p>
+						<h2 class={stepHeadClass}>how do i reach you?</h2>
+						<p class="text-fg-muted mt-3 text-sm leading-relaxed">
+							goes straight to my phone. i reply within a business day.
+						</p>
+					</div>
+					<div>
+						<label for="name" class={labelClass}>your name</label>
+						<input
+							id="name"
+							name="name"
+							type="text"
+							required
+							maxlength="120"
+							autocomplete="name"
+							bind:value={name}
+							class="{inputClass} mt-2"
+						/>
+					</div>
+					<div>
+						<label for="email" class={labelClass}>work email</label>
+						<input
+							id="email"
+							name="email"
+							type="email"
+							required
+							maxlength="254"
+							autocomplete="email"
+							bind:value={email}
+							class="{inputClass} mt-2"
+						/>
+						<p class={hintClass}>personal Gmail counts; just expect a slower reply.</p>
+					</div>
+					<div>
+						<label for="company_url" class={labelClass}>company URL</label>
+						<input
+							id="company_url"
+							name="company_url"
+							type="url"
+							required
+							maxlength="500"
+							placeholder="https://"
+							autocomplete="url"
+							bind:value={companyUrl}
+							class="{inputClass} mt-2"
+						/>
+					</div>
 				</div>
 
 				<input type="hidden" name="message" value="" />
@@ -213,16 +294,40 @@
 					class="absolute top-auto left-[-9999px] h-px w-px overflow-hidden"
 				/>
 
-				<button
-					type="submit"
-					data-umami-event="book_submit"
-					disabled={submitting}
-					class="btn-accent w-full px-6 py-3 text-base hover:opacity-90 disabled:opacity-60"
-				>
-					{submitting ? 'sending…' : 'send it →'}
-				</button>
+				<div class="mt-10 flex items-center gap-4">
+					{#if step > 1}
+						<button
+							type="button"
+							onclick={back}
+							data-umami-event="book_step_back"
+							class="text-fg-subtle hover:text-fg text-sm tracking-widest uppercase transition-colors"
+						>
+							← back
+						</button>
+					{/if}
+					{#if step < TOTAL_STEPS}
+						<button
+							type="button"
+							onclick={next}
+							disabled={!canAdvance()}
+							data-umami-event="book_step_next"
+							class="btn-accent ml-auto px-6 py-3 text-base hover:opacity-90 disabled:opacity-60"
+						>
+							next →
+						</button>
+					{:else}
+						<button
+							type="submit"
+							data-umami-event="book_submit"
+							disabled={submitting}
+							class="btn-accent ml-auto px-6 py-3 text-base hover:opacity-90 disabled:opacity-60"
+						>
+							{submitting ? 'sending…' : 'send it →'}
+						</button>
+					{/if}
+				</div>
 
-				<div role="alert" aria-live="polite">
+				<div role="alert" aria-live="polite" class="mt-4">
 					{#if form?.status === 'error'}
 						<p class="text-error text-sm">{form.message}</p>
 					{/if}

--- a/src/routes/book/+page.svelte
+++ b/src/routes/book/+page.svelte
@@ -13,9 +13,6 @@
 	let built = $state('')
 	let deliverable = $state('')
 	let budget = $state('')
-	let name = $state('')
-	let email = $state('')
-	let companyUrl = $state('')
 
 	let formStartedAt = $state('')
 	let enhanced = $state('')
@@ -248,7 +245,6 @@
 							required
 							maxlength="120"
 							autocomplete="name"
-							bind:value={name}
 							class="{inputClass} mt-2"
 						/>
 					</div>
@@ -261,7 +257,6 @@
 							required
 							maxlength="254"
 							autocomplete="email"
-							bind:value={email}
 							class="{inputClass} mt-2"
 						/>
 						<p class={hintClass}>personal Gmail counts; just expect a slower reply.</p>
@@ -276,7 +271,6 @@
 							maxlength="500"
 							placeholder="https://"
 							autocomplete="url"
-							bind:value={companyUrl}
 							class="{inputClass} mt-2"
 						/>
 					</div>

--- a/src/routes/book/+page.svelte
+++ b/src/routes/book/+page.svelte
@@ -2,7 +2,7 @@
 	import { enhance } from '$app/forms'
 	import { site } from '$lib/content'
 	import type { ActionData } from './$types'
-	import { STAGE_OPTIONS, BUDGET_OPTIONS } from './options'
+	import { STAGE_OPTIONS, BUDGET_OPTIONS, DISQUALIFY_STAGE } from './options'
 
 	let { form }: { form: ActionData } = $props()
 
@@ -22,7 +22,7 @@
 		enhanced = '1'
 	})
 
-	const isPreBuild = $derived(stage === 'pre-build')
+	const isPreBuild = $derived(stage === DISQUALIFY_STAGE)
 
 	function canAdvance(): boolean {
 		if (step === 1) return stage !== '' && !isPreBuild

--- a/src/routes/book/+page.svelte
+++ b/src/routes/book/+page.svelte
@@ -144,6 +144,7 @@
 		{:else}
 			<form
 				method="post"
+				novalidate
 				use:enhance={() => {
 					submitting = true
 					return async ({ update }) => {

--- a/src/routes/book/options.ts
+++ b/src/routes/book/options.ts
@@ -13,10 +13,5 @@ export const BUDGET_OPTIONS = [
 	{ value: 'not-sure', label: 'not sure yet' }
 ] as const
 
-export const AUTHORITY_OPTIONS = [
-	{ value: 'yes', label: 'yes' },
-	{ value: 'no', label: "no, i'll need to bring someone in" }
-] as const
-
 // Stage that auto-disqualifies — sixtom isn't greenfield.
 export const DISQUALIFY_STAGE = 'pre-build'


### PR DESCRIPTION
## Summary
- /book reworked into a 3-step form (fit → work → contact). Pre-build disqualifies inline with no email capture; authority field dropped.
- SiteFooter restored with sixtom wordmark — SIX|TO|M, middle tile inverted via semantic tokens so colors flip with theme.
- Home: "run yours →" moves to its own block under the cost equation; how-it-works reframed as "only two weeks?" with outcome bullets.

## Test plan
- [ ] Vercel preview loads cleanly
- [ ] /book: tab through 3 steps, back/forward preserves answers, pre-build shows inline disqualify, valid submission returns Cal.com link
- [ ] Footer wordmark renders at mobile and desktop; TO tile inverts correctly in both themes
- [ ] No console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)