### PR TITLE
Hero/CTA: extract BookCta; closing CTA matches hero; gradient X

### DIFF
--- a/src/lib/components/BookCta.svelte
+++ b/src/lib/components/BookCta.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+	// The "solve for X" booking CTA — teal-gradient pill with the logo-style X
+	// chip. Used on the hero and the home page's closing section, so it lives in
+	// one place. `event` sets the analytics label; `class` adds per-placement
+	// tweaks (e.g. top margin). Pure markup — safe under csr=false.
+	import XMark from './XMark.svelte'
+
+	let { event, class: cls = '' }: { event: string; class?: string } = $props()
+</script>
+
+<a
+	href="/book"
+	data-umami-event={event}
+	class="btn-accent w-full px-8 py-4 text-center text-xl font-bold md:w-auto md:px-12 md:py-5 md:text-2xl {cls}"
+>
+	solve for <XMark class="bg-[#161616] text-accent text-[1.35em]" />
+</a>

--- a/src/lib/components/Hero.svelte
+++ b/src/lib/components/Hero.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import XMark from './XMark.svelte'
+	import BookCta from './BookCta.svelte'
 </script>
 
 <section class="snap-section bg-surface relative">
@@ -40,13 +41,7 @@
 			AI built your first draft. i build <span class="font-bold whitespace-nowrap">your solution.</span>
 		</p>
 		<div class="mt-12" data-hero style="--rise: 240ms">
-			<a
-				href="/book"
-				data-umami-event="cta_hero_book"
-				class="btn-accent w-full px-8 py-4 text-center text-xl font-bold md:w-auto md:px-12 md:py-5 md:text-2xl"
-			>
-				solve for <XMark class="bg-[#161616] text-accent text-[1.35em]" />
-			</a>
+			<BookCta event="cta_hero_book" />
 		</div>
 	</div>
 </section>

--- a/src/lib/components/XMark.svelte
+++ b/src/lib/components/XMark.svelte
@@ -9,5 +9,7 @@
 
 <span
 	class="mx-[0.08em] inline-flex aspect-square h-[1.25em] items-center justify-center rounded-[0.2em] border-2 border-current align-middle {cls}"
-	aria-hidden="true"><span class="text-[0.95em] leading-none font-black">X</span></span
-><span class="sr-only">X</span>
+	aria-hidden="true"><span
+		class="bg-[linear-gradient(95deg,oklch(72%_0.15_200),oklch(64%_0.16_178))] bg-clip-text text-[0.95em] leading-none font-black text-transparent"
+		>X</span
+	></span><span class="sr-only">X</span>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import Hero from '$lib/components/Hero.svelte'
+	import BookCta from '$lib/components/BookCta.svelte'
 	import SiteFooter from '$lib/components/SiteFooter.svelte'
 	import { site } from '$lib/content'
 
@@ -140,13 +141,7 @@
 				${site.audit.priceUSD.toLocaleString()} to look at what you've got. within a week: a written breakdown
 				plus a short video walkthrough. credited toward the sprint if you book one within 30 days.
 			</p>
-			<a
-				href="/book"
-				data-umami-event="cta_final_book"
-				class="btn-accent mt-12 inline-block px-8 py-4 text-lg hover:opacity-90"
-			>
-				{site.hero.ctaPrimary} →
-			</a>
+			<BookCta event="cta_final_book" class="mt-12" />
 		</div>
 	</div>
 	<SiteFooter />


### PR DESCRIPTION
- **One component.** New \`BookCta.svelte\` renders the "solve for X" booking CTA (teal-gradient pill + X chip). Both the hero and the home page's closing section use it (`event` + `class` props) — removes the duplicated anchor markup.
- **Bottom matches top.** The closing CTA is now identical to the hero CTA (size, full-width-on-mobile, bold), not the old smaller `text-lg` variant.
- **Gradient X.** The X glyph now carries the CTA's gradient (`linear-gradient(95deg, oklch(72% .15 200), oklch(64% .16 178))`) via `bg-clip-text`; teal border retained.

Verified hero + closing CTA on desktop. `pnpm check`: 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)