### PR TITLE
Hero: oversized type on desktop (fill the void)

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -116,3 +116,23 @@ html {
 	flex-direction: column;
 	justify-content: center;
 }
+
+/* Staggered hero load reveal. Each [data-hero] element rises + fades in, offset
+ * by its own --rise delay. Gated behind no-preference so reduced-motion users
+ * (and the no-animation default) see the content immediately, fully visible. */
+@keyframes hero-rise {
+	from {
+		opacity: 0;
+		transform: translateY(0.75rem);
+	}
+	to {
+		opacity: 1;
+		transform: translateY(0);
+	}
+}
+@media (prefers-reduced-motion: no-preference) {
+	[data-hero] {
+		animation: hero-rise 0.65s cubic-bezier(0.22, 0.61, 0.36, 1) both;
+		animation-delay: var(--rise, 0ms);
+	}
+}

--- a/src/lib/components/Hero.svelte
+++ b/src/lib/components/Hero.svelte
@@ -1,5 +1,8 @@
 <script lang="ts">
 	import { site } from '$lib/content'
+
+	const headlineClass =
+		'mt-2 block text-4xl leading-[1.05] font-bold tracking-tight md:text-6xl lg:text-8xl lg:leading-[0.92] xl:text-[7.5rem]'
 </script>
 
 <section class="snap-section bg-surface relative overflow-hidden">
@@ -14,19 +17,11 @@
 	<div class="relative mx-auto w-full max-w-6xl px-6">
 		<h1 class="text-fg">
 			<span class="eyebrow block text-sm md:text-base" data-hero style="--rise: 0ms">AI built</span>
-			<span
-				class="mt-2 block text-4xl leading-[1.05] font-bold tracking-tight md:text-6xl lg:text-8xl lg:leading-[0.92] xl:text-[7.5rem]"
-				data-hero
-				style="--rise: 80ms">your demo.</span
-			>
+			<span class={headlineClass} data-hero style="--rise: 80ms">your demo.</span>
 			<span class="eyebrow mt-10 block text-sm md:text-base" data-hero style="--rise: 160ms"
 				>i build</span
 			>
-			<span
-				class="mt-2 block text-4xl leading-[1.05] font-bold tracking-tight md:text-6xl lg:text-8xl lg:leading-[0.92] xl:text-[7.5rem]"
-				data-hero
-				style="--rise: 240ms">your solution.</span
-			>
+			<span class={headlineClass} data-hero style="--rise: 240ms">your solution.</span>
 		</h1>
 		<p
 			class="text-fg-muted mt-8 max-w-2xl text-base leading-relaxed md:text-xl"

--- a/src/lib/components/Hero.svelte
+++ b/src/lib/components/Hero.svelte
@@ -5,20 +5,26 @@
 		'mt-2 block text-4xl leading-[1.05] font-bold tracking-tight md:text-6xl lg:text-8xl lg:leading-[0.92] xl:text-[7.5rem]'
 </script>
 
-<section class="snap-section bg-surface relative overflow-hidden">
-	<!-- Atmospheric glow, desktop only — gives the oversized type depth instead of
-	     floating on flat black. Hidden on mobile so the mobile layout is untouched. -->
+<section class="snap-section bg-surface relative">
+	<!-- Atmospheric glow, desktop only. Clipped to the section via its own
+	     overflow-hidden wrapper so it can't add scrollbars or clip hero content
+	     (the section itself must stay un-clipped — oversized type can exceed
+	     100svh on short/zoomed viewports and needs to grow, not get cut off). -->
 	<div
-		class="pointer-events-none absolute top-1/2 left-[-12%] hidden h-[75vh] w-[75vh] -translate-y-1/2 rounded-full opacity-[0.08] blur-[130px] md:block"
-		style="background: radial-gradient(circle, var(--color-accent) 0%, transparent 70%)"
+		class="pointer-events-none absolute inset-0 hidden overflow-hidden md:block"
 		aria-hidden="true"
-	></div>
+	>
+		<div
+			class="absolute top-1/2 left-[-12%] h-[75vh] w-[75vh] -translate-y-1/2 rounded-full opacity-[0.08] blur-[130px]"
+			style="background: radial-gradient(circle, var(--color-accent) 0%, transparent 70%)"
+		></div>
+	</div>
 
 	<div class="relative mx-auto w-full max-w-6xl px-6">
 		<h1 class="text-fg">
-			<span class="eyebrow block text-sm md:text-base" data-hero style="--rise: 0ms">AI built</span>
+			<span class="eyebrow block text-sm lg:text-base" data-hero style="--rise: 0ms">AI built</span>
 			<span class={headlineClass} data-hero style="--rise: 80ms">your demo.</span>
-			<span class="eyebrow mt-10 block text-sm md:text-base" data-hero style="--rise: 160ms"
+			<span class="eyebrow mt-10 block text-sm lg:text-base" data-hero style="--rise: 160ms"
 				>i build</span
 			>
 			<span class={headlineClass} data-hero style="--rise: 240ms">your solution.</span>

--- a/src/lib/components/Hero.svelte
+++ b/src/lib/components/Hero.svelte
@@ -15,7 +15,7 @@
 		aria-hidden="true"
 	>
 		<div
-			class="absolute top-1/2 left-[-12%] h-[75vh] w-[75vh] -translate-y-1/2 rounded-full opacity-[0.08] blur-[130px]"
+			class="absolute top-1/2 left-[-12%] h-[700px] w-[700px] -translate-y-1/2 rounded-full opacity-[0.08] blur-[130px]"
 			style="background: radial-gradient(circle, var(--color-accent) 0%, transparent 70%)"
 		></div>
 	</div>

--- a/src/lib/components/Hero.svelte
+++ b/src/lib/components/Hero.svelte
@@ -2,26 +2,40 @@
 	import { site } from '$lib/content'
 </script>
 
-<section class="snap-section bg-surface">
-	<div class="mx-auto w-full max-w-4xl px-6">
+<section class="snap-section bg-surface relative overflow-hidden">
+	<!-- Atmospheric glow, desktop only — gives the oversized type depth instead of
+	     floating on flat black. Hidden on mobile so the mobile layout is untouched. -->
+	<div
+		class="pointer-events-none absolute top-1/2 left-[-12%] hidden h-[75vh] w-[75vh] -translate-y-1/2 rounded-full opacity-[0.08] blur-[130px] md:block"
+		style="background: radial-gradient(circle, var(--color-accent) 0%, transparent 70%)"
+		aria-hidden="true"
+	></div>
+
+	<div class="relative mx-auto w-full max-w-6xl px-6">
 		<h1 class="text-fg">
-			<span class="eyebrow block text-sm">AI built</span>
+			<span class="eyebrow block text-sm md:text-base" data-hero style="--rise: 0ms">AI built</span>
 			<span
-				class="mt-2 block text-4xl leading-[1.05] font-bold tracking-tight md:text-6xl lg:text-7xl"
+				class="mt-2 block text-4xl leading-[1.05] font-bold tracking-tight md:text-6xl lg:text-8xl lg:leading-[0.92] xl:text-[7.5rem]"
+				data-hero
+				style="--rise: 80ms">your demo.</span
 			>
-				your demo.
-			</span>
-			<span class="eyebrow mt-10 block text-sm">i build</span>
+			<span class="eyebrow mt-10 block text-sm md:text-base" data-hero style="--rise: 160ms"
+				>i build</span
+			>
 			<span
-				class="mt-2 block text-4xl leading-[1.05] font-bold tracking-tight md:text-6xl lg:text-7xl"
+				class="mt-2 block text-4xl leading-[1.05] font-bold tracking-tight md:text-6xl lg:text-8xl lg:leading-[0.92] xl:text-[7.5rem]"
+				data-hero
+				style="--rise: 240ms">your solution.</span
 			>
-				your solution.
-			</span>
 		</h1>
-		<p class="text-fg-muted mt-8 max-w-2xl text-base leading-relaxed md:text-xl">
+		<p
+			class="text-fg-muted mt-8 max-w-2xl text-base leading-relaxed md:text-xl"
+			data-hero
+			style="--rise: 340ms"
+		>
 			what's the <span class="text-accent">X</span> between you and peace of mind?
 		</p>
-		<div class="mt-12">
+		<div class="mt-12" data-hero style="--rise: 440ms">
 			<a
 				href="/book"
 				data-umami-event="cta_hero_book"


### PR DESCRIPTION
Fixes the janky "lonely text in a black void" on wide desktop viewports. Headlines scale up at lg/xl (lg:text-8xl + xl:text-[7.5rem]), container widens to max-w-6xl, subtle teal atmospheric glow + staggered load reveal add depth. Mobile is byte-identical (base sizing, spacing, and glow are all gated to desktop breakpoints). Direction chosen: oversized type (brutalist/editorial).

## Test plan
- [ ] Desktop preview: type fills the width, void gone, glow subtle not smudgy
- [ ] Mobile preview: identical to before
- [ ] Reduced-motion: content visible immediately, no animation
- [ ] "your solution." does not overflow at xl