### PR TITLE
meta: normalize all titles to "<subject> | SIXTOM"

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -7,7 +7,7 @@
 		<meta name="author" content="Sam D'Angelo" />
 		<meta name="format-detection" content="telephone=no" />
 
-		<title>SIXTOM — AI built your first draft. i build your solution.</title>
+		<title>AI built your first draft. i build your solution. | SIXTOM</title>
 		<meta
 			name="description"
 			content="AI built your first draft. i build your solution. production-grade in two weeks. $10,000 flat, 1 client a month."
@@ -37,7 +37,7 @@
 			crossorigin
 		/>
 
-		<meta property="og:title" content="SIXTOM — AI built your first draft. i build your solution." />
+		<meta property="og:title" content="AI built your first draft. i build your solution. | SIXTOM" />
 		<meta
 			property="og:description"
 			content="production-grade in two weeks. $10,000 flat, 1 client a month."
@@ -50,7 +50,7 @@
 		<meta property="og:image:alt" content="SIXTOM — AI built your first draft. I build your solution." />
 
 		<meta name="twitter:card" content="summary_large_image" />
-		<meta name="twitter:title" content="SIXTOM — AI built your first draft. i build your solution." />
+		<meta name="twitter:title" content="AI built your first draft. i build your solution. | SIXTOM" />
 		<meta
 			name="twitter:description"
 			content="production-grade in two weeks. $10,000 flat, 1 client a month."

--- a/src/routes/book/+page.svelte
+++ b/src/routes/book/+page.svelte
@@ -49,7 +49,7 @@
 </script>
 
 <svelte:head>
-	<title>book — sixtom</title>
+	<title>book | SIXTOM</title>
 	<meta name="robots" content="noindex, nofollow" />
 	<meta
 		name="description"

--- a/src/routes/log/+page.svelte
+++ b/src/routes/log/+page.svelte
@@ -18,12 +18,12 @@
 </script>
 
 <svelte:head>
-	<title>log — sixtom</title>
+	<title>log | SIXTOM</title>
 	<meta
 		name="description"
 		content="Everything I'm publishing on LinkedIn, mirrored here in one place."
 	/>
-	<meta property="og:title" content="log — sixtom" />
+	<meta property="og:title" content="log | SIXTOM" />
 	<meta
 		property="og:description"
 		content="Everything I'm publishing on LinkedIn, mirrored here in one place."

--- a/src/routes/log/garden-party/+page.svelte
+++ b/src/routes/log/garden-party/+page.svelte
@@ -63,12 +63,12 @@
 </script>
 
 <svelte:head>
-	<title>garden party — SIXTOM log</title>
+	<title>garden party | SIXTOM</title>
 	<meta
 		name="description"
 		content="why we ported threesam.com from Next.js to SvelteKit: the impulse, the experiment, and what the numbers showed."
 	/>
-	<meta property="og:title" content="garden party" />
+	<meta property="og:title" content="garden party | SIXTOM" />
 	<meta
 		property="og:description"
 		content="why we ported threesam.com from Next.js to SvelteKit: the impulse, the experiment, and what the numbers showed."

--- a/src/routes/notify/+page.svelte
+++ b/src/routes/notify/+page.svelte
@@ -15,7 +15,7 @@
 </script>
 
 <svelte:head>
-	<title>notify — sixtom</title>
+	<title>notify | SIXTOM</title>
 	<meta
 		name="description"
 		content="one client a month. drop your email to hear when the next sprint slot opens."

--- a/src/routes/privacy/+page.svelte
+++ b/src/routes/privacy/+page.svelte
@@ -2,7 +2,7 @@
 </script>
 
 <svelte:head>
-	<title>privacy — sixtom</title>
+	<title>privacy | SIXTOM</title>
 	<meta
 		name="description"
 		content="what sixtom collects, what it doesn't, and how to get it deleted."

--- a/src/routes/tax/+page.svelte
+++ b/src/routes/tax/+page.svelte
@@ -5,12 +5,12 @@
 </script>
 
 <svelte:head>
-	<title>vibe-code tax — sixtom</title>
+	<title>vibe-code tax | SIXTOM</title>
 	<meta
 		name="description"
 		content="how much your vibe-coded prototype is costing you per year. 4 inputs, instant number, no email."
 	/>
-	<meta property="og:title" content="vibe-code tax — sixtom" />
+	<meta property="og:title" content="vibe-code tax | SIXTOM" />
 	<meta
 		property="og:description"
 		content="how much your vibe-coded prototype is costing you per year."

--- a/src/routes/terms/+page.svelte
+++ b/src/routes/terms/+page.svelte
@@ -2,7 +2,7 @@
 </script>
 
 <svelte:head>
-	<title>terms — sixtom</title>
+	<title>terms | SIXTOM</title>
 	<meta
 		name="description"
 		content="how engagement with sixtom works. plain-English terms for the audit and the sprint."


### PR DESCRIPTION
Normalizes every meta title to the `<subject> | SIXTOM` convention.

Before, three inconsistent patterns coexisted:
- Home (`app.html`): `SIXTOM — AI built your first draft. i build your solution.` (brand-first, em-dash)
- Most routes: `<page> — sixtom` (lowercase, em-dash)
- garden-party: `garden party — SIXTOM log` + an og:title of just `garden party`

After: subject-first, pipe separator, uppercase brand — applied to `<title>`, `og:title`, and `twitter:title` everywhere they appear.

- Home → `AI built your first draft. i build your solution. | SIXTOM`
- book / privacy / terms / notify / log / vibe-code tax / garden party → `<subject> | SIXTOM`

Left untouched: `og:image:alt` / `twitter:image:alt` (image alt text describing the baked OG graphic, not titles).

`pnpm check`: 0 errors, 0 warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)