### PR TITLE
Hero: fatter desktop CTA + CTA-gradient teal bubble field

### DIFF
--- a/src/lib/components/Hero.svelte
+++ b/src/lib/components/Hero.svelte
@@ -43,7 +43,7 @@
 			<a
 				href="/book"
 				data-umami-event="cta_hero_book"
-				class="btn-accent block w-full px-8 py-4 text-center text-xl font-bold hover:opacity-90 md:inline-block md:w-auto"
+				class="btn-accent block w-full px-8 py-4 text-center text-xl font-bold hover:opacity-90 md:inline-block md:w-auto md:px-12 md:py-5 md:text-2xl"
 			>
 				{site.hero.ctaPrimary} →
 			</a>

--- a/static/bubbles.js
+++ b/static/bubbles.js
@@ -81,17 +81,19 @@ const initBubbles = () => {
 
 	// Each frame, sample the noise at every point with a time offset (the drift) so
 	// the high-noise regions — blobs — translate across the grid. A point's radius,
-	// blue-green colour and opacity all track its local noise value, so a blob reads
-	// as a swelling, brightening cluster sliding through.
+	// colour and opacity all track its local noise value, so a blob reads as a
+	// swelling, brightening cluster sliding through. Colour spans the CTA gradient
+	// (oklch 64% .16 178 → 72% .15 200) by noise, so the field is the same teal.
 	const render = (field, elapsed) => {
 		ctx.clearRect(0, 0, field.width, field.height)
 		const { space, blobScale, points } = field
 		const drift = elapsed * NDRIFT
 		for (const p of points) {
 			const n = noise(p.x * blobScale + drift, p.y * blobScale + drift * 0.4)
-			const g = Math.floor(map(n, 0, 1, 100, 200))
-			const b = Math.floor(map(n, 0, 1, 130, 255))
-			ctx.fillStyle = `rgba(0,${g},${b},${map(n, 0, 1, 0.1, ALPHA_MAX).toFixed(3)})`
+			const l = map(n, 0, 1, 64, 72)
+			const c = map(n, 0, 1, 0.16, 0.15)
+			const h = map(n, 0, 1, 178, 200)
+			ctx.fillStyle = `oklch(${l.toFixed(1)}% ${c.toFixed(3)} ${h.toFixed(1)} / ${map(n, 0, 1, 0.1, ALPHA_MAX).toFixed(3)})`
 			ctx.beginPath()
 			ctx.arc(p.x, p.y, space * map(n, 0, 1, 0.12, 0.95), 0, Math.PI * 2)
 			ctx.fill()


### PR DESCRIPTION
- CTA: bigger on desktop (`md:px-12 md:py-5 md:text-2xl`) to match the enlarged headline; mobile full-width pill unchanged.
- Bubble field: colour now spans the CTA gradient (`oklch(64% .16 178)` → `oklch(72% .15 200)`) by noise, replacing the rgba blue-green — the field is now the exact teal of the button/CTA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)