### PR TITLE
Hero: coin-gold CTA

### DIFF
--- a/src/lib/components/Hero.svelte
+++ b/src/lib/components/Hero.svelte
@@ -43,7 +43,7 @@
 			<a
 				href="/book"
 				data-umami-event="cta_hero_book"
-				class="btn-accent block w-full px-8 py-4 text-center text-xl font-bold hover:opacity-90 md:inline-block md:w-auto md:px-12 md:py-5 md:text-2xl"
+				class="block w-full rounded-full bg-coin px-8 py-4 text-center text-xl font-bold text-[#161616] transition hover:brightness-110 md:inline-block md:w-auto md:px-12 md:py-5 md:text-2xl"
 			>
 				{site.hero.ctaPrimary} →
 			</a>


### PR DESCRIPTION
Black-on-teal CTA vanished into the bubble field. Switch the hero CTA to the brand coin gold (`--color-coin`) with dark text — complementary to teal, so it pops. Pill shape + sizing unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)