### PR TITLE
Hero: render the "X" as a logo-style chip; drop CTA arrow

### DIFF
--- a/src/lib/components/Hero.svelte
+++ b/src/lib/components/Hero.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { site } from '$lib/content'
+	import XMark from './XMark.svelte'
 </script>
 
 <section class="snap-section bg-surface relative">
@@ -30,7 +30,7 @@
 			data-hero
 			style="--rise: 0ms"
 		>
-			what's the X between you and peace of mind?
+			what's the <XMark class="bg-fg text-surface" /> between you and peace of mind?
 		</h1>
 		<p
 			class="text-fg mx-auto mt-6 max-w-3xl text-xl font-medium leading-snug md:mt-8 md:text-3xl"
@@ -45,7 +45,7 @@
 				data-umami-event="cta_hero_book"
 				class="block w-full rounded-full bg-coin px-8 py-4 text-center text-xl font-bold text-[#161616] transition hover:brightness-110 md:inline-block md:w-auto md:px-12 md:py-5 md:text-2xl"
 			>
-				{site.hero.ctaPrimary} →
+				solve for <XMark class="bg-[#161616] text-coin" />
 			</a>
 		</div>
 	</div>

--- a/src/lib/components/XMark.svelte
+++ b/src/lib/components/XMark.svelte
@@ -1,0 +1,13 @@
+<script lang="ts">
+	// Decorative "X" chip echoing the "to" mark in the sixtom logo: a square tile
+	// with a centered "X". Colours (bg + text) arrive via `class`. The tile is
+	// aria-hidden and a sr-only "X" carries the letter, so screen readers still
+	// read the surrounding sentence correctly. Pure markup — safe on the
+	// csr=false home page.
+	let { class: cls = '' }: { class?: string } = $props()
+</script>
+
+<span
+	class="mx-[0.08em] inline-flex aspect-square h-[1.05em] items-center justify-center rounded-[0.12em] align-middle {cls}"
+	aria-hidden="true"><span class="text-[0.95em] leading-none font-black">X</span></span
+><span class="sr-only">X</span>


### PR DESCRIPTION
The "X" in the hero now renders as a chip echoing the "to" mark in the sixtom logo — a square tile with a centered "X".

- **Question** ("what's the [X] between you and peace of mind?"): white tile, black X.
- **CTA** ("solve for [X]"): black tile, gold X; the "→" arrow is removed.

New `XMark.svelte` (colours passed via `class`). The tile is `aria-hidden` with a `sr-only` "X" so screen readers read the sentence and the CTA label unchanged. Pure markup — safe on the `csr=false` home page. Verified centered on mobile + desktop. `pnpm check`: 0 errors.

Note: the closing CTA on the home page (`btn-accent`, teal) still reads plain "solve for X →" — left as-is since its chip would need a teal-context colour; can follow up if you want it consistent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)