### PR TITLE
book: selected radio is a solid teal disc

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -117,6 +117,15 @@ input[type='checkbox'] {
 	accent-color: var(--color-accent);
 }
 
+/* Selected radio: a solid teal disc — no white center dot, no ring gap, filled
+ * all the way in. Overrides the @tailwindcss/forms checked dot (its background
+ * radial-gradient) with a flat teal fill + matching border. */
+input[type='radio']:checked {
+	background-image: none;
+	background-color: var(--color-accent);
+	border-color: var(--color-accent);
+}
+
 .snap-section {
 	scroll-snap-align: start;
 	min-height: 100svh;


### PR DESCRIPTION
Selected radios were rendering as a teal ring with a white center hole (the `@tailwindcss/forms` checked dot over the fill). Override the checked state to drop the dot and fill flat teal with a matching border — selected is now filled all the way in.

Verified on /book step 1. `pnpm check`: 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)