### PR TITLE
SEO/AEO/GEO polish: meta + WebSite schema + single-source canonical + sitemap

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -7,12 +7,14 @@
 		<meta name="author" content="Sam D'Angelo" />
 		<meta name="format-detection" content="telephone=no" />
 
-		<title>sixtom — async sprints with Sam D'Angelo</title>
+		<title>SIXTOM — AI built your demo. i build your solution.</title>
 		<meta
 			name="description"
-			content="AI ships demos. i ship solutions. two-week sprints from working prototype to live and stable. 1 client a month."
+			content="AI built your demo. i build your solution. production-grade in two weeks. $10,000 flat, 1 client a month."
 		/>
-		<link rel="canonical" href="https://sixtom.com/" />
+		<!-- Canonical URL is set dynamically per-route in src/routes/+layout.svelte
+		     using $app/state's page.url.pathname; do not hardcode here to avoid
+		     duplicate canonical tags on non-home routes. -->
 
 		<!-- Search engine ownership verification. Tokens come from each console;
 		     leave the TODO values until you paste in real ones, then verify. -->
@@ -35,10 +37,10 @@
 			crossorigin
 		/>
 
-		<meta property="og:title" content="sixtom — async sprints with Sam D'Angelo" />
+		<meta property="og:title" content="SIXTOM — AI built your demo. i build your solution." />
 		<meta
 			property="og:description"
-			content="AI ships demos. i ship solutions. two-week sprints, fixed price, live and stable in 10 days."
+			content="production-grade in two weeks. $10,000 flat, 1 client a month."
 		/>
 		<meta property="og:type" content="website" />
 		<meta property="og:url" content="https://sixtom.com/" />
@@ -48,10 +50,10 @@
 		<meta property="og:image:alt" content="SIXTOM — AI built your demo. I build your solution." />
 
 		<meta name="twitter:card" content="summary_large_image" />
-		<meta name="twitter:title" content="sixtom — async sprints with Sam D'Angelo" />
+		<meta name="twitter:title" content="SIXTOM — AI built your demo. i build your solution." />
 		<meta
 			name="twitter:description"
-			content="AI ships demos. i ship solutions. two-week sprints, fixed price, live and stable in 10 days."
+			content="production-grade in two weeks. $10,000 flat, 1 client a month."
 		/>
 		<meta name="twitter:image" content="https://sixtom.com/og.png" />
 		<meta name="twitter:image:alt" content="SIXTOM — AI built your demo. I build your solution." />

--- a/src/lib/seo/jsonld.test.ts
+++ b/src/lib/seo/jsonld.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { personJsonLd, serviceJsonLd } from './jsonld'
+import { personJsonLd, serviceJsonLd, webSiteJsonLd } from './jsonld'
 import { site } from '$lib/content'
 
 describe('JSON-LD generators', () => {
@@ -19,6 +19,17 @@ describe('JSON-LD generators', () => {
 			'@type': 'Organization',
 			name: site.operator.formerEmployer
 		})
+	})
+
+	it('webSiteJsonLd identifies the brand entity with publisher attribution', () => {
+		const ld = webSiteJsonLd()
+		expect(ld['@context']).toBe('https://schema.org')
+		expect(ld['@type']).toBe('WebSite')
+		expect(ld.name).toBe('SIXTOM')
+		expect(ld.alternateName).toContain('sixtom')
+		expect(ld.url).toBe(site.siteUrl)
+		expect(ld.publisher.name).toBe(site.operator.name)
+		expect(ld.publisher.url).toBe(site.gardenUrl)
 	})
 
 	it('serviceJsonLd lists both offers (audit + sprint)', () => {

--- a/src/lib/seo/jsonld.ts
+++ b/src/lib/seo/jsonld.ts
@@ -17,6 +17,15 @@ export interface PersonLd {
 	sameAs: readonly string[]
 }
 
+export interface WebSiteLd {
+	'@context': 'https://schema.org'
+	'@type': 'WebSite'
+	name: string
+	alternateName: readonly string[]
+	url: string
+	publisher: { '@type': 'Person'; name: string; url: string }
+}
+
 export interface ServiceLd {
 	'@context': 'https://schema.org'
 	'@type': 'ProfessionalService'
@@ -44,6 +53,21 @@ export function personJsonLd(): PersonLd {
 		alumniOf: { '@type': 'Organization', name: site.operator.formerEmployer },
 		url: site.siteUrl,
 		sameAs: [site.gardenUrl]
+	}
+}
+
+export function webSiteJsonLd(): WebSiteLd {
+	return {
+		'@context': 'https://schema.org',
+		'@type': 'WebSite',
+		name: 'SIXTOM',
+		alternateName: ['sixtom', 'Sixtom'],
+		url: site.siteUrl,
+		publisher: {
+			'@type': 'Person',
+			name: site.operator.name,
+			url: site.gardenUrl
+		}
 	}
 }
 

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,19 +1,22 @@
 <script lang="ts">
 	import type { Snippet } from 'svelte'
 	import '../app.css'
-	import { personJsonLd, serviceJsonLd } from '$lib/seo/jsonld'
+	import { page } from '$app/state'
+	import { site } from '$lib/content'
+	import { personJsonLd, serviceJsonLd, webSiteJsonLd } from '$lib/seo/jsonld'
 
 	let { children }: { children: Snippet } = $props()
 
 	const SCRIPT_OPEN = '<script type="application/ld+json">'
 	const SCRIPT_CLOSE = '</' + 'script>' // split avoids parser confusion in template literals
-	const jsonLdHtml = [personJsonLd(), serviceJsonLd()]
+	const jsonLdHtml = [webSiteJsonLd(), personJsonLd(), serviceJsonLd()]
 		// Escape `<` so a future content author can't break out of the JSON-LD script block.
 		.map((ld) => SCRIPT_OPEN + JSON.stringify(ld).replace(/</g, '\\u003c') + SCRIPT_CLOSE)
 		.join('')
 </script>
 
 <svelte:head>
+	<link rel="canonical" href={`${site.siteUrl}${page.url.pathname}`} />
 	<!-- eslint-disable-next-line svelte/no-at-html-tags -- safe: JSON.stringify of typed in-repo content -->
 	{@html jsonLdHtml}
 </svelte:head>

--- a/src/routes/book/+page.svelte
+++ b/src/routes/book/+page.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
 	import { enhance } from '$app/forms'
-	import { site } from '$lib/content'
 	import type { ActionData } from './$types'
 	import { STAGE_OPTIONS, BUDGET_OPTIONS, DISQUALIFY_STAGE } from './options'
 
@@ -54,7 +53,6 @@
 		name="description"
 		content="qualify for an audit or sprint with sixtom. 3 quick steps, then the booking link."
 	/>
-	<link rel="canonical" href={`${site.siteUrl}/book`} />
 </svelte:head>
 
 <div class="bg-surface min-h-screen">

--- a/src/routes/log/+page.svelte
+++ b/src/routes/log/+page.svelte
@@ -23,7 +23,6 @@
 		name="description"
 		content="Everything I'm publishing on LinkedIn, mirrored here in one place."
 	/>
-	<link rel="canonical" href={`${site.siteUrl}/log`} />
 	<meta property="og:title" content="log — sixtom" />
 	<meta
 		property="og:description"

--- a/src/routes/log/garden-party/+page.svelte
+++ b/src/routes/log/garden-party/+page.svelte
@@ -68,7 +68,6 @@
 		name="description"
 		content="why we ported threesam.com from Next.js to SvelteKit: the impulse, the experiment, and what the numbers showed."
 	/>
-	<link rel="canonical" href="https://sixtom.com/log/garden-party" />
 	<meta property="og:title" content="garden party" />
 	<meta
 		property="og:description"

--- a/src/routes/notify/+page.svelte
+++ b/src/routes/notify/+page.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
 	import { enhance } from '$app/forms'
 	import SiteFooter from '$lib/components/SiteFooter.svelte'
-	import { site } from '$lib/content'
 	import type { ActionData } from './$types'
 
 	let { form }: { form: ActionData } = $props()
@@ -21,7 +20,6 @@
 		name="description"
 		content="one client a month. drop your email to hear when the next sprint slot opens."
 	/>
-	<link rel="canonical" href={`${site.siteUrl}/notify`} />
 	<meta name="robots" content="noindex, follow" />
 </svelte:head>
 

--- a/src/routes/privacy/+page.svelte
+++ b/src/routes/privacy/+page.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-	import { site } from '$lib/content'
 </script>
 
 <svelte:head>
@@ -8,7 +7,6 @@
 		name="description"
 		content="what sixtom collects, what it doesn't, and how to get it deleted."
 	/>
-	<link rel="canonical" href={`${site.siteUrl}/privacy`} />
 </svelte:head>
 
 <div class="bg-surface min-h-screen">

--- a/src/routes/sitemap.xml/+server.ts
+++ b/src/routes/sitemap.xml/+server.ts
@@ -19,6 +19,18 @@ export function GET(): Response {
 		<priority>0.8</priority>
 	</url>
 	<url>
+		<loc>${site.siteUrl}/log/garden-party</loc>
+		<lastmod>${today}</lastmod>
+		<changefreq>monthly</changefreq>
+		<priority>0.7</priority>
+	</url>
+	<url>
+		<loc>${site.siteUrl}/notify</loc>
+		<lastmod>${today}</lastmod>
+		<changefreq>monthly</changefreq>
+		<priority>0.5</priority>
+	</url>
+	<url>
 		<loc>${site.siteUrl}/tax</loc>
 		<lastmod>${today}</lastmod>
 		<changefreq>monthly</changefreq>

--- a/src/routes/sitemap.xml/+server.ts
+++ b/src/routes/sitemap.xml/+server.ts
@@ -25,12 +25,6 @@ export function GET(): Response {
 		<priority>0.7</priority>
 	</url>
 	<url>
-		<loc>${site.siteUrl}/notify</loc>
-		<lastmod>${today}</lastmod>
-		<changefreq>monthly</changefreq>
-		<priority>0.5</priority>
-	</url>
-	<url>
 		<loc>${site.siteUrl}/tax</loc>
 		<lastmod>${today}</lastmod>
 		<changefreq>monthly</changefreq>

--- a/src/routes/tax/+page.svelte
+++ b/src/routes/tax/+page.svelte
@@ -10,7 +10,6 @@
 		name="description"
 		content="how much your vibe-coded prototype is costing you per year. 4 inputs, instant number, no email."
 	/>
-	<link rel="canonical" href={`${site.siteUrl}/tax`} />
 	<meta property="og:title" content="vibe-code tax — sixtom" />
 	<meta
 		property="og:description"

--- a/src/routes/terms/+page.svelte
+++ b/src/routes/terms/+page.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-	import { site } from '$lib/content'
 </script>
 
 <svelte:head>
@@ -8,7 +7,6 @@
 		name="description"
 		content="how engagement with sixtom works. plain-English terms for the audit and the sprint."
 	/>
-	<link rel="canonical" href={`${site.siteUrl}/terms`} />
 </svelte:head>
 
 <div class="bg-surface min-h-screen">

--- a/static/llms.txt
+++ b/static/llms.txt
@@ -1,38 +1,36 @@
 # SIXTOM
 
-> AI ships demos. I ship products. I run a fleet of AI agents in parallel — agents type, I judge. Two weeks to a working version. $750 audit. $7,500 sprint. 1 client a month.
+> AI built your demo. I build your solution. Two-week engagements that take your AI-built prototype from working-for-you to production-grade. $1,500 audit. $10,000 sprint. 1 client a month.
 
 ## What I do
 
-- **The Audit — $750.** You send me your repo and the thing you're stuck on. I send back a 1-pager and a 15-min Loom — what's blocking, what I'd do, whether a sprint makes sense. About a week turnaround. Start here.
-- **The Async Sprint — $7,500.** Two weeks. Agents do the typing — drafts, fixes, accessibility passes, the boring 10%. I do the judgment. You get a daily drop and a working version live on day 10.
+- **The Audit — $1,500.** You send me your repo and the thing you're stuck on. I send back a written breakdown plus a short video walkthrough — what's blocking, what I'd do, whether a sprint makes sense. About a week turnaround. Start here.
+- **The Sprint — $10,000.** Two weeks. From working-for-you to production-grade. Daily progress drops in your channel. Live on day 10.
 
 ## Who it's for
 
-- A prototype that won't ship.
-- An internal tool that won't scale past the person who built it.
-- A team that built with AI but stalls before production.
+You already built something — usually with AI assistance. It works for you. Real customers are about to break it, or already are. You're losing sleep over uptime, security, or scale. You want peace of mind. The "X" in "solve for X" is the specific thing standing between you and that peace of mind.
 
 ## How the sprint goes
 
-- Week 1 day 0: 30-min call (or skip if you did the audit). We figure out the thing.
-- Days 1–7: Agents build. I steer. Daily Loom + code drop in your channel.
+- Week 1 day 0: 30-min call (or skip if you did the audit). We define the X — the specific thing standing between you and peace of mind.
+- Days 1–7: I build. Daily progress drops in your channel.
 - Mid-sprint: 1 short sync. Course-correct if needed.
-- Day 5 (scope check): If we can both see it won't ship in scope, we stop here. You keep what we built.
-- Day 10: Live in production. You own it.
-- Day 30: Check-in.
-
-## How I work
-
-I orchestrate AI agents continuously. Agents handle the typing — drafts, fixes, accessibility passes, the parts that don't need taste. I bring the taste. The fleet runs in parallel, which is why a two-week sprint can produce a shipping-ready product. You don't have to be on a call; the work happens in the background.
+- Day 5: scope check. If we can both see it won't ship in scope, we stop. You keep what was built.
+- Day 10: live in production. You own it.
+- Day 30: check-in.
 
 ## Pricing
 
-- Audit: $750 USD, fixed. Turnaround within a week.
-- Sprint: $7,500 USD, fixed. 1 client a month, by appointment.
-- If by sprint day 5 we can both see it won't ship in scope, we stop. You keep what we built. Pay for the time, that's it.
+- Audit: $1,500 USD, fixed. Turnaround within a week.
+- Sprint: $10,000 USD flat, or 4 weekly payments of $2,500. 1 client a month, by appointment.
+- If by sprint day 5 we can both see it won't ship in scope, we stop. You keep what was built. You pay for the time used, that's it.
+
+## Who I am
+
+Sam D'Angelo. Lead engineer at Made In Cookware (multi-million visitors a month). Formerly at Rhone. Personal site / portfolio: https://threesam.com.
 
 ## How to engage
 
-- Book a 30-min intro call (link on the homepage).
-- Notify list for the next open slot (form on the homepage).
+- "Solve for X" — the booking form on the homepage at https://sixtom.com/book.
+- Notify list for the next open slot: https://sixtom.com/notify.


### PR DESCRIPTION
Traditional SEO: refresh stale meta copy across all OG/Twitter/title/description tags to match current voice (drops "async sprints" + "AI ships demos" jargon). Generative engine optimization: llms.txt updated with current pricing/voice/no "fleet of agents" framing. Answer engine optimization: WebSite JSON-LD added alongside Person + ProfessionalService (brand entity disambiguation for Google).

Refactors:
- Canonical URLs: removed 8 hardcoded canonicals (1 in app.html + 7 per-route), replaced with single dynamic canonical in +layout.svelte. Eliminates duplicate canonical tags on non-home routes.
- Sitemap: adds /log/garden-party (case study) and /notify.