### PR TITLE
Hero: teal X chip (rounded) + teal-gradient CTA

### DIFF
--- a/src/lib/components/Hero.svelte
+++ b/src/lib/components/Hero.svelte
@@ -30,7 +30,7 @@
 			data-hero
 			style="--rise: 0ms"
 		>
-			what's the <XMark class="bg-[#161616] text-coin" /> between you and peace of mind?
+			what's the <XMark class="bg-[#161616] text-accent" /> between you and peace of mind?
 		</h1>
 		<p
 			class="text-fg mx-auto mt-6 max-w-3xl text-xl font-medium leading-snug md:mt-8 md:text-3xl"
@@ -45,7 +45,7 @@
 				data-umami-event="cta_hero_book"
 				class="block w-full rounded-full bg-coin px-8 py-4 text-center text-xl font-bold text-[#161616] transition hover:brightness-110 md:inline-block md:w-auto md:px-12 md:py-5 md:text-2xl"
 			>
-				solve for <XMark class="bg-[#161616] text-coin text-[1.35em]" />
+				solve for <XMark class="bg-[#161616] text-accent text-[1.35em]" />
 			</a>
 		</div>
 	</div>

--- a/src/lib/components/Hero.svelte
+++ b/src/lib/components/Hero.svelte
@@ -43,7 +43,7 @@
 			<a
 				href="/book"
 				data-umami-event="cta_hero_book"
-				class="block w-full rounded-full bg-coin px-8 py-4 text-center text-xl font-bold text-[#161616] transition hover:brightness-110 md:inline-block md:w-auto md:px-12 md:py-5 md:text-2xl"
+				class="btn-accent w-full px-8 py-4 text-center text-xl font-bold md:w-auto md:px-12 md:py-5 md:text-2xl"
 			>
 				solve for <XMark class="bg-[#161616] text-accent text-[1.35em]" />
 			</a>

--- a/src/lib/components/XMark.svelte
+++ b/src/lib/components/XMark.svelte
@@ -8,6 +8,6 @@
 </script>
 
 <span
-	class="mx-[0.08em] inline-flex aspect-square h-[1.25em] items-center justify-center border-2 border-current align-middle {cls}"
+	class="mx-[0.08em] inline-flex aspect-square h-[1.25em] items-center justify-center rounded-[0.2em] border-2 border-current align-middle {cls}"
 	aria-hidden="true"><span class="text-[0.95em] leading-none font-black">X</span></span
 ><span class="sr-only">X</span>


### PR DESCRIPTION
Hero polish, all teal:
- X chips switched from coin gold to the **teal accent** (`text-accent`; border tracks via `border-current`), in both the question and the CTA.
- Hero **CTA** swapped from coin gold to the shared **btn-accent teal gradient** (pill + on-accent text + hover-angle flair); full-width on mobile via `w-full md:w-auto`.
- X chip corners **rounded** (`rounded-[0.2em]`).

Verified mobile + desktop. `pnpm check`: 0 errors.