### PR TITLE
Hero: unify X chip — black bg, gold border + X, bigger in CTA

### DIFF
--- a/src/lib/components/Hero.svelte
+++ b/src/lib/components/Hero.svelte
@@ -30,7 +30,7 @@
 			data-hero
 			style="--rise: 0ms"
 		>
-			what's the <XMark class="bg-fg text-surface" /> between you and peace of mind?
+			what's the <XMark class="bg-[#161616] text-coin" /> between you and peace of mind?
 		</h1>
 		<p
 			class="text-fg mx-auto mt-6 max-w-3xl text-xl font-medium leading-snug md:mt-8 md:text-3xl"
@@ -45,7 +45,7 @@
 				data-umami-event="cta_hero_book"
 				class="block w-full rounded-full bg-coin px-8 py-4 text-center text-xl font-bold text-[#161616] transition hover:brightness-110 md:inline-block md:w-auto md:px-12 md:py-5 md:text-2xl"
 			>
-				solve for <XMark class="bg-[#161616] text-coin" />
+				solve for <XMark class="bg-[#161616] text-coin text-[1.35em]" />
 			</a>
 		</div>
 	</div>

--- a/src/lib/components/XMark.svelte
+++ b/src/lib/components/XMark.svelte
@@ -8,6 +8,6 @@
 </script>
 
 <span
-	class="mx-[0.08em] inline-flex aspect-square h-[1.05em] items-center justify-center rounded-[0.12em] align-middle {cls}"
+	class="mx-[0.08em] inline-flex aspect-square h-[1.25em] items-center justify-center border-2 border-current align-middle {cls}"
 	aria-hidden="true"><span class="text-[0.95em] leading-none font-black">X</span></span
 ><span class="sr-only">X</span>


### PR DESCRIPTION
Follow-up polish on the hero X chip:

- Both chips now identical: **black tile, gold "X", 2px gold border**, **square** (no rounded corners). Border uses `border-current` so it tracks the gold text colour.
- More padding around the glyph (tile `1.05em` → `1.25em`).
- CTA chip scaled up (`text-[1.35em]`) so the X reads larger inside the button.

Verified mobile + desktop. `pnpm check`: 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)