### PR TITLE
Hero: lead with the question; bright wedge line; 2x bubble drift

### DIFF
--- a/src/lib/components/Hero.svelte
+++ b/src/lib/components/Hero.svelte
@@ -21,23 +21,23 @@
 		></div>
 	</div>
 
-	<div class="relative mx-auto w-full max-w-6xl px-6 text-center">
-		<!-- One sentence per line, each fluid (vw) so it fills the width on mobile,
-		     clamped for desktop. Only "your solution." (the payoff) is bright. -->
-		<h1 class="text-fg-muted font-bold tracking-tight" data-hero style="--rise: 0ms">
-			<span class="block text-[clamp(1.25rem,7.1vw,4.5rem)] leading-[1.1]"
-				>AI built your first draft.</span
-			>
-			<span class="block text-[clamp(1.5rem,8.5vw,6.5rem)] leading-[1.02]"
-				>i build <span class="text-fg">your solution.</span></span
-			>
+	<div class="relative mx-auto w-full max-w-6xl px-6 text-left md:text-center">
+		<!-- Lead with the question as the hero title; the positioning line follows,
+		     bright and bold (the wedge, not a footnote), with "your solution" the
+		     emphasized payoff. -->
+		<h1
+			class="text-fg text-[clamp(2.25rem,9.5vw,4.75rem)] font-bold leading-[1.08] tracking-tight"
+			data-hero
+			style="--rise: 0ms"
+		>
+			what's the X between you and peace of mind?
 		</h1>
 		<p
-			class="text-fg mx-auto mt-8 max-w-2xl text-lg leading-relaxed md:text-2xl"
+			class="text-fg mx-auto mt-6 max-w-3xl text-xl font-medium leading-snug md:mt-8 md:text-3xl"
 			data-hero
 			style="--rise: 120ms"
 		>
-			what's the X between you<br />and peace of mind?
+			AI built your first draft. i build <span class="font-bold whitespace-nowrap">your solution.</span>
 		</p>
 		<div class="mt-12" data-hero style="--rise: 240ms">
 			<a

--- a/static/bubbles.js
+++ b/static/bubbles.js
@@ -13,7 +13,7 @@ const initBubbles = () => {
 	const DENSITY = 46 // grid cells across the short side (desktop)
 	const MOBILE_DENSITY = 32 // ~half the circle count on narrow screens (count ∝ density²)
 	const BLOBS = 4.5 // noise blobs across the short side — low → big contiguous blobs
-	const NDRIFT = 0.00012 // noise-units/ms the field scrolls (blobs "move through")
+	const NDRIFT = 0.00024 // noise-units/ms the field scrolls (blobs "move through")
 	const ALPHA_MAX = 0.85 // peak opacity at a blob's core; the CSS overlay fades left→right
 	const STATIC_FRAME = 3400 // reduced-motion: a representative mid-drift elapsed (ms)
 	const FPS = 20 // cap render rate — a slow ambient drift needs no more, keeps cost low


### PR DESCRIPTION
Restructures the hero around the question, per design iteration:

- **Lead with the question.** "what's the X between you and peace of mind?" is now the hero `<h1>` — it opens a loop that the "solve for X →" CTA closes.
- **The wedge is bright, not buried.** "AI built your first draft. i build **your solution.**" follows as a bright, bold positioning line (was a muted footnote), with "your solution." the emphasized payoff and kept unbreakable.
- **Mobile left, desktop center.** Fluid sizing fills the width on mobile; `max-w-3xl` keeps the wedge to one line on desktop.
- **2× bubble drift** (`NDRIFT` 0.00012 → 0.00024).

Verified mobile + desktop via emulated viewports. `pnpm check`: 0 errors. Presentational-only (no logic/data).

🤖 Generated with [Claude Code](https://claude.com/claude-code)