### PR TITLE
links: drop arrows; footer threesam.com → coin

### DIFF
--- a/src/lib/components/SiteFooter.svelte
+++ b/src/lib/components/SiteFooter.svelte
@@ -28,9 +28,9 @@
 				target="_blank"
 				rel="noopener noreferrer"
 				data-umami-event="cta_garden_link"
-				class="text-fg hover:text-coin transition-colors"
+				class="text-fg link-coin"
 			>
-				threesam.com →
+				threesam.com
 			</a>
 		</div>
 	</div>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -89,7 +89,7 @@
 				data-umami-event="cta_tax_calc"
 				class="text-fg hover:text-coin text-base underline underline-offset-4 transition-colors md:text-lg"
 			>
-				run yours →
+				run yours
 			</a>
 		</p>
 	</div>
@@ -126,7 +126,7 @@
 		</p>
 		<p class="mt-6 text-sm">
 			<a href="/log/garden-party" data-umami-event="cta_case_study" class="text-fg-muted">
-				the writeup →
+				the writeup
 			</a>
 		</p>
 		<blockquote class="text-fg-muted mt-12 max-w-2xl text-base leading-relaxed italic md:text-lg">

--- a/src/routes/book/+page.svelte
+++ b/src/routes/book/+page.svelte
@@ -65,7 +65,7 @@
 				class="eyebrow text-fg-subtle hover:text-coin text-xs transition-colors"
 				data-umami-event="book_back_home"
 			>
-				← sixtom
+				sixtom
 			</a>
 			<h1 class="text-fg mt-12 text-4xl font-bold tracking-tight md:text-5xl">
 				let's see if we're a fit.
@@ -86,7 +86,7 @@
 							data-umami-event="book_disqualified_notify"
 							class="text-fg-subtle hover:text-coin text-xs tracking-widest uppercase transition-colors"
 						>
-							get notified when ready →
+							get notified when ready
 						</a>
 						<a
 							href="/book"
@@ -94,7 +94,7 @@
 							data-umami-event="book_disqualified_restart"
 							class="text-fg-subtle hover:text-coin text-xs tracking-widest uppercase transition-colors"
 						>
-							start over →
+							start over
 						</a>
 					</div>
 				</div>
@@ -110,7 +110,7 @@
 							target="_blank"
 							class="btn-accent mt-8 inline-block px-6 py-3 text-base hover:opacity-90"
 						>
-							book the call →
+							book the call
 						</a>
 					{/if}
 				</div>
@@ -129,7 +129,7 @@
 						data-umami-event="book_pre_build_notify"
 						class="text-fg-subtle hover:text-coin text-xs tracking-widest uppercase transition-colors"
 					>
-						get notified when ready →
+						get notified when ready
 					</a>
 					<button
 						type="button"
@@ -137,7 +137,7 @@
 						data-umami-event="book_pre_build_restart"
 						class="text-fg-subtle hover:text-coin text-left text-xs tracking-widest uppercase transition-colors"
 					>
-						i picked the wrong one →
+						i picked the wrong one
 					</button>
 				</div>
 			</div>

--- a/src/routes/log/+page.svelte
+++ b/src/routes/log/+page.svelte
@@ -56,7 +56,7 @@
 					href={`/log/${entry.slug}`}
 					class="text-fg-subtle hover:text-coin mt-3 inline-block text-xs tracking-widest uppercase transition-colors"
 				>
-					read →
+					read
 				</a>
 			</div>
 		</article>
@@ -72,7 +72,7 @@
 				class="eyebrow text-fg-subtle hover:text-coin text-xs transition-colors"
 				data-umami-event="log_back_home"
 			>
-				← sixtom
+				sixtom
 			</a>
 			<p class="eyebrow mt-12 text-sm">the log</p>
 			<h2 class="text-fg mt-2 text-4xl font-bold tracking-tight md:text-6xl">

--- a/src/routes/notify/+page.svelte
+++ b/src/routes/notify/+page.svelte
@@ -30,7 +30,7 @@
 			class="eyebrow text-fg-subtle hover:text-coin text-xs transition-colors"
 			data-umami-event="notify_back_home"
 		>
-			← sixtom
+			sixtom
 		</a>
 	</div>
 

--- a/src/routes/privacy/+page.svelte
+++ b/src/routes/privacy/+page.svelte
@@ -17,7 +17,7 @@
 				class="eyebrow text-fg-subtle hover:text-coin text-xs transition-colors"
 				data-umami-event="legal_back_home"
 			>
-				← sixtom
+				sixtom
 			</a>
 			<p class="eyebrow mt-12 text-sm">legal</p>
 			<h1 class="text-fg mt-2 text-4xl font-bold tracking-tight md:text-6xl">privacy.</h1>

--- a/src/routes/tax/+page.svelte
+++ b/src/routes/tax/+page.svelte
@@ -26,7 +26,7 @@
 			class="eyebrow text-fg-subtle hover:text-coin text-xs transition-colors"
 			data-umami-event="tax_back_home"
 		>
-			← sixtom
+			sixtom
 		</a>
 	</div>
 	<VibeTaxCalculator />

--- a/src/routes/terms/+page.svelte
+++ b/src/routes/terms/+page.svelte
@@ -17,7 +17,7 @@
 				class="eyebrow text-fg-subtle hover:text-coin text-xs transition-colors"
 				data-umami-event="legal_back_home"
 			>
-				← sixtom
+				sixtom
 			</a>
 			<p class="eyebrow mt-12 text-sm">legal</p>
 			<h1 class="text-fg mt-2 text-4xl font-bold tracking-tight md:text-6xl">terms.</h1>


### PR DESCRIPTION
Removes the decorative → / ← arrows from anchor links site-wide (the underline carries the affordance now). Form-flow buttons keep their arrows (`next →`, `← back`, `send it →`, `notify me →`). Footer `threesam.com` gets the coin underline to match the Garden (same destination). `pnpm check` 0 errors, 26 tests, prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)