### PR TITLE
links: site-wide teal underline standard + why-me rework

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -129,6 +129,43 @@ input[type='radio']:checked {
 	border-color: var(--color-accent);
 }
 
+/* Text links: a teal underline tucked 4px under the text; on hover / focus /
+ * tap the whole link goes teal and the underline pulls in to 2px (400ms). It
+ * stays teal once visited (the offset can't animate for :visited — a browser
+ * privacy restriction — but the colour does). Buttons (.btn-accent) and the
+ * wordmark / card links (.no-link) opt out. */
+a:not(.btn-accent):not(.no-link) {
+	text-decoration-line: underline;
+	text-decoration-color: var(--color-accent);
+	text-decoration-thickness: 2px;
+	text-underline-offset: 4px;
+	transition:
+		color 400ms ease,
+		text-decoration-color 400ms ease,
+		text-underline-offset 400ms ease;
+}
+a:not(.btn-accent):not(.no-link):hover,
+a:not(.btn-accent):not(.no-link):focus-visible,
+a:not(.btn-accent):not(.no-link):active {
+	color: var(--color-accent);
+	text-underline-offset: 2px;
+}
+a:not(.btn-accent):not(.no-link):visited {
+	color: var(--color-accent);
+}
+
+/* Coin variant — the Garden (external personal work) gets a gold underline to
+ * set it apart from the teal content links; same offset/hover motion. */
+a.link-coin:not(.btn-accent):not(.no-link) {
+	text-decoration-color: var(--color-coin);
+}
+a.link-coin:not(.btn-accent):not(.no-link):hover,
+a.link-coin:not(.btn-accent):not(.no-link):focus-visible,
+a.link-coin:not(.btn-accent):not(.no-link):active,
+a.link-coin:not(.btn-accent):not(.no-link):visited {
+	color: var(--color-coin);
+}
+
 .snap-section {
 	scroll-snap-align: start;
 	min-height: 100svh;

--- a/src/lib/components/LogHero.svelte
+++ b/src/lib/components/LogHero.svelte
@@ -41,7 +41,7 @@
 	{id}
 	{href}
 	onclick={navigate}
-	class="log-hero-card relative block h-[35dvh] w-full overflow-hidden md:h-[45dvh]"
+	class="log-hero-card no-link relative block h-[35dvh] w-full overflow-hidden md:h-[45dvh]"
 	class:clickable
 	data-clickable={clickable}
 >

--- a/src/lib/components/SiteFooter.svelte
+++ b/src/lib/components/SiteFooter.svelte
@@ -11,7 +11,7 @@
 			href="/"
 			aria-label="sixtom home"
 			data-umami-event="footer_home"
-			class="text-fg inline-flex items-center text-2xl leading-none font-bold tracking-tight uppercase"
+			class="no-link text-fg inline-flex items-center text-2xl leading-none font-bold tracking-tight uppercase"
 		>
 			<span class="pr-0.5">six</span><span class="bg-fg text-surface px-px py-px">to</span><span
 				class="pl-px">m</span

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -116,24 +116,16 @@
 		<h2 class={h2Class}>why me?</h2>
 		<p class={bodyClass}>
 			day job: lead engineer at Made In Cookware. multi-million visitors a month. i rebuilt my own
-			creative work — the Garden — on the same methods. 5 hours of build time, 40% smaller, every
-			score up.
-		</p>
-		<p class="mt-6 flex flex-wrap gap-6 text-sm">
-			<a
+			creative work — <a
 				href={site.gardenUrl}
 				target="_blank"
 				rel="noopener noreferrer"
 				data-umami-event="cta_garden_link_why"
-				class="text-fg hover:text-coin transition-colors"
-			>
-				see the work →
-			</a>
-			<a
-				href="/log/garden-party"
-				data-umami-event="cta_case_study"
-				class="text-fg-muted hover:text-coin underline underline-offset-4 transition-colors"
-			>
+				class="link-coin">the Garden</a
+			> — on the same methods. 5 hours of build time, 40% smaller, every score up.
+		</p>
+		<p class="mt-6 text-sm">
+			<a href="/log/garden-party" data-umami-event="cta_case_study" class="text-fg-muted">
 				the writeup →
 			</a>
 		</p>


### PR DESCRIPTION
**Site-wide text-link treatment.** Teal underline at 4px offset; on hover / focus / tap the link goes all-teal and the underline pulls in to 2px (400ms). Stays teal once visited (color only — `:visited` can't animate `text-underline-offset`, a browser privacy restriction). Buttons (`.btn-accent`) and the wordmark / log-card links opt out via `.no-link`. Tap triggers the state via `:active`.

**Coin variant** (`.link-coin`): a gold underline for the Garden (external personal work), to distinguish it from teal content links.

**why-me rework**: dropped the standalone "see the work →" link; "the Garden" is now an inline coin link in the prose; "the writeup →" is the only standalone link. Both umami events (`cta_garden_link_why`, `cta_case_study`) preserved.

Verified: resting/hover computed styles, footer links (logo excluded), CTA excluded, why-me coin/teal. `pnpm check` 0 errors, 26 tests pass, prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)