### PR TITLE
perf/seo: cache static fonts + llms.txt markdown links

### DIFF
--- a/static/llms.txt
+++ b/static/llms.txt
@@ -28,9 +28,10 @@ You already built something — usually with AI assistance. It works for you. Re
 
 ## Who I am
 
-Sam D'Angelo. Lead engineer at Made In Cookware (multi-million visitors a month). Formerly at Rhone. Personal site / portfolio: https://threesam.com.
+Sam D'Angelo. Lead engineer at Made In Cookware (multi-million visitors a month). Formerly at Rhone. Personal site / portfolio: [threesam.com](https://threesam.com).
 
 ## How to engage
 
-- "Solve for X" — the booking form on the homepage at https://sixtom.com/book.
-- Notify list for the next open slot: https://sixtom.com/notify.
+- [Solve for X — book a call](https://sixtom.com/book): the qualifying booking form on the homepage. Start here if you know you want the sprint.
+- [The vibe-code tax calculator](https://sixtom.com/tax): a quick estimate of what the gap is costing you per year. No email.
+- [Notify list](https://sixtom.com/notify): get told when the next slot opens.

--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,17 @@
 {
 	"redirects": [
 		{ "source": "/log/garden-porty", "destination": "/log/garden-party", "permanent": true }
+	],
+	"headers": [
+		{
+			"source": "/fonts/(.*)",
+			"headers": [{ "key": "Cache-Control", "value": "public, max-age=31536000, immutable" }]
+		},
+		{
+			"source": "/bubbles.js",
+			"headers": [
+				{ "key": "Cache-Control", "value": "public, max-age=86400, stale-while-revalidate=604800" }
+			]
+		}
 	]
 }


### PR DESCRIPTION
Lighthouse round on a local prod build (mobile). Baseline was already **A11y 100 / Best Practices 100 / SEO 100**, CLS 0.01, LCP not flagged. Two real improvements:

**1. Agentic Browsing 67 → 100.** The `llms.txt` audit failed with "file does not appear to contain any links" — our URLs were bare, not markdown links. Converted the key URLs to `[text](url)` (and added the `/tax` calculator). Re-audit: **100 / 100 / 100 / 100, 0 failed.**

**2. Cache headers for static assets.** The only perf insight with real wasted bytes: `recursive.woff2` (23.8 kB), `space-grotesk.woff2` (22.6 kB), and `bubbles.js` (3.2 kB) all return `Cache-Control` TTL 0, so repeat visitors re-fetch/revalidate ~46 kB of fonts. Added `vercel.json` headers — `/fonts/*` immutable 1y (content-stable), `/bubbles.js` 1d + `stale-while-revalidate` (stable filename, content changes occasionally). (Hashed `_app/immutable` assets already cache correctly.)

Cache headers apply in prod only (vite preview ignores `vercel.json`); the llms.txt fix is verified locally. Build passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)