### PR TITLE
Hero bubbles: full-bleed + CTA-gradient color; tighten footer wordmark

### DIFF
--- a/src/lib/components/Hero.svelte
+++ b/src/lib/components/Hero.svelte
@@ -23,7 +23,7 @@
 		<div class="absolute inset-0 bg-gradient-to-r from-[#000000b0] to-[#00000021]"></div>
 	</div>
 
-	<div class="relative mx-auto w-full max-w-6xl px-6 max-md:pb-28">
+	<div class="relative mx-auto w-full max-w-6xl px-6">
 		<h1 class="text-fg">
 			<span class="eyebrow block text-sm leading-none lg:text-base" data-hero style="--rise: 0ms"
 				>AI built</span
@@ -47,17 +47,11 @@
 		>
 			what's the <span class="text-accent">X</span> between you and peace of mind?
 		</p>
-		<!-- Desktop: inline CTA. Mobile: full-width bar fixed to the bottom of the
-		     viewport (it's the only CTA, so keep it always in reach). -->
-		<div
-			class="mt-12 max-md:fixed max-md:inset-x-0 max-md:bottom-0 max-md:z-40 max-md:mt-0 max-md:border-t max-md:border-border max-md:bg-surface/85 max-md:p-4 max-md:backdrop-blur"
-			data-hero
-			style="--rise: 440ms"
-		>
+		<div class="mt-12" data-hero style="--rise: 440ms">
 			<a
 				href="/book"
 				data-umami-event="cta_hero_book"
-				class="btn-accent block w-full px-8 py-4 text-center text-lg font-bold hover:opacity-90 md:inline-block md:w-auto md:text-left"
+				class="btn-accent px-8 py-4 text-lg font-bold hover:opacity-90"
 			>
 				{site.hero.ctaPrimary} →
 			</a>

--- a/src/lib/components/Hero.svelte
+++ b/src/lib/components/Hero.svelte
@@ -10,15 +10,14 @@
 </script>
 
 <section class="snap-section bg-surface relative">
-	<!-- Bubble field (threesam day20 "sea of shapes" port), behind the text. Its
-	     own overflow-hidden wrapper clips the bleed without constraining the
-	     section (oversized type can exceed 100svh on short/zoomed viewports and
-	     must stay un-clipped). Desktop: a square snapped right into the void beside
-	     the copy. Mobile: a square centered behind the copy (no right-side void on
-	     a phone). Animated by static/bubbles.js (wired in app.html) so the page
-	     keeps csr=false — the canvas is plain markup that survives no-hydration;
-	     the script no-ops elsewhere. Decorative + aria-hidden; alpha ramps to 0 on
-	     the left so it can't hurt text contrast where it overlaps the copy. -->
+	<!-- Bubble field (threesam day20 "sea of shapes" port), full-bleed behind the
+	     text. Its own overflow-hidden wrapper clips the bleed without constraining
+	     the section (oversized type can exceed 100svh on short/zoomed viewports and
+	     must stay un-clipped). Animated by static/bubbles.js (wired in app.html) so
+	     the page keeps csr=false — the canvas is plain markup that survives
+	     no-hydration; the script no-ops elsewhere. Decorative + aria-hidden; opacity
+	     ramps to 0 on the left so it can't hurt text contrast where it overlaps the
+	     copy. -->
 	<div class="pointer-events-none absolute inset-0 overflow-hidden" aria-hidden="true">
 		<canvas data-bubble class="absolute inset-0 block h-full w-full"></canvas>
 	</div>
@@ -51,7 +50,7 @@
 			<a
 				href="/book"
 				data-umami-event="cta_hero_book"
-				class="btn-accent px-8 py-4 text-lg hover:opacity-90"
+				class="btn-accent px-8 py-4 text-lg font-bold hover:opacity-90"
 			>
 				{site.hero.ctaPrimary} →
 			</a>

--- a/src/lib/components/Hero.svelte
+++ b/src/lib/components/Hero.svelte
@@ -10,24 +10,20 @@
 </script>
 
 <section class="snap-section bg-surface relative">
-	<!-- Bubble field (threesam day20 "sea of shapes" port). The canvas is a square
-	     sized object-cover (min-h/w-full + aspect-square, centered) so the proven
-	     square sketch fills the hero without distorting — then a left→right
-	     surface→transparent overlay fades it out under the copy for text contrast.
-	     overflow-hidden clips the square's overscan without constraining the section
-	     (oversized type can exceed 100svh and must stay un-clipped). Animated by
-	     static/bubbles.js (wired in app.html) so the page keeps csr=false — the
+	<!-- Bubble field ("sea of shapes"), full-bleed and rendered crisp at native pixel
+	     size. A left→right black overlay (0.69 over the copy → 0.13 over the bubbles)
+	     darkens the text side for contrast while leaving a light veil on the field.
+	     overflow-hidden keeps it from adding scrollbars without constraining the
+	     section (oversized type can exceed 100svh and must stay un-clipped). Animated
+	     by static/bubbles.js (wired in app.html) so the page keeps csr=false — the
 	     canvas is plain markup that survives no-hydration; the script no-ops
 	     elsewhere. Decorative + aria-hidden. -->
 	<div class="pointer-events-none absolute inset-0 overflow-hidden" aria-hidden="true">
-		<canvas
-			data-bubble
-			class="absolute top-1/2 left-1/2 block aspect-square min-h-full min-w-full -translate-x-1/2 -translate-y-1/2"
-		></canvas>
-		<div class="absolute inset-0 bg-gradient-to-r from-surface from-45% to-transparent"></div>
+		<canvas data-bubble class="absolute inset-0 block h-full w-full"></canvas>
+		<div class="absolute inset-0 bg-gradient-to-r from-[#000000b0] to-[#00000021]"></div>
 	</div>
 
-	<div class="relative mx-auto w-full max-w-6xl px-6">
+	<div class="relative mx-auto w-full max-w-6xl px-6 max-md:pb-28">
 		<h1 class="text-fg">
 			<span class="eyebrow block text-sm leading-none lg:text-base" data-hero style="--rise: 0ms"
 				>AI built</span
@@ -51,11 +47,17 @@
 		>
 			what's the <span class="text-accent">X</span> between you and peace of mind?
 		</p>
-		<div class="mt-12" data-hero style="--rise: 440ms">
+		<!-- Desktop: inline CTA. Mobile: full-width bar fixed to the bottom of the
+		     viewport (it's the only CTA, so keep it always in reach). -->
+		<div
+			class="mt-12 max-md:fixed max-md:inset-x-0 max-md:bottom-0 max-md:z-40 max-md:mt-0 max-md:border-t max-md:border-border max-md:bg-surface/85 max-md:p-4 max-md:backdrop-blur"
+			data-hero
+			style="--rise: 440ms"
+		>
 			<a
 				href="/book"
 				data-umami-event="cta_hero_book"
-				class="btn-accent px-8 py-4 text-lg font-bold hover:opacity-90"
+				class="btn-accent block w-full px-8 py-4 text-center text-lg font-bold hover:opacity-90 md:inline-block md:w-auto md:text-left"
 			>
 				{site.hero.ctaPrimary} →
 			</a>

--- a/src/lib/components/Hero.svelte
+++ b/src/lib/components/Hero.svelte
@@ -16,11 +16,7 @@
 	     the script no-ops elsewhere. Decorative + aria-hidden; alpha ramps to 0 on
 	     the left so it can't hurt text contrast where it overlaps the copy. -->
 	<div class="pointer-events-none absolute inset-0 overflow-hidden" aria-hidden="true">
-		<div
-			class="absolute aspect-square max-md:top-1/2 max-md:left-1/2 max-md:h-[80%] max-md:-translate-x-1/2 max-md:-translate-y-1/2 md:inset-y-[8%] md:right-[-6%]"
-		>
-			<canvas data-bubble class="block h-full w-full"></canvas>
-		</div>
+		<canvas data-bubble class="absolute inset-0 block h-full w-full"></canvas>
 	</div>
 
 	<div class="relative mx-auto w-full max-w-6xl px-6">

--- a/src/lib/components/Hero.svelte
+++ b/src/lib/components/Hero.svelte
@@ -1,8 +1,12 @@
 <script lang="ts">
 	import { site } from '$lib/content'
 
-	const headlineClass =
-		'mt-2 block text-4xl leading-[1.05] font-bold tracking-tight md:text-6xl lg:text-8xl lg:leading-[0.92] xl:text-[7.5rem]'
+	// Shared headline shape; size is per-line so "your demo." (the setup) sits a
+	// notch below "your solution." (the payoff). mt-1 keeps each line tight to its
+	// eyebrow.
+	const headlineBase = 'mt-1 block leading-[1.05] font-bold tracking-tight lg:leading-[0.92]'
+	const solutionSize = 'text-4xl md:text-6xl lg:text-8xl xl:text-[7.5rem]'
+	const demoSize = 'text-[1.95rem] md:text-[3.1rem] lg:text-[5rem] xl:text-[6.25rem]'
 </script>
 
 <section class="snap-section bg-surface relative">
@@ -21,12 +25,20 @@
 
 	<div class="relative mx-auto w-full max-w-6xl px-6">
 		<h1 class="text-fg">
-			<span class="eyebrow block text-sm lg:text-base" data-hero style="--rise: 0ms">AI built</span>
-			<span class="{headlineClass} text-fg-muted" data-hero style="--rise: 80ms">your demo.</span>
-			<span class="eyebrow mt-10 block text-sm lg:text-base" data-hero style="--rise: 160ms"
-				>i build</span
+			<span class="eyebrow block text-sm leading-none lg:text-base" data-hero style="--rise: 0ms"
+				>AI built</span
 			>
-			<span class={headlineClass} data-hero style="--rise: 240ms">your solution.</span>
+			<span class="{headlineBase} {demoSize} text-fg-muted" data-hero style="--rise: 80ms"
+				>your demo.</span
+			>
+			<span
+				class="eyebrow mt-10 block text-sm leading-none lg:text-base"
+				data-hero
+				style="--rise: 160ms">i build</span
+			>
+			<span class="{headlineBase} {solutionSize}" data-hero style="--rise: 240ms"
+				>your solution.</span
+			>
 		</h1>
 		<p
 			class="text-fg-muted mt-8 max-w-2xl text-base leading-relaxed md:text-xl"

--- a/src/lib/components/Hero.svelte
+++ b/src/lib/components/Hero.svelte
@@ -10,16 +10,21 @@
 </script>
 
 <section class="snap-section bg-surface relative">
-	<!-- Bubble field (threesam day20 "sea of shapes" port), full-bleed behind the
-	     text. Its own overflow-hidden wrapper clips the bleed without constraining
-	     the section (oversized type can exceed 100svh on short/zoomed viewports and
-	     must stay un-clipped). Animated by static/bubbles.js (wired in app.html) so
-	     the page keeps csr=false — the canvas is plain markup that survives
-	     no-hydration; the script no-ops elsewhere. Decorative + aria-hidden; opacity
-	     ramps to 0 on the left so it can't hurt text contrast where it overlaps the
-	     copy. -->
+	<!-- Bubble field (threesam day20 "sea of shapes" port). The canvas is a square
+	     sized object-cover (min-h/w-full + aspect-square, centered) so the proven
+	     square sketch fills the hero without distorting — then a left→right
+	     surface→transparent overlay fades it out under the copy for text contrast.
+	     overflow-hidden clips the square's overscan without constraining the section
+	     (oversized type can exceed 100svh and must stay un-clipped). Animated by
+	     static/bubbles.js (wired in app.html) so the page keeps csr=false — the
+	     canvas is plain markup that survives no-hydration; the script no-ops
+	     elsewhere. Decorative + aria-hidden. -->
 	<div class="pointer-events-none absolute inset-0 overflow-hidden" aria-hidden="true">
-		<canvas data-bubble class="absolute inset-0 block h-full w-full"></canvas>
+		<canvas
+			data-bubble
+			class="absolute top-1/2 left-1/2 block aspect-square min-h-full min-w-full -translate-x-1/2 -translate-y-1/2"
+		></canvas>
+		<div class="absolute inset-0 bg-gradient-to-r from-surface from-45% to-transparent"></div>
 	</div>
 
 	<div class="relative mx-auto w-full max-w-6xl px-6">

--- a/src/lib/components/Hero.svelte
+++ b/src/lib/components/Hero.svelte
@@ -22,7 +22,7 @@
 	<div class="relative mx-auto w-full max-w-6xl px-6">
 		<h1 class="text-fg">
 			<span class="eyebrow block text-sm lg:text-base" data-hero style="--rise: 0ms">AI built</span>
-			<span class={headlineClass} data-hero style="--rise: 80ms">your demo.</span>
+			<span class="{headlineClass} text-fg-muted" data-hero style="--rise: 80ms">your demo.</span>
 			<span class="eyebrow mt-10 block text-sm lg:text-base" data-hero style="--rise: 160ms"
 				>i build</span
 			>

--- a/src/lib/components/SiteFooter.svelte
+++ b/src/lib/components/SiteFooter.svelte
@@ -14,7 +14,7 @@
 			class="text-fg inline-flex items-center text-2xl leading-none font-bold tracking-tight uppercase"
 		>
 			<span class="pr-0.5">six</span><span class="bg-fg text-surface px-px pt-0.5">to</span><span
-				class="pl-0.5">m</span
+				class="pl-1">m</span
 			>
 		</a>
 		<div class="text-fg-subtle flex flex-wrap items-center justify-center gap-x-5 gap-y-2 text-xs">

--- a/src/lib/components/SiteFooter.svelte
+++ b/src/lib/components/SiteFooter.svelte
@@ -13,8 +13,8 @@
 			data-umami-event="footer_home"
 			class="text-fg inline-flex items-center text-2xl leading-none font-bold tracking-tight uppercase"
 		>
-			<span class="pr-px">six</span><span class="bg-fg text-surface px-px">to</span><span
-				class="pl-px">m</span
+			<span class="pr-0.5">six</span><span class="bg-fg text-surface px-px pt-0.5">to</span><span
+				class="pl-0.5">m</span
 			>
 		</a>
 		<div class="text-fg-subtle flex flex-wrap items-center justify-center gap-x-5 gap-y-2 text-xs">

--- a/src/lib/components/SiteFooter.svelte
+++ b/src/lib/components/SiteFooter.svelte
@@ -13,8 +13,8 @@
 			data-umami-event="footer_home"
 			class="text-fg inline-flex items-center text-2xl leading-none font-bold tracking-tight uppercase"
 		>
-			<span class="pr-1">six</span><span class="bg-fg text-surface p-1">to</span><span class="pl-1"
-				>m</span
+			<span class="pr-px">six</span><span class="bg-fg text-surface px-px">to</span><span
+				class="pl-px">m</span
 			>
 		</a>
 		<div class="text-fg-subtle flex flex-wrap items-center justify-center gap-x-5 gap-y-2 text-xs">

--- a/src/lib/components/SiteFooter.svelte
+++ b/src/lib/components/SiteFooter.svelte
@@ -14,7 +14,7 @@
 			class="text-fg inline-flex items-center text-2xl leading-none font-bold tracking-tight uppercase"
 		>
 			<span class="pr-0.5">six</span><span class="bg-fg text-surface px-px pt-0.5">to</span><span
-				class="pl-1">m</span
+				class="pl-px">m</span
 			>
 		</a>
 		<div class="text-fg-subtle flex flex-wrap items-center justify-center gap-x-5 gap-y-2 text-xs">

--- a/static/bubbles.js
+++ b/static/bubbles.js
@@ -10,9 +10,9 @@ const initBubbles = () => {
 	if (!ctx) return
 
 	const DENSITY = 44
-	const SPEED = 0.0009 // sway units per ms (~5x slower than the original; ~7s loop)
+	const SPEED = 0.00045 // sway units per ms (~10x slower than the original; ~14s loop)
 	const STATIC_FRAME = 3.4 // reduced-motion: freeze on a swayed mid-sketch frame
-	const FPS = 24 // cap render rate — a slow ambient sway needs no more, keeps cost low
+	const FPS = 12 // cap render rate — a very slow ambient sway needs no more, keeps cost low
 	const FRAME_MS = 1000 / FPS
 
 	const fade = (t) => t * t * (3 - 2 * t)

--- a/static/bubbles.js
+++ b/static/bubbles.js
@@ -10,7 +10,8 @@ const initBubbles = () => {
 	const ctx = canvas.getContext('2d')
 	if (!ctx) return
 
-	const DENSITY = 46 // grid cells across the short side
+	const DENSITY = 46 // grid cells across the short side (desktop)
+	const MOBILE_DENSITY = 32 // ~half the circle count on narrow screens (count ∝ density²)
 	const BLOBS = 4.5 // noise blobs across the short side — low → big contiguous blobs
 	const NDRIFT = 0.00012 // noise-units/ms the field scrolls (blobs "move through")
 	const ALPHA_MAX = 0.85 // peak opacity at a blob's core; the CSS overlay fades left→right
@@ -63,7 +64,7 @@ const initBubbles = () => {
 		ctx.setTransform(dpr, 0, 0, dpr, 0, 0)
 
 		const minDim = Math.min(width, height)
-		const space = minDim / DENSITY
+		const space = minDim / (width < 768 ? MOBILE_DENSITY : DENSITY)
 		const blobScale = BLOBS / minDim
 
 		const points = []

--- a/static/bubbles.js
+++ b/static/bubbles.js
@@ -18,9 +18,7 @@ const initBubbles = () => {
 	const STATIC_FRAME = 3.4 // reduced-motion: freeze on a swayed mid-sketch frame
 	const FPS = 20 // cap render rate — a slow ambient sway needs no more, keeps cost low
 	const FRAME_MS = 1000 / FPS
-	const BUCKETS = 13 // distinct fill tones; the whole field draws in BUCKETS fill()
-	// calls instead of one per circle (no per-circle colour-string parsing/fill setup).
-	const MAX_ALPHA = 0.69 // opacity at the right edge; ramps from 0 on the left
+	const MAX_ALPHA = 0.33 // opacity at the right edge; ramps from 0 on the left
 
 	const fade = (t) => t * t * (3 - 2 * t)
 
@@ -49,24 +47,12 @@ const initBubbles = () => {
 	}
 
 	const map = (v, a1, a2, b1, b2) => b1 + ((v - a1) * (b2 - b1)) / (a2 - a1)
-	const clamp01 = (v) => (v < 0 ? 0 : v > 1 ? 1 : v)
 
 	const noise = makeNoise(20)
 	const reduceMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches
 
-	// BUCKETS fixed fills sampled along the CTA gradient (oklch 72% .15 200 →
-	// 64% .16 178), opacity ramping 0 → MAX_ALPHA. Computed once; points reference
-	// these by index so the render loop can batch one fill() per tone.
-	const bucketFills = Array.from({ length: BUCKETS }, (_, i) => {
-		const f = i / (BUCKETS - 1)
-		const l = map(f, 0, 1, 72, 64)
-		const c = map(f, 0, 1, 0.15, 0.16)
-		const hue = map(f, 0, 1, 200, 178)
-		return `oklch(${l.toFixed(1)}% ${c.toFixed(3)} ${hue.toFixed(1)} / ${(f * MAX_ALPHA).toFixed(3)})`
-	})
-
-	// Returns an immutable field (geometry + bucketed points) or null until the
-	// canvas has a real laid-out size. Rebuilt on resize rather than mutating globals.
+	// Returns an immutable field (geometry + points) or null until the canvas
+	// has a real laid-out size. Rebuilt on resize rather than mutating globals.
 	const buildField = () => {
 		const dpr = Math.min(window.devicePixelRatio || 1, 2)
 		const { width, height } = canvas.getBoundingClientRect()
@@ -91,50 +77,49 @@ const initBubbles = () => {
 		const freq = (Math.PI * 2) / (space * WAVE_CELLS)
 		const breathe = space * 0.12
 
-		// Spans the whole screen. Each point is sorted into a tone bucket by its x
-		// position dithered by the noise field — the dither (smooth value noise)
-		// turns the BUCKETS hard tone steps into organic, blobby boundaries.
-		const buckets = Array.from({ length: BUCKETS }, () => [])
+		// Each bubble's colour follows the CTA gradient (oklch 72% .15 200 → 64%
+		// .16 178) by x, with lightness/hue jittered by the noise field so the
+		// field reads organic and mottled rather than a smooth wash. Opacity is a
+		// clean left→right ramp (0 → MAX_ALPHA): exactly 0 at the left edge so it
+		// can't hurt text contrast over the copy. Baked into a fill string here so
+		// the per-frame loop never builds strings.
+		const points = []
 		for (let x = -halfW; x < halfW; x += space) {
 			for (let y = -halfH; y < halfH; y += space) {
 				const n = noise(x * multi, y * multi)
 				const tx = map(x, -halfW, halfW, 0, 1) // 0 left → 1 right
-				const shade = clamp01(tx + (n - 0.5) * 0.32)
-				const bi = Math.round(shade * (BUCKETS - 1))
-				buckets[bi].push({
+				const l = map(tx, 0, 1, 72, 64) + map(n, 0, 1, -6, 6)
+				const c = map(tx, 0, 1, 0.15, 0.16)
+				const hue = map(tx, 0, 1, 200, 178) + map(n, 0, 1, -8, 8)
+				const alpha = tx * MAX_ALPHA
+				points.push({
 					x,
 					y,
 					// Tight radius range (~0.42–0.56 cell) keeps the dots distinct so the
 					// tone variation reads — a wide size range let big circles overlap
 					// into blobs and washed the texture out.
 					r: map(n, 0, 1, space * 0.42, space * 0.56),
-					wamp: baseAmp * tx
+					wamp: baseAmp * tx,
+					fill: `oklch(${l.toFixed(1)}% ${c.toFixed(3)} ${hue.toFixed(1)} / ${alpha.toFixed(3)})`
 				})
 			}
 		}
-		return { width, height, freq, breathe, buckets }
+		return { width, height, freq, breathe, points }
 	}
 
-	// One fill() per bucket: set the tone, trace every circle in it into a single
-	// path (moveTo before each arc so the subpaths don't connect), fill once.
 	const render = (field, offset) => {
 		ctx.clearRect(0, 0, field.width, field.height)
 		ctx.save()
 		ctx.translate(field.width / 2, field.height / 2)
-		const { freq, breathe, buckets } = field
-		for (let b = 0; b < buckets.length; b++) {
-			const pts = buckets[b]
-			if (pts.length === 0) continue
-			ctx.fillStyle = bucketFills[b]
+		const { freq, breathe, points } = field
+		for (let i = 0; i < points.length; i++) {
+			const p = points[i]
+			const cx = p.x + Math.sin(p.y * freq + offset) * p.wamp
+			const cy = p.y + Math.sin(p.x * freq + offset) * p.wamp
+			const r = Math.max(0.5, p.r + Math.sin((p.x + p.y) * freq + offset) * breathe)
+			ctx.fillStyle = p.fill
 			ctx.beginPath()
-			for (let i = 0; i < pts.length; i++) {
-				const p = pts[i]
-				const cx = p.x + Math.sin(p.y * freq + offset) * p.wamp
-				const cy = p.y + Math.sin(p.x * freq + offset) * p.wamp
-				const r = Math.max(0.5, p.r + Math.sin((p.x + p.y) * freq + offset) * breathe)
-				ctx.moveTo(cx + r, cy)
-				ctx.arc(cx, cy, r, 0, Math.PI * 2)
-			}
+			ctx.arc(cx, cy, r, 0, Math.PI * 2)
 			ctx.fill()
 		}
 		ctx.restore()
@@ -144,17 +129,19 @@ const initBubbles = () => {
 	let raf = 0
 	let running = false
 	let onScreen = true
-	let t0 = 0
+	let elapsed = 0 // accumulated animation time (ms), persists across pauses
 	let lastRender = 0
 
 	// rAF fires at display rate (~60/120Hz) but we only redraw at FPS — the loop
-	// body is a cheap timestamp check on skipped frames. Motion is time-based, so
-	// throttling lowers cost without changing the sway speed.
+	// body is a cheap timestamp check on skipped frames. `elapsed` accumulates only
+	// the time between rendered frames, so pausing (tab hidden / scrolled away) and
+	// resuming continues the sway from where it left off instead of snapping back.
 	const frame = (now) => {
+		if (!running) return
 		if (now - lastRender >= FRAME_MS) {
-			t0 ||= now
+			if (lastRender) elapsed += now - lastRender
 			lastRender = now
-			render(field, (now - t0) * SPEED)
+			render(field, elapsed * SPEED)
 		}
 		raf = requestAnimationFrame(frame)
 	}
@@ -162,8 +149,7 @@ const initBubbles = () => {
 	const startLoop = () => {
 		if (running || !field || reduceMotion || document.hidden || !onScreen) return
 		running = true
-		t0 = 0
-		lastRender = 0
+		lastRender = 0 // re-anchor without advancing elapsed → no phase jump on resume
 		raf = requestAnimationFrame(frame)
 	}
 
@@ -173,9 +159,8 @@ const initBubbles = () => {
 	}
 
 	// Single source of truth for "the canvas has a size". ResizeObserver fires an
-	// initial callback and again whenever the canvas crosses the md breakpoint
-	// (display:none ⇄ block), so there's no need for a blind rAF retry — a hidden
-	// canvas (mobile) simply never builds a field and never loops.
+	// initial callback and again on any layout change, so there's no need for a
+	// blind rAF retry — a 0-sized canvas simply never builds a field and never loops.
 	const sync = () => {
 		field = buildField()
 		if (!field) {

--- a/static/bubbles.js
+++ b/static/bubbles.js
@@ -10,6 +10,10 @@ const initBubbles = () => {
 	if (!ctx) return
 
 	const DENSITY = 44
+	const WAVE_CELLS = 7 // wave wavelength in cells — set relative to cell size so the
+	// sway stays a coherent traveling wave at any viewport (a fixed spatial frequency
+	// drifts in/out of phase as the responsive cell size changes, which reads as
+	// circles "dancing in place" rather than rippling).
 	const SPEED = 0.000225 // sway units per ms (~20x slower than the original; ~28s loop)
 	const STATIC_FRAME = 3.4 // reduced-motion: freeze on a swayed mid-sketch frame
 	const FPS = 24 // cap render rate — a very slow ambient sway needs no more, keeps cost low
@@ -63,10 +67,14 @@ const initBubbles = () => {
 		const halfH = height / 2
 		const multi = 0.025
 		const space = Math.max(Math.min(width, height) / DENSITY, 12)
-		// Wave amplitude (~0.9 of a cell at full strength) is enveloped to the right
-		// 2/3: zero through the left third (calm under the copy), ramping to full at
-		// the right edge — so the ripple "hits" across the visible right side.
-		const baseAmp = space * 0.9
+		// Positional sway (~0.6 cell at full strength) is enveloped to the right 2/3:
+		// zero through the left third, ramping to full at the right edge.
+		const baseAmp = space * 0.6
+		// Cell-relative wave frequency → coherent ripple at any viewport. Size
+		// "breathe" is a small, separate pulse so the high-amplitude right side
+		// undulates instead of pulsing violently.
+		const freq = (Math.PI * 2) / (space * WAVE_CELLS)
+		const breathe = space * 0.12
 
 		// Each bubble's colour is sampled along the CTA gradient (oklch 72% .15 200
 		// → 64% .16 178) by its x position; alpha ramps left→0 so the field can't
@@ -93,25 +101,28 @@ const initBubbles = () => {
 				points.push({
 					x,
 					y,
-					size: Math.floor(map(n, 0, 1, space * 0.69, space * 1.5)),
+					// Tight radius range (~0.42–0.56 cell) keeps the dots distinct so the
+					// colour/opacity noise reads — a wide size range let big circles
+					// overlap into blobs and washed the texture out.
+					r: map(n, 0, 1, space * 0.42, space * 0.56),
 					wamp: baseAmp * ramp,
 					fill: `oklch(${l}% ${c} ${hue} / ${alpha})`
 				})
 			}
 		}
-		return { width, height, points }
+		return { width, height, freq, breathe, points }
 	}
 
 	// Curried renderer: fix the frame's offset, return a per-point draw. Each point
 	// carries its own wave amplitude (p.wamp) — enveloped so the ripple "hits" the
 	// right side and fades out toward the (skipped) left third.
-	const drawPoint = (offset) => (p) => {
+	const drawPoint = (offset, freq, breathe) => (p) => {
 		ctx.fillStyle = p.fill
 		ctx.beginPath()
 		ctx.arc(
-			p.x + Math.sin(p.y * 0.41 + offset) * p.wamp,
-			p.y + Math.sin(p.x * 0.41 + offset) * p.wamp,
-			Math.max(1, (p.size + Math.sin((p.x + p.y) * 0.41 + offset) * p.wamp) / 2),
+			p.x + Math.sin(p.y * freq + offset) * p.wamp,
+			p.y + Math.sin(p.x * freq + offset) * p.wamp,
+			Math.max(0.5, p.r + Math.sin((p.x + p.y) * freq + offset) * breathe),
 			0,
 			Math.PI * 2
 		)
@@ -122,7 +133,7 @@ const initBubbles = () => {
 		ctx.clearRect(0, 0, field.width, field.height)
 		ctx.save()
 		ctx.translate(field.width / 2, field.height / 2)
-		field.points.forEach(drawPoint(offset))
+		field.points.forEach(drawPoint(offset, field.freq, field.breathe))
 		ctx.restore()
 	}
 

--- a/static/bubbles.js
+++ b/static/bubbles.js
@@ -10,7 +10,7 @@ const initBubbles = () => {
 	if (!ctx) return
 
 	const DENSITY = 44
-	const ALPHA_SCALE = 0.55 // right-edge cap; left edge ramps to 0 over the copy
+	const ALPHA_SCALE = 0.3 // right-edge cap; left edge ramps to 0 over the copy
 	const SPEED = 0.0018 // sway units per ms (~2.5x slower than the original)
 	const STATIC_FRAME = 3.4 // reduced-motion: freeze on a swayed mid-sketch frame
 
@@ -55,34 +55,42 @@ const initBubbles = () => {
 		canvas.height = Math.round(height * dpr)
 		ctx.setTransform(dpr, 0, 0, dpr, 0, 0)
 
-		const smallSide = Math.min(width, height) * 0.75
+		// Tile the full canvas (centered origin). Cell size scales with the short
+		// side but is floor-capped so a tall/narrow phone canvas doesn't explode
+		// the point count.
+		const halfW = width / 2
+		const halfH = height / 2
 		const multi = 0.025
-		const start = -smallSide * 0.4
-		const end = smallSide * 0.4
-		const space = smallSide / DENSITY
+		const space = Math.max(Math.min(width, height) / DENSITY, 12)
 
+		// Each bubble's colour is sampled along the CTA gradient (oklch 72% .15 200
+		// → 64% .16 178) by its x position; alpha ramps left→0 so the field can't
+		// hurt text contrast over the copy. Both are baked into a fill string here
+		// so the per-frame loop never builds strings.
 		const points = []
-		for (let x = start; x < end; x += space) {
-			for (let y = start; y < end; y += space) {
+		for (let x = -halfW; x < halfW; x += space) {
+			for (let y = -halfH; y < halfH; y += space) {
 				const n = noise(x * multi, y * multi)
+				const tx = map(x, -halfW, halfW, 0, 1)
+				const l = map(tx, 0, 1, 72, 64)
+				const c = map(tx, 0, 1, 0.15, 0.16)
+				const hue = map(tx, 0, 1, 200, 178)
 				points.push({
 					x,
 					y,
 					size: Math.floor(map(n, 0, 1, space * 0.69, space * 1.5)),
-					g: Math.floor(map(n, 0, 1, 100, 200)),
-					b: Math.floor(map(n, 0, 1, 130, 255)),
-					a: map(x, start, end, 0, 1) // left -> right alpha ramp (0..1)
+					fill: `oklch(${l}% ${c} ${hue} / ${tx * ALPHA_SCALE})`
 				})
 			}
 		}
-		return { width, height, start, end, points }
+		return { width, height, halfW, halfH, points }
 	}
 
 	// Curried renderer: fix the frame's offset + field bounds, return a per-point draw.
-	const drawPoint = (offset, start, end) => (p) => {
-		const waveX = map(p.x, start, end, 10, 0)
-		const waveY = map(p.y, start, end, 10, 0)
-		ctx.fillStyle = `rgba(0,${p.g},${p.b},${p.a * ALPHA_SCALE})`
+	const drawPoint = (offset, halfW, halfH) => (p) => {
+		const waveX = map(p.x, -halfW, halfW, 10, 0)
+		const waveY = map(p.y, -halfH, halfH, 10, 0)
+		ctx.fillStyle = p.fill
 		ctx.beginPath()
 		ctx.arc(
 			p.x + Math.sin(p.y * 0.41 + offset) * waveX,
@@ -98,7 +106,7 @@ const initBubbles = () => {
 		ctx.clearRect(0, 0, field.width, field.height)
 		ctx.save()
 		ctx.translate(field.width / 2, field.height / 2)
-		field.points.forEach(drawPoint(offset, field.start, field.end))
+		field.points.forEach(drawPoint(offset, field.halfW, field.halfH))
 		ctx.restore()
 	}
 

--- a/static/bubbles.js
+++ b/static/bubbles.js
@@ -10,7 +10,7 @@ const initBubbles = () => {
 	if (!ctx) return
 
 	const DENSITY = 44
-	const SPEED = 0.0018 // sway units per ms (~2.5x slower than the original)
+	const SPEED = 0.0009 // sway units per ms (~5x slower than the original; ~7s loop)
 	const STATIC_FRAME = 3.4 // reduced-motion: freeze on a swayed mid-sketch frame
 	const FPS = 24 // cap render rate — a slow ambient sway needs no more, keeps cost low
 	const FRAME_MS = 1000 / FPS

--- a/static/bubbles.js
+++ b/static/bubbles.js
@@ -10,9 +10,9 @@ const initBubbles = () => {
 	if (!ctx) return
 
 	const DENSITY = 44
-	const SPEED = 0.00045 // sway units per ms (~10x slower than the original; ~14s loop)
+	const SPEED = 0.000225 // sway units per ms (~20x slower than the original; ~28s loop)
 	const STATIC_FRAME = 3.4 // reduced-motion: freeze on a swayed mid-sketch frame
-	const FPS = 12 // cap render rate — a very slow ambient sway needs no more, keeps cost low
+	const FPS = 24 // cap render rate — a very slow ambient sway needs no more, keeps cost low
 	const FRAME_MS = 1000 / FPS
 
 	const fade = (t) => t * t * (3 - 2 * t)

--- a/static/bubbles.js
+++ b/static/bubbles.js
@@ -1,27 +1,22 @@
-// Hero bubble field — self-contained port of threesam.com's day20 "sea of
-// shapes": a grid of blue-green circles that sway via sine waves and breathe in
-// size. Standalone (no framework) so the home page can stay csr=false — zero
-// SvelteKit JS — while still getting the animation for ~1.3KB. No-ops on any
-// page without a [data-bubble] canvas.
-//
-// Rendered into a fixed REF×REF buffer and CSS-scaled up (the canvas element is
-// sized object-cover): this reproduces the live sketch exactly — same point
-// count, noise frequency and wave coherence — just enlarged, rather than
-// re-deriving the field at full-screen coordinates (which changes the texture).
-// A left→right surface→transparent CSS overlay fades it under the copy.
+// Hero bubble field — a "sea of shapes" descended from threesam.com's day20
+// sketch: a dot grid whose circles swell and brighten where a slow-drifting
+// value-noise field is high, so contiguous blobs of blue-green drift through
+// rather than rippling uniformly in place. Standalone (no framework) so the home
+// page can stay csr=false — zero SvelteKit JS — for ~1.3KB. No-ops on any page
+// without a [data-bubble] canvas. A left→right CSS overlay fades it under the copy.
 const initBubbles = () => {
 	const canvas = document.querySelector('canvas[data-bubble]')
 	if (!canvas) return
 	const ctx = canvas.getContext('2d')
 	if (!ctx) return
 
-	const DENSITY = 44
-	const REF = 760 // fixed render resolution; CSS scales the canvas element up to cover
-	const SPEED = 0.0018 // sway units per ms (matches the live sketch)
-	const STATIC_FRAME = 3.4 // reduced-motion: freeze on a swayed mid-sketch frame
-	const FPS = 20 // cap render rate — a slow ambient sway needs no more, keeps cost low
+	const DENSITY = 46 // grid cells across the short side
+	const BLOBS = 4.5 // noise blobs across the short side — low → big contiguous blobs
+	const NDRIFT = 0.00012 // noise-units/ms the field scrolls (blobs "move through")
+	const ALPHA_MAX = 0.85 // peak opacity at a blob's core; the CSS overlay fades left→right
+	const STATIC_FRAME = 3400 // reduced-motion: a representative mid-drift elapsed (ms)
+	const FPS = 20 // cap render rate — a slow ambient drift needs no more, keeps cost low
 	const FRAME_MS = 1000 / FPS
-	const ALPHA = 0.8 // flat opacity; the CSS overlay handles the left→right fade
 
 	const fade = (t) => t * t * (3 - 2 * t)
 
@@ -54,61 +49,52 @@ const initBubbles = () => {
 	const noise = makeNoise(20)
 	const reduceMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches
 
-	// Returns an immutable field (geometry + points) or null while the canvas is
-	// unsized (display:none / not laid out). The buffer is fixed at REF — only the
-	// laid-out check uses the element box. Rebuilt on resize, not mutated.
+	// Returns the field (geometry + fixed point positions) or null while the canvas
+	// is unsized. Rendered at the element's real pixel size (crisp, no upscale); the
+	// noise blob scale is tied to the short side so blobs are a fixed fraction of the
+	// viewport regardless of resolution. Positions carry a small static jitter so the
+	// grid doesn't read as a grid. Rebuilt on resize, not mutated.
 	const buildField = () => {
 		const { width, height } = canvas.getBoundingClientRect()
 		if (width === 0 || height === 0) return null
 		const dpr = Math.min(window.devicePixelRatio || 1, 2)
-		canvas.width = canvas.height = Math.round(REF * dpr)
+		canvas.width = Math.round(width * dpr)
+		canvas.height = Math.round(height * dpr)
 		ctx.setTransform(dpr, 0, 0, dpr, 0, 0)
 
-		const half = REF / 2
-		const multi = 0.025
-		const space = (REF * 0.75) / DENSITY
-		const waveAmp = space * 0.6
+		const minDim = Math.min(width, height)
+		const space = minDim / DENSITY
+		const blobScale = BLOBS / minDim
 
-		// Size and blue-green colour are driven by the noise field (the og sketch's
-		// organic texture); colour baked into a fill string so the loop builds none.
 		const points = []
-		for (let x = -half; x < half; x += space) {
-			for (let y = -half; y < half; y += space) {
-				const n = noise(x * multi, y * multi)
-				const g = Math.floor(map(n, 0, 1, 100, 200))
-				const b = Math.floor(map(n, 0, 1, 130, 255))
+		for (let x = space / 2; x < width; x += space) {
+			for (let y = space / 2; y < height; y += space) {
 				points.push({
-					x,
-					y,
-					size: Math.floor(map(n, 0, 1, space * 0.69, space * 1.5)),
-					fill: `rgba(0,${g},${b},${ALPHA})`
+					x: x + (noise(x * 0.1, y * 0.1) - 0.5) * space * 0.5,
+					y: y + (noise(y * 0.1, x * 0.1) - 0.5) * space * 0.5
 				})
 			}
 		}
-		return { dim: REF, waveAmp, points }
+		return { width, height, space, blobScale, points }
 	}
 
-	// Sway frequency 0.41 matches the live sketch and stays a coherent wave at REF's
-	// cell size (a fixed frequency only reads as a ripple — not "dancing" — when the
-	// cell size it was tuned for is held constant, which the fixed buffer guarantees).
-	const render = (field, offset) => {
-		ctx.clearRect(0, 0, field.dim, field.dim)
-		ctx.save()
-		ctx.translate(field.dim / 2, field.dim / 2)
-		const { waveAmp, points } = field
+	// Each frame, sample the noise at every point with a time offset (the drift) so
+	// the high-noise regions — blobs — translate across the grid. A point's radius,
+	// blue-green colour and opacity all track its local noise value, so a blob reads
+	// as a swelling, brightening cluster sliding through.
+	const render = (field, elapsed) => {
+		ctx.clearRect(0, 0, field.width, field.height)
+		const { space, blobScale, points } = field
+		const drift = elapsed * NDRIFT
 		for (const p of points) {
-			ctx.fillStyle = p.fill
+			const n = noise(p.x * blobScale + drift, p.y * blobScale + drift * 0.4)
+			const g = Math.floor(map(n, 0, 1, 100, 200))
+			const b = Math.floor(map(n, 0, 1, 130, 255))
+			ctx.fillStyle = `rgba(0,${g},${b},${map(n, 0, 1, 0.1, ALPHA_MAX).toFixed(3)})`
 			ctx.beginPath()
-			ctx.arc(
-				p.x + Math.sin(p.y * 0.41 + offset) * waveAmp,
-				p.y + Math.sin(p.x * 0.41 + offset) * waveAmp,
-				Math.max(1, (p.size + Math.sin((p.x + p.y) * 0.41 + offset) * waveAmp) / 2),
-				0,
-				Math.PI * 2
-			)
+			ctx.arc(p.x, p.y, space * map(n, 0, 1, 0.12, 0.95), 0, Math.PI * 2)
 			ctx.fill()
 		}
-		ctx.restore()
 	}
 
 	let field = null
@@ -121,13 +107,13 @@ const initBubbles = () => {
 	// rAF fires at display rate (~60/120Hz) but we only redraw at FPS — the loop
 	// body is a cheap timestamp check on skipped frames. `elapsed` accumulates only
 	// the time between rendered frames, so pausing (tab hidden / scrolled away) and
-	// resuming continues the sway from where it left off instead of snapping back.
+	// resuming continues the drift from where it left off instead of snapping back.
 	const frame = (now) => {
 		if (!running) return
 		if (now - lastRender >= FRAME_MS) {
 			if (lastRender) elapsed += now - lastRender
 			lastRender = now
-			render(field, elapsed * SPEED)
+			render(field, elapsed)
 		}
 		raf = requestAnimationFrame(frame)
 	}
@@ -135,7 +121,7 @@ const initBubbles = () => {
 	const startLoop = () => {
 		if (running || !field || reduceMotion || document.hidden || !onScreen) return
 		running = true
-		lastRender = 0 // re-anchor without advancing elapsed → no phase jump on resume
+		lastRender = 0 // re-anchor without advancing elapsed → no jump on resume
 		raf = requestAnimationFrame(frame)
 	}
 

--- a/static/bubbles.js
+++ b/static/bubbles.js
@@ -13,6 +13,8 @@ const initBubbles = () => {
 	const ALPHA_SCALE = 0.3 // right-edge cap; left edge ramps to 0 over the copy
 	const SPEED = 0.0018 // sway units per ms (~2.5x slower than the original)
 	const STATIC_FRAME = 3.4 // reduced-motion: freeze on a swayed mid-sketch frame
+	const FPS = 30 // cap render rate — a slow ambient sway needs no more, ~halves the cost
+	const FRAME_MS = 1000 / FPS
 
 	const fade = (t) => t * t * (3 - 2 * t)
 
@@ -62,6 +64,10 @@ const initBubbles = () => {
 		const halfH = height / 2
 		const multi = 0.025
 		const space = Math.max(Math.min(width, height) / DENSITY, 12)
+		// Uniform sway amplitude (~0.9 of a cell) so the ripple reads everywhere,
+		// including the visible right side — the original ramped it to 0 on the
+		// right, which is exactly where the full-bleed field is most visible.
+		const amp = space * 0.9
 
 		// Each bubble's colour is sampled along the CTA gradient (oklch 72% .15 200
 		// → 64% .16 178) by its x position; alpha ramps left→0 so the field can't
@@ -83,19 +89,18 @@ const initBubbles = () => {
 				})
 			}
 		}
-		return { width, height, halfW, halfH, points }
+		return { width, height, amp, points }
 	}
 
-	// Curried renderer: fix the frame's offset + field bounds, return a per-point draw.
-	const drawPoint = (offset, halfW, halfH) => (p) => {
-		const waveX = map(p.x, -halfW, halfW, 10, 0)
-		const waveY = map(p.y, -halfH, halfH, 10, 0)
+	// Curried renderer: fix the frame's offset + sway amplitude, return a per-point
+	// draw. Sway is uniform so the ripple reads across the whole field.
+	const drawPoint = (offset, amp) => (p) => {
 		ctx.fillStyle = p.fill
 		ctx.beginPath()
 		ctx.arc(
-			p.x + Math.sin(p.y * 0.41 + offset) * waveX,
-			p.y + Math.sin(p.x * 0.41 + offset) * waveY,
-			Math.max(1, (p.size + Math.sin((p.x + p.y) * 0.41 + offset) * waveX) / 2),
+			p.x + Math.sin(p.y * 0.41 + offset) * amp,
+			p.y + Math.sin(p.x * 0.41 + offset) * amp,
+			Math.max(1, (p.size + Math.sin((p.x + p.y) * 0.41 + offset) * amp) / 2),
 			0,
 			Math.PI * 2
 		)
@@ -106,7 +111,7 @@ const initBubbles = () => {
 		ctx.clearRect(0, 0, field.width, field.height)
 		ctx.save()
 		ctx.translate(field.width / 2, field.height / 2)
-		field.points.forEach(drawPoint(offset, field.halfW, field.halfH))
+		field.points.forEach(drawPoint(offset, field.amp))
 		ctx.restore()
 	}
 
@@ -114,10 +119,17 @@ const initBubbles = () => {
 	let raf = 0
 	let running = false
 	let t0 = 0
+	let lastRender = 0
 
+	// rAF fires at display rate (~60/120Hz) but we only redraw at FPS — the loop
+	// body is a cheap timestamp check on skipped frames. Motion is time-based, so
+	// throttling lowers cost without changing the sway speed.
 	const frame = (now) => {
-		t0 ||= now
-		render(field, (now - t0) * SPEED)
+		if (now - lastRender >= FRAME_MS) {
+			t0 ||= now
+			lastRender = now
+			render(field, (now - t0) * SPEED)
+		}
 		raf = requestAnimationFrame(frame)
 	}
 
@@ -125,6 +137,7 @@ const initBubbles = () => {
 		if (running || !field || reduceMotion || document.hidden) return
 		running = true
 		t0 = 0
+		lastRender = 0
 		raf = requestAnimationFrame(frame)
 	}
 

--- a/static/bubbles.js
+++ b/static/bubbles.js
@@ -10,7 +10,6 @@ const initBubbles = () => {
 	if (!ctx) return
 
 	const DENSITY = 44
-	const ALPHA_SCALE = 0.3 // right-edge cap; left edge ramps to 0 over the copy
 	const SPEED = 0.0018 // sway units per ms (~2.5x slower than the original)
 	const STATIC_FRAME = 3.4 // reduced-motion: freeze on a swayed mid-sketch frame
 	const FPS = 24 // cap render rate — a slow ambient sway needs no more, keeps cost low
@@ -80,18 +79,22 @@ const initBubbles = () => {
 			for (let y = -halfH; y < halfH; y += space) {
 				const n = noise(x * multi, y * multi)
 				const tx = map(x, -halfW, halfW, 0, 1)
-				// Colour follows the CTA gradient by x, but lightness/hue/opacity are
+				// 0 at the left edge of the kept field → 1 at the right edge. Drives
+				// both the wave amplitude and the opacity fade-in (so the skip boundary
+				// fades in from transparent rather than showing a hard edge).
+				const ramp = Math.max(0, (3 * tx - 1) / 2)
+				// Colour follows the CTA gradient by x; lightness/hue/opacity are
 				// jittered by the noise field so the bubbles read organic and mottled
 				// (like the original) rather than a smooth uniform wash.
 				const l = map(tx, 0, 1, 72, 64) + map(n, 0, 1, -6, 6)
 				const c = map(tx, 0, 1, 0.15, 0.16)
 				const hue = map(tx, 0, 1, 200, 178) + map(n, 0, 1, -8, 8)
-				const alpha = tx * ALPHA_SCALE * map(n, 0, 1, 0.45, 1.25)
+				const alpha = ramp * map(n, 0, 1, 0.65, 1) // 0 left → ~1 right, mottled
 				points.push({
 					x,
 					y,
 					size: Math.floor(map(n, 0, 1, space * 0.69, space * 1.5)),
-					wamp: baseAmp * Math.max(0, (3 * tx - 1) / 2), // 0 at left edge of kept field → full at right
+					wamp: baseAmp * ramp,
 					fill: `oklch(${l}% ${c} ${hue} / ${alpha})`
 				})
 			}

--- a/static/bubbles.js
+++ b/static/bubbles.js
@@ -9,15 +9,18 @@ const initBubbles = () => {
 	const ctx = canvas.getContext('2d')
 	if (!ctx) return
 
-	const DENSITY = 44
+	const DENSITY = 40
 	const WAVE_CELLS = 7 // wave wavelength in cells — set relative to cell size so the
 	// sway stays a coherent traveling wave at any viewport (a fixed spatial frequency
 	// drifts in/out of phase as the responsive cell size changes, which reads as
 	// circles "dancing in place" rather than rippling).
-	const SPEED = 0.000225 // sway units per ms (~20x slower than the original; ~28s loop)
+	const SPEED = 0.00045 // sway units per ms (slow ambient drift)
 	const STATIC_FRAME = 3.4 // reduced-motion: freeze on a swayed mid-sketch frame
-	const FPS = 24 // cap render rate — a very slow ambient sway needs no more, keeps cost low
+	const FPS = 20 // cap render rate — a slow ambient sway needs no more, keeps cost low
 	const FRAME_MS = 1000 / FPS
+	const BUCKETS = 13 // distinct fill tones; the whole field draws in BUCKETS fill()
+	// calls instead of one per circle (no per-circle colour-string parsing/fill setup).
+	const MAX_ALPHA = 0.69 // opacity at the right edge; ramps from 0 on the left
 
 	const fade = (t) => t * t * (3 - 2 * t)
 
@@ -46,12 +49,24 @@ const initBubbles = () => {
 	}
 
 	const map = (v, a1, a2, b1, b2) => b1 + ((v - a1) * (b2 - b1)) / (a2 - a1)
+	const clamp01 = (v) => (v < 0 ? 0 : v > 1 ? 1 : v)
 
 	const noise = makeNoise(20)
 	const reduceMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches
 
-	// Returns an immutable field (geometry + points) or null until the canvas
-	// has a real laid-out size. Rebuilt on resize rather than mutating globals.
+	// BUCKETS fixed fills sampled along the CTA gradient (oklch 72% .15 200 →
+	// 64% .16 178), opacity ramping 0 → MAX_ALPHA. Computed once; points reference
+	// these by index so the render loop can batch one fill() per tone.
+	const bucketFills = Array.from({ length: BUCKETS }, (_, i) => {
+		const f = i / (BUCKETS - 1)
+		const l = map(f, 0, 1, 72, 64)
+		const c = map(f, 0, 1, 0.15, 0.16)
+		const hue = map(f, 0, 1, 200, 178)
+		return `oklch(${l.toFixed(1)}% ${c.toFixed(3)} ${hue.toFixed(1)} / ${(f * MAX_ALPHA).toFixed(3)})`
+	})
+
+	// Returns an immutable field (geometry + bucketed points) or null until the
+	// canvas has a real laid-out size. Rebuilt on resize rather than mutating globals.
 	const buildField = () => {
 		const dpr = Math.min(window.devicePixelRatio || 1, 2)
 		const { width, height } = canvas.getBoundingClientRect()
@@ -67,8 +82,8 @@ const initBubbles = () => {
 		const halfH = height / 2
 		const multi = 0.025
 		const space = Math.max(Math.min(width, height) / DENSITY, 12)
-		// Positional sway (~0.6 cell at full strength) is enveloped to the right 2/3:
-		// zero through the left third, ramping to full at the right edge.
+		// Positional sway (~0.6 cell at full strength) ramps with x: calm under the
+		// copy on the left, full on the right.
 		const baseAmp = space * 0.6
 		// Cell-relative wave frequency → coherent ripple at any viewport. Size
 		// "breathe" is a small, separate pulse so the high-amplitude right side
@@ -76,70 +91,59 @@ const initBubbles = () => {
 		const freq = (Math.PI * 2) / (space * WAVE_CELLS)
 		const breathe = space * 0.12
 
-		// Each bubble's colour is sampled along the CTA gradient (oklch 72% .15 200
-		// → 64% .16 178) by its x position; alpha ramps left→0 so the field can't
-		// hurt text contrast over the copy. Both are baked into a fill string here
-		// so the per-frame loop never builds strings.
-		const points = []
-		// Skip the left third entirely — it ramps to ~0 alpha and 0 wave anyway, so
-		// it's pure waste. ~33% fewer drawn circles.
-		for (let x = -halfW / 3; x < halfW; x += space) {
+		// Spans the whole screen. Each point is sorted into a tone bucket by its x
+		// position dithered by the noise field — the dither (smooth value noise)
+		// turns the BUCKETS hard tone steps into organic, blobby boundaries.
+		const buckets = Array.from({ length: BUCKETS }, () => [])
+		for (let x = -halfW; x < halfW; x += space) {
 			for (let y = -halfH; y < halfH; y += space) {
 				const n = noise(x * multi, y * multi)
-				const tx = map(x, -halfW, halfW, 0, 1)
-				// 0 at the left edge of the kept field → 1 at the right edge. Drives
-				// both the wave amplitude and the opacity fade-in (so the skip boundary
-				// fades in from transparent rather than showing a hard edge).
-				const ramp = Math.max(0, (3 * tx - 1) / 2)
-				// Colour follows the CTA gradient by x; lightness/hue/opacity are
-				// jittered by the noise field so the bubbles read organic and mottled
-				// (like the original) rather than a smooth uniform wash.
-				const l = map(tx, 0, 1, 72, 64) + map(n, 0, 1, -6, 6)
-				const c = map(tx, 0, 1, 0.15, 0.16)
-				const hue = map(tx, 0, 1, 200, 178) + map(n, 0, 1, -8, 8)
-				const alpha = ramp * map(n, 0, 1, 0.65, 1) // 0 left → ~1 right, mottled
-				points.push({
+				const tx = map(x, -halfW, halfW, 0, 1) // 0 left → 1 right
+				const shade = clamp01(tx + (n - 0.5) * 0.32)
+				const bi = Math.round(shade * (BUCKETS - 1))
+				buckets[bi].push({
 					x,
 					y,
 					// Tight radius range (~0.42–0.56 cell) keeps the dots distinct so the
-					// colour/opacity noise reads — a wide size range let big circles
-					// overlap into blobs and washed the texture out.
+					// tone variation reads — a wide size range let big circles overlap
+					// into blobs and washed the texture out.
 					r: map(n, 0, 1, space * 0.42, space * 0.56),
-					wamp: baseAmp * ramp,
-					fill: `oklch(${l}% ${c} ${hue} / ${alpha})`
+					wamp: baseAmp * tx
 				})
 			}
 		}
-		return { width, height, freq, breathe, points }
+		return { width, height, freq, breathe, buckets }
 	}
 
-	// Curried renderer: fix the frame's offset, return a per-point draw. Each point
-	// carries its own wave amplitude (p.wamp) — enveloped so the ripple "hits" the
-	// right side and fades out toward the (skipped) left third.
-	const drawPoint = (offset, freq, breathe) => (p) => {
-		ctx.fillStyle = p.fill
-		ctx.beginPath()
-		ctx.arc(
-			p.x + Math.sin(p.y * freq + offset) * p.wamp,
-			p.y + Math.sin(p.x * freq + offset) * p.wamp,
-			Math.max(0.5, p.r + Math.sin((p.x + p.y) * freq + offset) * breathe),
-			0,
-			Math.PI * 2
-		)
-		ctx.fill()
-	}
-
+	// One fill() per bucket: set the tone, trace every circle in it into a single
+	// path (moveTo before each arc so the subpaths don't connect), fill once.
 	const render = (field, offset) => {
 		ctx.clearRect(0, 0, field.width, field.height)
 		ctx.save()
 		ctx.translate(field.width / 2, field.height / 2)
-		field.points.forEach(drawPoint(offset, field.freq, field.breathe))
+		const { freq, breathe, buckets } = field
+		for (let b = 0; b < buckets.length; b++) {
+			const pts = buckets[b]
+			if (pts.length === 0) continue
+			ctx.fillStyle = bucketFills[b]
+			ctx.beginPath()
+			for (let i = 0; i < pts.length; i++) {
+				const p = pts[i]
+				const cx = p.x + Math.sin(p.y * freq + offset) * p.wamp
+				const cy = p.y + Math.sin(p.x * freq + offset) * p.wamp
+				const r = Math.max(0.5, p.r + Math.sin((p.x + p.y) * freq + offset) * breathe)
+				ctx.moveTo(cx + r, cy)
+				ctx.arc(cx, cy, r, 0, Math.PI * 2)
+			}
+			ctx.fill()
+		}
 		ctx.restore()
 	}
 
 	let field = null
 	let raf = 0
 	let running = false
+	let onScreen = true
 	let t0 = 0
 	let lastRender = 0
 
@@ -156,7 +160,7 @@ const initBubbles = () => {
 	}
 
 	const startLoop = () => {
-		if (running || !field || reduceMotion || document.hidden) return
+		if (running || !field || reduceMotion || document.hidden || !onScreen) return
 		running = true
 		t0 = 0
 		lastRender = 0
@@ -183,6 +187,14 @@ const initBubbles = () => {
 	}
 
 	new ResizeObserver(sync).observe(canvas)
+
+	// Pause whenever the hero scrolls out of view — no point painting a canvas
+	// nobody can see while the rest of the page is read.
+	new IntersectionObserver((entries) => {
+		onScreen = entries[0].isIntersecting
+		if (onScreen) startLoop()
+		else stopLoop()
+	}).observe(canvas)
 
 	document.addEventListener('visibilitychange', () => {
 		if (document.hidden) stopLoop()

--- a/static/bubbles.js
+++ b/static/bubbles.js
@@ -4,9 +4,11 @@
 // SvelteKit JS — while still getting the animation for ~1.3KB. No-ops on any
 // page without a [data-bubble] canvas.
 //
-// The canvas is sized object-cover (a square that fills the hero) and a CSS
-// overlay fades it surface→transparent left→right for text contrast, so the
-// field renders rich and uniform here — no in-canvas alpha ramp.
+// Rendered into a fixed REF×REF buffer and CSS-scaled up (the canvas element is
+// sized object-cover): this reproduces the live sketch exactly — same point
+// count, noise frequency and wave coherence — just enlarged, rather than
+// re-deriving the field at full-screen coordinates (which changes the texture).
+// A left→right surface→transparent CSS overlay fades it under the copy.
 const initBubbles = () => {
 	const canvas = document.querySelector('canvas[data-bubble]')
 	if (!canvas) return
@@ -14,10 +16,7 @@ const initBubbles = () => {
 	if (!ctx) return
 
 	const DENSITY = 44
-	const WAVE_CELLS = 7 // wave wavelength in cells — frequency is set relative to cell
-	// size so the sway stays a coherent traveling wave at any scale (a fixed spatial
-	// frequency drifts in/out of phase as the cell size changes when blown up, which
-	// reads as circles "dancing in place" rather than rippling).
+	const REF = 760 // fixed render resolution; CSS scales the canvas element up to cover
 	const SPEED = 0.0018 // sway units per ms (matches the live sketch)
 	const STATIC_FRAME = 3.4 // reduced-motion: freeze on a swayed mid-sketch frame
 	const FPS = 20 // cap render rate — a slow ambient sway needs no more, keeps cost low
@@ -55,30 +54,26 @@ const initBubbles = () => {
 	const noise = makeNoise(20)
 	const reduceMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches
 
-	// Returns an immutable field (geometry + points) or null until the canvas
-	// has a real laid-out size. Rebuilt on resize rather than mutating globals.
+	// Returns an immutable field (geometry + points) or null while the canvas is
+	// unsized (display:none / not laid out). The buffer is fixed at REF — only the
+	// laid-out check uses the element box. Rebuilt on resize, not mutated.
 	const buildField = () => {
-		const dpr = Math.min(window.devicePixelRatio || 1, 2)
 		const { width, height } = canvas.getBoundingClientRect()
 		if (width === 0 || height === 0) return null
-		canvas.width = Math.round(width * dpr)
-		canvas.height = Math.round(height * dpr)
+		const dpr = Math.min(window.devicePixelRatio || 1, 2)
+		canvas.width = canvas.height = Math.round(REF * dpr)
 		ctx.setTransform(dpr, 0, 0, dpr, 0, 0)
 
-		// Tile the full (square, object-cover) canvas from a centered origin.
-		const halfW = width / 2
-		const halfH = height / 2
+		const half = REF / 2
 		const multi = 0.025
-		const space = Math.max((Math.min(width, height) * 0.75) / DENSITY, 10)
-		const waveAmp = space * 0.6 // uniform sway; the overlay (not amplitude) shapes the reveal
-		const freq = (Math.PI * 2) / (space * WAVE_CELLS) // cell-relative → coherent at any scale
+		const space = (REF * 0.75) / DENSITY
+		const waveAmp = space * 0.6
 
-		// Each bubble's size and blue-green colour are driven by the noise field
-		// (the og sketch's organic texture). Colour is baked into a fill string here
-		// so the per-frame loop never builds strings.
+		// Size and blue-green colour are driven by the noise field (the og sketch's
+		// organic texture); colour baked into a fill string so the loop builds none.
 		const points = []
-		for (let x = -halfW; x < halfW; x += space) {
-			for (let y = -halfH; y < halfH; y += space) {
+		for (let x = -half; x < half; x += space) {
+			for (let y = -half; y < half; y += space) {
 				const n = noise(x * multi, y * multi)
 				const g = Math.floor(map(n, 0, 1, 100, 200))
 				const b = Math.floor(map(n, 0, 1, 130, 255))
@@ -90,21 +85,24 @@ const initBubbles = () => {
 				})
 			}
 		}
-		return { width, height, waveAmp, freq, points }
+		return { dim: REF, waveAmp, points }
 	}
 
+	// Sway frequency 0.41 matches the live sketch and stays a coherent wave at REF's
+	// cell size (a fixed frequency only reads as a ripple — not "dancing" — when the
+	// cell size it was tuned for is held constant, which the fixed buffer guarantees).
 	const render = (field, offset) => {
-		ctx.clearRect(0, 0, field.width, field.height)
+		ctx.clearRect(0, 0, field.dim, field.dim)
 		ctx.save()
-		ctx.translate(field.width / 2, field.height / 2)
-		const { waveAmp, freq, points } = field
+		ctx.translate(field.dim / 2, field.dim / 2)
+		const { waveAmp, points } = field
 		for (const p of points) {
 			ctx.fillStyle = p.fill
 			ctx.beginPath()
 			ctx.arc(
-				p.x + Math.sin(p.y * freq + offset) * waveAmp,
-				p.y + Math.sin(p.x * freq + offset) * waveAmp,
-				Math.max(1, (p.size + Math.sin((p.x + p.y) * freq + offset) * waveAmp) / 2),
+				p.x + Math.sin(p.y * 0.41 + offset) * waveAmp,
+				p.y + Math.sin(p.x * 0.41 + offset) * waveAmp,
+				Math.max(1, (p.size + Math.sin((p.x + p.y) * 0.41 + offset) * waveAmp) / 2),
 				0,
 				Math.PI * 2
 			)

--- a/static/bubbles.js
+++ b/static/bubbles.js
@@ -3,22 +3,26 @@
 // size. Standalone (no framework) so the home page can stay csr=false — zero
 // SvelteKit JS — while still getting the animation for ~1.3KB. No-ops on any
 // page without a [data-bubble] canvas.
+//
+// The canvas is sized object-cover (a square that fills the hero) and a CSS
+// overlay fades it surface→transparent left→right for text contrast, so the
+// field renders rich and uniform here — no in-canvas alpha ramp.
 const initBubbles = () => {
 	const canvas = document.querySelector('canvas[data-bubble]')
 	if (!canvas) return
 	const ctx = canvas.getContext('2d')
 	if (!ctx) return
 
-	const DENSITY = 40
-	const WAVE_CELLS = 7 // wave wavelength in cells — set relative to cell size so the
-	// sway stays a coherent traveling wave at any viewport (a fixed spatial frequency
-	// drifts in/out of phase as the responsive cell size changes, which reads as
-	// circles "dancing in place" rather than rippling).
-	const SPEED = 0.00045 // sway units per ms (slow ambient drift)
+	const DENSITY = 44
+	const WAVE_CELLS = 7 // wave wavelength in cells — frequency is set relative to cell
+	// size so the sway stays a coherent traveling wave at any scale (a fixed spatial
+	// frequency drifts in/out of phase as the cell size changes when blown up, which
+	// reads as circles "dancing in place" rather than rippling).
+	const SPEED = 0.0018 // sway units per ms (matches the live sketch)
 	const STATIC_FRAME = 3.4 // reduced-motion: freeze on a swayed mid-sketch frame
 	const FPS = 20 // cap render rate — a slow ambient sway needs no more, keeps cost low
 	const FRAME_MS = 1000 / FPS
-	const MAX_ALPHA = 0.33 // opacity at the right edge; ramps from 0 on the left
+	const ALPHA = 0.8 // flat opacity; the CSS overlay handles the left→right fade
 
 	const fade = (t) => t * t * (3 - 2 * t)
 
@@ -61,65 +65,49 @@ const initBubbles = () => {
 		canvas.height = Math.round(height * dpr)
 		ctx.setTransform(dpr, 0, 0, dpr, 0, 0)
 
-		// Tile the full canvas (centered origin). Cell size scales with the short
-		// side but is floor-capped so a tall/narrow phone canvas doesn't explode
-		// the point count.
+		// Tile the full (square, object-cover) canvas from a centered origin.
 		const halfW = width / 2
 		const halfH = height / 2
 		const multi = 0.025
-		const space = Math.max(Math.min(width, height) / DENSITY, 12)
-		// Positional sway (~0.6 cell at full strength) ramps with x: calm under the
-		// copy on the left, full on the right.
-		const baseAmp = space * 0.6
-		// Cell-relative wave frequency → coherent ripple at any viewport. Size
-		// "breathe" is a small, separate pulse so the high-amplitude right side
-		// undulates instead of pulsing violently.
-		const freq = (Math.PI * 2) / (space * WAVE_CELLS)
-		const breathe = space * 0.12
+		const space = Math.max((Math.min(width, height) * 0.75) / DENSITY, 10)
+		const waveAmp = space * 0.6 // uniform sway; the overlay (not amplitude) shapes the reveal
+		const freq = (Math.PI * 2) / (space * WAVE_CELLS) // cell-relative → coherent at any scale
 
-		// Each bubble's colour follows the CTA gradient (oklch 72% .15 200 → 64%
-		// .16 178) by x, with lightness/hue jittered by the noise field so the
-		// field reads organic and mottled rather than a smooth wash. Opacity is a
-		// clean left→right ramp (0 → MAX_ALPHA): exactly 0 at the left edge so it
-		// can't hurt text contrast over the copy. Baked into a fill string here so
-		// the per-frame loop never builds strings.
+		// Each bubble's size and blue-green colour are driven by the noise field
+		// (the og sketch's organic texture). Colour is baked into a fill string here
+		// so the per-frame loop never builds strings.
 		const points = []
 		for (let x = -halfW; x < halfW; x += space) {
 			for (let y = -halfH; y < halfH; y += space) {
 				const n = noise(x * multi, y * multi)
-				const tx = map(x, -halfW, halfW, 0, 1) // 0 left → 1 right
-				const l = map(tx, 0, 1, 72, 64) + map(n, 0, 1, -6, 6)
-				const c = map(tx, 0, 1, 0.15, 0.16)
-				const hue = map(tx, 0, 1, 200, 178) + map(n, 0, 1, -8, 8)
-				const alpha = tx * MAX_ALPHA
+				const g = Math.floor(map(n, 0, 1, 100, 200))
+				const b = Math.floor(map(n, 0, 1, 130, 255))
 				points.push({
 					x,
 					y,
-					// Tight radius range (~0.42–0.56 cell) keeps the dots distinct so the
-					// tone variation reads — a wide size range let big circles overlap
-					// into blobs and washed the texture out.
-					r: map(n, 0, 1, space * 0.42, space * 0.56),
-					wamp: baseAmp * tx,
-					fill: `oklch(${l.toFixed(1)}% ${c.toFixed(3)} ${hue.toFixed(1)} / ${alpha.toFixed(3)})`
+					size: Math.floor(map(n, 0, 1, space * 0.69, space * 1.5)),
+					fill: `rgba(0,${g},${b},${ALPHA})`
 				})
 			}
 		}
-		return { width, height, freq, breathe, points }
+		return { width, height, waveAmp, freq, points }
 	}
 
 	const render = (field, offset) => {
 		ctx.clearRect(0, 0, field.width, field.height)
 		ctx.save()
 		ctx.translate(field.width / 2, field.height / 2)
-		const { freq, breathe, points } = field
-		for (let i = 0; i < points.length; i++) {
-			const p = points[i]
-			const cx = p.x + Math.sin(p.y * freq + offset) * p.wamp
-			const cy = p.y + Math.sin(p.x * freq + offset) * p.wamp
-			const r = Math.max(0.5, p.r + Math.sin((p.x + p.y) * freq + offset) * breathe)
+		const { waveAmp, freq, points } = field
+		for (const p of points) {
 			ctx.fillStyle = p.fill
 			ctx.beginPath()
-			ctx.arc(cx, cy, r, 0, Math.PI * 2)
+			ctx.arc(
+				p.x + Math.sin(p.y * freq + offset) * waveAmp,
+				p.y + Math.sin(p.x * freq + offset) * waveAmp,
+				Math.max(1, (p.size + Math.sin((p.x + p.y) * freq + offset) * waveAmp) / 2),
+				0,
+				Math.PI * 2
+			)
 			ctx.fill()
 		}
 		ctx.restore()

--- a/static/bubbles.js
+++ b/static/bubbles.js
@@ -13,7 +13,7 @@ const initBubbles = () => {
 	const ALPHA_SCALE = 0.3 // right-edge cap; left edge ramps to 0 over the copy
 	const SPEED = 0.0018 // sway units per ms (~2.5x slower than the original)
 	const STATIC_FRAME = 3.4 // reduced-motion: freeze on a swayed mid-sketch frame
-	const FPS = 30 // cap render rate — a slow ambient sway needs no more, ~halves the cost
+	const FPS = 24 // cap render rate — a slow ambient sway needs no more, keeps cost low
 	const FRAME_MS = 1000 / FPS
 
 	const fade = (t) => t * t * (3 - 2 * t)
@@ -64,43 +64,51 @@ const initBubbles = () => {
 		const halfH = height / 2
 		const multi = 0.025
 		const space = Math.max(Math.min(width, height) / DENSITY, 12)
-		// Uniform sway amplitude (~0.9 of a cell) so the ripple reads everywhere,
-		// including the visible right side — the original ramped it to 0 on the
-		// right, which is exactly where the full-bleed field is most visible.
-		const amp = space * 0.9
+		// Wave amplitude (~0.9 of a cell at full strength) is enveloped to the right
+		// 2/3: zero through the left third (calm under the copy), ramping to full at
+		// the right edge — so the ripple "hits" across the visible right side.
+		const baseAmp = space * 0.9
 
 		// Each bubble's colour is sampled along the CTA gradient (oklch 72% .15 200
 		// → 64% .16 178) by its x position; alpha ramps left→0 so the field can't
 		// hurt text contrast over the copy. Both are baked into a fill string here
 		// so the per-frame loop never builds strings.
 		const points = []
-		for (let x = -halfW; x < halfW; x += space) {
+		// Skip the left third entirely — it ramps to ~0 alpha and 0 wave anyway, so
+		// it's pure waste. ~33% fewer drawn circles.
+		for (let x = -halfW / 3; x < halfW; x += space) {
 			for (let y = -halfH; y < halfH; y += space) {
 				const n = noise(x * multi, y * multi)
 				const tx = map(x, -halfW, halfW, 0, 1)
-				const l = map(tx, 0, 1, 72, 64)
+				// Colour follows the CTA gradient by x, but lightness/hue/opacity are
+				// jittered by the noise field so the bubbles read organic and mottled
+				// (like the original) rather than a smooth uniform wash.
+				const l = map(tx, 0, 1, 72, 64) + map(n, 0, 1, -6, 6)
 				const c = map(tx, 0, 1, 0.15, 0.16)
-				const hue = map(tx, 0, 1, 200, 178)
+				const hue = map(tx, 0, 1, 200, 178) + map(n, 0, 1, -8, 8)
+				const alpha = tx * ALPHA_SCALE * map(n, 0, 1, 0.45, 1.25)
 				points.push({
 					x,
 					y,
 					size: Math.floor(map(n, 0, 1, space * 0.69, space * 1.5)),
-					fill: `oklch(${l}% ${c} ${hue} / ${tx * ALPHA_SCALE})`
+					wamp: baseAmp * Math.max(0, (3 * tx - 1) / 2), // 0 at left edge of kept field → full at right
+					fill: `oklch(${l}% ${c} ${hue} / ${alpha})`
 				})
 			}
 		}
-		return { width, height, amp, points }
+		return { width, height, points }
 	}
 
-	// Curried renderer: fix the frame's offset + sway amplitude, return a per-point
-	// draw. Sway is uniform so the ripple reads across the whole field.
-	const drawPoint = (offset, amp) => (p) => {
+	// Curried renderer: fix the frame's offset, return a per-point draw. Each point
+	// carries its own wave amplitude (p.wamp) — enveloped so the ripple "hits" the
+	// right side and fades out toward the (skipped) left third.
+	const drawPoint = (offset) => (p) => {
 		ctx.fillStyle = p.fill
 		ctx.beginPath()
 		ctx.arc(
-			p.x + Math.sin(p.y * 0.41 + offset) * amp,
-			p.y + Math.sin(p.x * 0.41 + offset) * amp,
-			Math.max(1, (p.size + Math.sin((p.x + p.y) * 0.41 + offset) * amp) / 2),
+			p.x + Math.sin(p.y * 0.41 + offset) * p.wamp,
+			p.y + Math.sin(p.x * 0.41 + offset) * p.wamp,
+			Math.max(1, (p.size + Math.sin((p.x + p.y) * 0.41 + offset) * p.wamp) / 2),
 			0,
 			Math.PI * 2
 		)
@@ -111,7 +119,7 @@ const initBubbles = () => {
 		ctx.clearRect(0, 0, field.width, field.height)
 		ctx.save()
 		ctx.translate(field.width / 2, field.height / 2)
-		field.points.forEach(drawPoint(offset, field.amp))
+		field.points.forEach(drawPoint(offset))
 		ctx.restore()
 	}
 


### PR DESCRIPTION
Full-bleed bubble field (full height + width) instead of a right-snapped square; color sampled from the CTA oklch gradient; ALPHA_SCALE dropped to 0.3 so it reads as an ambient wash with the copy side staying faint/readable (left→right alpha ramp preserved). Footer wordmark padding tightened to pr-px/px-px/pl-px. Verified desktop (1512) + mobile (390).