### PR TITLE
rl: fix broken umami test + drop dead ctaPrimary (UI sweep)

### DIFF
--- a/src/lib/components/umami-events.test.ts
+++ b/src/lib/components/umami-events.test.ts
@@ -37,10 +37,20 @@ describe('Umami CRO event instrumentation', () => {
 			// survives ternaries / snippet refactors.
 			const literalForm = `data-umami-event="${event}"`
 			const dynamicForm = new RegExp(`data-umami-event=\\{[^}]*['"]${event}['"]`)
-			const hit = contents.includes(literalForm) || dynamicForm.test(contents)
+			// CTAs may delegate rendering to <BookCta event="…">, which emits the
+			// data-umami-event attr; the owning file then pins the event string via
+			// the prop. Accept that form too (BookCta's wiring is pinned below).
+			const propForm = `event="${event}"`
+			const hit =
+				contents.includes(literalForm) || dynamicForm.test(contents) || contents.includes(propForm)
 			expect(hit, `${label} should reference "${event}" on a data-umami-event attr`).toBe(true)
 		})
 	}
+
+	it('BookCta wires data-umami-event to its event prop', () => {
+		const contents = readFileSync(resolve(COMPONENT_DIR, 'BookCta.svelte'), 'utf-8')
+		expect(contents).toContain('data-umami-event={event}')
+	})
 
 	it('fires "notify_signup_success" server-side from the notify action', () => {
 		const contents = readFileSync(resolve(ROUTES_DIR, 'notify/+page.server.ts'), 'utf-8')

--- a/src/lib/content/site.ts
+++ b/src/lib/content/site.ts
@@ -11,8 +11,7 @@ export const site: Site = {
 	thesisBody:
 		"AI gets you to a demo because the model can hold the whole thing in its head. once the codebase outgrows that window, the AI starts making it worse instead of better. that's the wall every vibe-coded project hits. it's also the thing i fix.",
 	hero: {
-		subhead: 'AI built your first draft. i build your solution.',
-		ctaPrimary: 'solve for X'
+		subhead: 'AI built your first draft. i build your solution.'
 	},
 	operator: {
 		name: "Sam D'Angelo",

--- a/src/lib/content/types.ts
+++ b/src/lib/content/types.ts
@@ -47,7 +47,6 @@ export interface Site {
 	thesisBody: string
 	hero: {
 		subhead: string
-		ctaPrimary: string
 	}
 	operator: Operator
 	audit: Offer


### PR DESCRIPTION
`/rl` sweep over the accumulated UI work (#96–#103), which had not been through the review loop. Two findings, both fixed:

1. **CI was red on `main`.** `umami-events.test.ts` has been failing since the BookCta extraction (#100) — it pins each CRO event to the file that fires it, but `cta_hero_book` / `cta_final_book` moved into `BookCta.svelte`. The events still fire (BookCta renders `data-umami-event={event}`); the test now accepts the `event="…"` prop form in the owning file **and** asserts BookCta wires the attribute. 26/26 tests green.
2. **Dead config removed.** `site.hero.ctaPrimary` was unreferenced after the CTA became `BookCta` — dropped from `site.ts` + the `Site` type.

`/rl clean: 3 rounds (security + 2 convergence), 2 findings addressed`. `pnpm check`: 0 errors; `pnpm vitest run`: 26 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)