### PR TITLE
book: trim budget question copy

### DIFF
--- a/src/routes/book/+page.svelte
+++ b/src/routes/book/+page.svelte
@@ -38,7 +38,7 @@
 		if (step > 1) step -= 1
 	}
 
-	const budgetQuestion = 'how much have you set aside for this?'
+	const budgetQuestion = 'how much have you set aside?'
 
 	const inputClass =
 		'border-border bg-surface text-fg placeholder:text-fg-subtle focus:border-accent focus:ring-accent w-full rounded-md border px-4 py-3 text-base focus:ring-2 focus:outline-none disabled:opacity-60'


### PR DESCRIPTION
Shortens the budget question (it was overextending) while keeping the 'set aside' committed-intent framing: "how much have you set aside for this?" → "how much have you set aside?". One const (`budgetQuestion`), used in the sr-only label + placeholder option. `pnpm check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)