### PR TITLE
links: text-decoration underline + secondary CTA + idiomatic TW

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -133,8 +133,9 @@ input[type='radio']:checked {
 
 /* Text links: a teal 2px bar 4px under the text, drawn as an absolutely
  * positioned ::after so it adds no box height — links stay aligned with the
- * text beside them. On hover / focus / tap the bar pulls in to 2px (400ms). The
- * text colour never changes; only the bar is coloured. Buttons (.btn-accent)
+ * text beside them. On hover / focus / tap the bar slides up from 4px to 2px
+ * below the text (400ms). The text colour never changes; only the bar is
+ * coloured. Buttons (.btn-accent)
  * and the wordmark / card links (.no-link) opt out; the coin variant (the
  * Garden / threesam.com) uses a gold bar. */
 a:not(.btn-accent):not(.no-link) {

--- a/src/app.css
+++ b/src/app.css
@@ -131,32 +131,26 @@ input[type='radio']:checked {
 	border-color: var(--color-accent);
 }
 
-/* Text links: a teal 2px bar 4px under the text, drawn as an absolutely
- * positioned ::after so it adds no box height — links stay aligned with the
- * text beside them. On hover / focus / tap the bar slides up from 4px to 2px
- * below the text (400ms). The text colour never changes; only the bar is
- * coloured. Buttons (.btn-accent)
- * and the wordmark / card links (.no-link) opt out; the coin variant (the
- * Garden / threesam.com) uses a gold bar. */
+/* Text links: a teal 2px underline tucked 4px below the text; on hover / focus
+ * / tap the underline slides up to 2px (400ms). text-underline-offset adds no
+ * box height (so links stay aligned with neighbouring text) and underlines each
+ * line fragment when a link wraps. The text colour never changes — only the
+ * underline is coloured. Buttons (.btn-accent) and the wordmark / card links
+ * (.no-link) opt out; the coin variant (the Garden / threesam.com) is gold. */
 a:not(.btn-accent):not(.no-link) {
-	position: relative;
+	text-decoration-line: underline;
+	text-decoration-color: var(--color-accent);
+	text-decoration-thickness: 2px;
+	text-underline-offset: 4px;
+	transition: text-underline-offset 400ms ease;
 }
-a:not(.btn-accent):not(.no-link)::after {
-	content: '';
-	position: absolute;
-	inset-inline: 0;
-	bottom: -4px;
-	height: 2px;
-	background-color: var(--color-accent);
-	transition: bottom 400ms ease;
+a:not(.btn-accent):not(.no-link):hover,
+a:not(.btn-accent):not(.no-link):focus-visible,
+a:not(.btn-accent):not(.no-link):active {
+	text-underline-offset: 2px;
 }
-a:not(.btn-accent):not(.no-link):hover::after,
-a:not(.btn-accent):not(.no-link):focus-visible::after,
-a:not(.btn-accent):not(.no-link):active::after {
-	bottom: -2px;
-}
-a.link-coin:not(.btn-accent):not(.no-link)::after {
-	background-color: var(--color-coin);
+a.link-coin:not(.btn-accent):not(.no-link) {
+	text-decoration-color: var(--color-coin);
 }
 
 .snap-section {

--- a/src/app.css
+++ b/src/app.css
@@ -142,7 +142,11 @@ a:not(.btn-accent):not(.no-link) {
 	text-decoration-color: var(--color-accent);
 	text-decoration-thickness: 2px;
 	text-underline-offset: 4px;
-	transition: text-underline-offset 400ms ease;
+	/* color is animated too so links that do recolor on hover (e.g. footer nav)
+	   still fade rather than snap; this rule itself never changes text colour. */
+	transition:
+		text-underline-offset 400ms ease,
+		color 150ms ease;
 }
 a:not(.btn-accent):not(.no-link):hover,
 a:not(.btn-accent):not(.no-link):focus-visible,

--- a/src/app.css
+++ b/src/app.css
@@ -41,6 +41,8 @@
 	--color-on-accent: oklch(14.5% 0 0);
 	--color-coin: #e8a317;
 	--color-error: oklch(71.2% 0.194 13.428);
+	/* Brand accent gradient (matches the .btn-accent fill); reused by the X chip. */
+	--gradient-accent: linear-gradient(95deg, oklch(72% 0.15 200), oklch(64% 0.16 178));
 }
 
 /* Blacklight effect: white surface, black text, neon accents fluoresce via shadow.
@@ -129,41 +131,31 @@ input[type='radio']:checked {
 	border-color: var(--color-accent);
 }
 
-/* Text links: a teal underline tucked 4px under the text; on hover / focus /
- * tap the whole link goes teal and the underline pulls in to 2px (400ms). It
- * stays teal once visited (the offset can't animate for :visited — a browser
- * privacy restriction — but the colour does). Buttons (.btn-accent) and the
- * wordmark / card links (.no-link) opt out. */
+/* Text links: a teal 2px bar 4px under the text, drawn as an absolutely
+ * positioned ::after so it adds no box height — links stay aligned with the
+ * text beside them. On hover / focus / tap the bar pulls in to 2px (400ms). The
+ * text colour never changes; only the bar is coloured. Buttons (.btn-accent)
+ * and the wordmark / card links (.no-link) opt out; the coin variant (the
+ * Garden / threesam.com) uses a gold bar. */
 a:not(.btn-accent):not(.no-link) {
-	text-decoration-line: underline;
-	text-decoration-color: var(--color-accent);
-	text-decoration-thickness: 2px;
-	text-underline-offset: 4px;
-	transition:
-		color 400ms ease,
-		text-decoration-color 400ms ease,
-		text-underline-offset 400ms ease;
+	position: relative;
 }
-a:not(.btn-accent):not(.no-link):hover,
-a:not(.btn-accent):not(.no-link):focus-visible,
-a:not(.btn-accent):not(.no-link):active {
-	color: var(--color-accent);
-	text-underline-offset: 2px;
+a:not(.btn-accent):not(.no-link)::after {
+	content: '';
+	position: absolute;
+	inset-inline: 0;
+	bottom: -4px;
+	height: 2px;
+	background-color: var(--color-accent);
+	transition: bottom 400ms ease;
 }
-a:not(.btn-accent):not(.no-link):visited {
-	color: var(--color-accent);
+a:not(.btn-accent):not(.no-link):hover::after,
+a:not(.btn-accent):not(.no-link):focus-visible::after,
+a:not(.btn-accent):not(.no-link):active::after {
+	bottom: -2px;
 }
-
-/* Coin variant — the Garden (external personal work) gets a gold underline to
- * set it apart from the teal content links; same offset/hover motion. */
-a.link-coin:not(.btn-accent):not(.no-link) {
-	text-decoration-color: var(--color-coin);
-}
-a.link-coin:not(.btn-accent):not(.no-link):hover,
-a.link-coin:not(.btn-accent):not(.no-link):focus-visible,
-a.link-coin:not(.btn-accent):not(.no-link):active,
-a.link-coin:not(.btn-accent):not(.no-link):visited {
-	color: var(--color-coin);
+a.link-coin:not(.btn-accent):not(.no-link)::after {
+	background-color: var(--color-coin);
 }
 
 .snap-section {

--- a/src/app.html
+++ b/src/app.html
@@ -47,7 +47,10 @@
 		<meta property="og:image" content="https://sixtom.com/og.png" />
 		<meta property="og:image:width" content="1200" />
 		<meta property="og:image:height" content="630" />
-		<meta property="og:image:alt" content="SIXTOM — AI built your first draft. I build your solution." />
+		<meta
+			property="og:image:alt"
+			content="SIXTOM — AI built your first draft. I build your solution."
+		/>
 
 		<meta name="twitter:card" content="summary_large_image" />
 		<meta name="twitter:title" content="SIXTOM — i build your solution." />
@@ -56,7 +59,10 @@
 			content="production-grade in two weeks. $10,000 flat, 1 client a month."
 		/>
 		<meta name="twitter:image" content="https://sixtom.com/og.png" />
-		<meta name="twitter:image:alt" content="SIXTOM — AI built your first draft. I build your solution." />
+		<meta
+			name="twitter:image:alt"
+			content="SIXTOM — AI built your first draft. I build your solution."
+		/>
 
 		<link rel="icon" href="%sveltekit.assets%/favicon.svg" type="image/svg+xml" />
 		<link rel="apple-touch-icon" sizes="180x180" href="%sveltekit.assets%/apple-touch-icon.png" />

--- a/src/lib/components/BookCta.svelte
+++ b/src/lib/components/BookCta.svelte
@@ -13,5 +13,5 @@
 	data-umami-event={event}
 	class="btn-accent w-full px-8 py-4 text-center text-xl font-bold md:w-auto md:px-12 md:py-5 md:text-2xl {cls}"
 >
-	solve for <XMark class="bg-[#161616] text-accent text-[1.35em]" />
+	solve for <XMark class="text-accent bg-surface text-[1.35em]" />
 </a>

--- a/src/lib/components/Hero.svelte
+++ b/src/lib/components/Hero.svelte
@@ -15,11 +15,9 @@
 	<div class="pointer-events-none absolute inset-0 overflow-hidden" aria-hidden="true">
 		<canvas data-bubble class="absolute inset-0 block h-full w-full"></canvas>
 		<div
-			class="absolute inset-0 bg-gradient-to-b from-[#0000005c] via-[#000000eb] to-[#00000080] md:hidden"
+			class="absolute inset-0 bg-gradient-to-b from-black/36 via-black/92 to-black/50 md:hidden"
 		></div>
-		<div
-			class="absolute inset-0 hidden bg-gradient-to-r from-[#000000d9] to-[#00000073] md:block"
-		></div>
+		<div class="absolute inset-0 hidden bg-gradient-to-r from-black/85 to-black/45 md:block"></div>
 	</div>
 
 	<div class="relative mx-auto w-full max-w-6xl px-6 text-left md:text-center">
@@ -27,20 +25,20 @@
 		     bright and bold (the wedge, not a footnote), with "your solution" the
 		     emphasized payoff. -->
 		<h1
-			class="text-fg text-[clamp(2.25rem,9.5vw,4.75rem)] font-bold leading-[1.08] tracking-tight"
+			class="text-fg text-[clamp(2.25rem,9.5vw,4.75rem)] leading-[1.08] font-bold tracking-tight [--rise:0ms]"
 			data-hero
-			style="--rise: 0ms"
 		>
-			what's the <XMark class="bg-[#161616] text-accent" /> between you and peace of mind?
+			what's the <XMark class="text-accent bg-surface" /> between you and peace of mind?
 		</h1>
 		<p
-			class="text-fg mx-auto mt-6 max-w-3xl text-xl font-medium leading-snug md:mt-8 md:text-3xl"
+			class="text-fg mx-auto mt-6 max-w-3xl text-xl leading-snug font-medium [--rise:120ms] md:mt-8 md:text-3xl"
 			data-hero
-			style="--rise: 120ms"
 		>
-			AI built your first draft. i build <span class="font-bold whitespace-nowrap">your solution.</span>
+			AI built your first draft. i build <span class="font-bold whitespace-nowrap"
+				>your solution.</span
+			>
 		</p>
-		<div class="mt-12" data-hero style="--rise: 240ms">
+		<div class="mt-12 [--rise:240ms]" data-hero>
 			<BookCta event="cta_hero_book" />
 		</div>
 	</div>

--- a/src/lib/components/VibeTaxCalculator.svelte
+++ b/src/lib/components/VibeTaxCalculator.svelte
@@ -55,7 +55,9 @@
 		<h2 class="text-fg mt-2 text-3xl font-bold tracking-tight md:text-5xl">
 			what's it costing you?
 		</h2>
-		<p class="text-fg-muted mt-4 text-base leading-relaxed">4 questions. instant number. no email.</p>
+		<p class="text-fg-muted mt-4 text-base leading-relaxed">
+			4 questions. instant number. no email.
+		</p>
 
 		<div class="mt-10 space-y-6">
 			<div class="grid gap-6 md:grid-cols-2">
@@ -98,8 +100,7 @@
 					step="1"
 					bind:value={firefightingHours}
 					aria-describedby="vt-hours-readout"
-					class="w-full accent-current"
-					style="color: var(--color-accent);"
+					class="accent-accent w-full"
 				/>
 				<p id="vt-hours-readout" class="text-fg-subtle mt-1 text-xs tabular-nums">
 					{safeHours} h/week
@@ -109,8 +110,16 @@
 			<fieldset class="space-y-3">
 				<legend class={labelClass}>where do you want to be in 90 days?</legend>
 				{#each GOAL_OPTIONS as opt (opt.value)}
-					<label class="{radioCardClass} {goal === opt.value ? 'border-accent ring-accent ring-1' : ''}">
-						<input type="radio" name="goal" value={opt.value} bind:group={goal} class="accent-accent" />
+					<label
+						class="{radioCardClass} {goal === opt.value ? 'border-accent ring-accent ring-1' : ''}"
+					>
+						<input
+							type="radio"
+							name="goal"
+							value={opt.value}
+							bind:group={goal}
+							class="accent-accent"
+						/>
 						<span class="text-fg text-base">{opt.label}</span>
 					</label>
 				{/each}

--- a/src/lib/components/XMark.svelte
+++ b/src/lib/components/XMark.svelte
@@ -9,7 +9,9 @@
 
 <span
 	class="mx-[0.08em] inline-flex aspect-square h-[1.25em] items-center justify-center rounded-[0.2em] border-2 border-current align-middle {cls}"
-	aria-hidden="true"><span
-		class="bg-[linear-gradient(95deg,oklch(72%_0.15_200),oklch(64%_0.16_178))] bg-clip-text text-[0.95em] leading-none font-black text-transparent"
+	aria-hidden="true"
+	><span
+		class="bg-[image:var(--gradient-accent)] bg-clip-text text-[0.95em] leading-none font-black text-transparent"
 		>X</span
-	></span><span class="sr-only">X</span>
+	></span
+><span class="sr-only">X</span>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -83,11 +83,11 @@
 		<p class="text-fg-muted mt-6 text-base leading-relaxed md:text-lg">
 			typical case: 1/mo × $50k × 12 = ~$600k/yr. plus the weekends. plus the sleep.
 		</p>
-		<p class="mt-6">
+		<p class="mt-10">
 			<a
 				href="/tax"
 				data-umami-event="cta_tax_calc"
-				class="text-fg hover:text-coin text-base underline underline-offset-4 transition-colors md:text-lg"
+				class="no-link border-fg text-fg hover:border-accent hover:bg-accent inline-block rounded-full border-2 px-8 py-3 text-lg font-bold transition-colors duration-[400ms] md:px-10 md:py-4 md:text-xl"
 			>
 				run yours
 			</a>


### PR DESCRIPTION
Reworks the link treatment and the /tax CTA, plus an idiomatic-Tailwind cleanup and a repo-wide prettier sweep.

- **Links**: a teal 2px underline 4px below the text → 2px on hover/focus/tap (400ms), via `text-decoration` + `text-underline-offset` (wrap-safe, no padding → no flex-row misalignment). **Text colour never changes** — only the underline is coloured. Coin variant (`.link-coin`) for the Garden / footer threesam.com.
- **"run yours" → secondary CTA**: black outline + black text; on hover the border and fill both go teal (400ms). Pill, slightly tighter than the primary CTA. Lives in the light `surface-uv` section, so `text-fg`/`border-fg` are dark → AA contrast on the teal fill.
- **Idiomatic TW / CSS vars**: removed inline `style=` from the active components (Hero `--rise` → `[--rise:*]` arbitrary props; calculator range → `accent-accent`), scrim hexes → `black/<opacity>`, X-chip tile → `bg-surface`, X gradient → `var(--gradient-accent)` (new token, matches `.btn-accent`).
- **prettier sweep**: fixes pre-existing format drift (`pnpm lint` = `prettier --check . && eslint .`).

`/rl`-clean: 3 rounds (security 0 · R1 3 · R2 1 · R3 0). `pnpm check` 0 errors, 26 tests, prettier clean.

Out of scope (flagged for a follow-up sweep): inline styles still in the `garden-party` blog post, `LogHero` (one is genuinely dynamic), and `MediaSlider`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)