### PR TITLE
ui: no hero intro stagger, X fade-in, CTA X borderless, /log inline writeups

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -165,22 +165,19 @@ a.link-coin:not(.btn-accent):not(.no-link) {
 	justify-content: center;
 }
 
-/* Staggered hero load reveal. Each [data-hero] element rises + fades in, offset
- * by its own --rise delay. Gated behind no-preference so reduced-motion users
- * (and the no-animation default) see the content immediately, fully visible. */
-@keyframes hero-rise {
+/* The X chips fade in on load — the one bit of intro motion (the page paints
+ * instantly otherwise). Gated behind no-preference; reduced-motion / no-anim
+ * default shows them immediately. */
+@keyframes x-fade {
 	from {
 		opacity: 0;
-		transform: translateY(0.75rem);
 	}
 	to {
 		opacity: 1;
-		transform: translateY(0);
 	}
 }
 @media (prefers-reduced-motion: no-preference) {
-	[data-hero] {
-		animation: hero-rise 0.65s cubic-bezier(0.22, 0.61, 0.36, 1) both;
-		animation-delay: var(--rise, 0ms);
+	[data-x-fade] {
+		animation: x-fade 0.6s ease-out both;
 	}
 }

--- a/src/lib/components/Hero.svelte
+++ b/src/lib/components/Hero.svelte
@@ -24,21 +24,16 @@
 		<!-- Lead with the question as the hero title; the positioning line follows,
 		     bright and bold (the wedge, not a footnote), with "your solution" the
 		     emphasized payoff. -->
-		<h1
-			class="text-fg text-[clamp(2.25rem,9.5vw,4.75rem)] leading-[1.08] font-bold tracking-tight [--rise:0ms]"
-			data-hero
-		>
-			what's the <XMark class="text-accent bg-surface" /> between you and peace of mind?
+		<h1 class="text-fg text-[clamp(2.25rem,9.5vw,4.75rem)] leading-[1.08] font-bold tracking-tight">
+			what's the <XMark class="text-accent bg-surface border-2 border-current" /> between you and peace
+			of mind?
 		</h1>
-		<p
-			class="text-fg mx-auto mt-6 max-w-3xl text-xl leading-snug font-medium [--rise:120ms] md:mt-8 md:text-3xl"
-			data-hero
-		>
+		<p class="text-fg mx-auto mt-6 max-w-3xl text-xl leading-snug font-medium md:mt-8 md:text-3xl">
 			AI built your first draft. i build <span class="font-bold whitespace-nowrap"
 				>your solution.</span
 			>
 		</p>
-		<div class="mt-12 [--rise:240ms]" data-hero>
+		<div class="mt-12">
 			<BookCta event="cta_hero_book" />
 		</div>
 	</div>

--- a/src/lib/components/XMark.svelte
+++ b/src/lib/components/XMark.svelte
@@ -1,14 +1,16 @@
 <script lang="ts">
 	// Decorative "X" chip echoing the "to" mark in the sixtom logo: a square tile
-	// with a centered "X". Colours (bg + text) arrive via `class`. The tile is
-	// aria-hidden and a sr-only "X" carries the letter, so screen readers still
-	// read the surrounding sentence correctly. Pure markup — safe on the
-	// csr=false home page.
+	// with a centered "X" that fades in on load. Colours (bg + text) and the
+	// border (border-2 border-current — used on the hero h1, omitted on the CTAs)
+	// arrive via `class`. The tile is aria-hidden and a sr-only "X" carries the
+	// letter, so screen readers still read the surrounding sentence correctly.
+	// Pure markup — safe on the csr=false home page.
 	let { class: cls = '' }: { class?: string } = $props()
 </script>
 
 <span
-	class="mx-[0.08em] inline-flex aspect-square h-[1.25em] items-center justify-center rounded-[0.2em] border-2 border-current align-middle {cls}"
+	data-x-fade
+	class="mx-[0.08em] inline-flex aspect-square h-[1.25em] items-center justify-center rounded-[0.2em] align-middle {cls}"
 	aria-hidden="true"
 	><span
 		class="bg-[image:var(--gradient-accent)] bg-clip-text text-[0.95em] leading-none font-black text-transparent"

--- a/src/routes/log/+page.svelte
+++ b/src/routes/log/+page.svelte
@@ -1,20 +1,43 @@
 <script lang="ts">
 	import type { PageData } from './$types'
 	import { site } from '$lib/content'
-	import LogHero from '$lib/components/LogHero.svelte'
-	import { LOG_ENTRIES } from '$lib/log'
+	import { LOG_ENTRIES, type LogEntry } from '$lib/log'
 
 	let { data }: { data: PageData } = $props()
 
+	// UTC so a calendar date like "2026-05-18" (parsed as UTC midnight) isn't
+	// rolled back a day when formatted in a behind-UTC local timezone.
 	const dateFmt = new Intl.DateTimeFormat('en-US', {
 		year: 'numeric',
 		month: 'long',
-		day: 'numeric'
+		day: 'numeric',
+		timeZone: 'UTC'
 	})
 	function formatDate(iso: string | null): string {
 		if (!iso) return ''
 		return dateFmt.format(new Date(iso))
 	}
+
+	// One timeline: LinkedIn posts + log writeups, pinned first then newest-first.
+	// A writeup (e.g. the garden-party case study) slots in on its publish date
+	// like any other entry instead of sitting in a separate hero section.
+	type PostItem = PageData['posts'][number]
+	type FeedItem =
+		| { kind: 'post'; date: string | null; pinned: boolean; post: PostItem }
+		| { kind: 'writeup'; date: string; pinned: false; entry: LogEntry }
+	const feed: FeedItem[] = $derived(
+		[
+			...data.posts.map(
+				(post): FeedItem => ({ kind: 'post', date: post.publishedAt, pinned: post.pinned, post })
+			),
+			...LOG_ENTRIES.map(
+				(entry): FeedItem => ({ kind: 'writeup', date: entry.date, pinned: false, entry })
+			)
+		].sort((a, b) => {
+			if (a.pinned !== b.pinned) return a.pinned ? -1 : 1
+			return (b.date ?? '').localeCompare(a.date ?? '')
+		})
+	)
 </script>
 
 <svelte:head>
@@ -30,40 +53,8 @@
 	/>
 	<meta property="og:url" content={`${site.siteUrl}/log`} />
 	<meta property="og:type" content="website" />
-	{#if LOG_ENTRIES[0]}
-		<link rel="preload" as="image" href={LOG_ENTRIES[0].heroImage} />
-	{/if}
 </svelte:head>
 
-<!-- case studies -->
-<div class="bg-surface">
-	{#each LOG_ENTRIES as entry (entry.slug)}
-		<article class="mx-auto mb-12 w-full max-w-3xl px-6 pt-12 md:mb-20 md:pt-20">
-			<div class="overflow-hidden rounded-lg">
-				<LogHero
-					id={entry.slug}
-					href={`/log/${entry.slug}`}
-					title={entry.title}
-					eyebrow={entry.eyebrow}
-					heroImage={entry.heroImage}
-					clickable={true}
-					headingLevel={2}
-				/>
-			</div>
-			<div class="py-6 md:py-8">
-				<p class="text-fg-muted text-base leading-relaxed md:text-lg">{entry.blurb}</p>
-				<a
-					href={`/log/${entry.slug}`}
-					class="text-fg-subtle hover:text-coin mt-3 inline-block text-xs tracking-widest uppercase transition-colors"
-				>
-					read
-				</a>
-			</div>
-		</article>
-	{/each}
-</div>
-
-<!-- linkedin feed -->
 <div class="bg-surface min-h-screen">
 	<div class="mx-auto w-full max-w-3xl px-6 py-20">
 		<header class="mb-20">
@@ -83,54 +74,94 @@
 			</p>
 		</header>
 
-		{#if data.posts.length === 0}
+		{#if feed.length === 0}
 			<p class="text-fg-subtle text-base">No posts yet. Check back soon.</p>
 		{:else}
 			<ul class="m-0 list-none p-0">
-				{#each data.posts as post (post.id)}
+				{#each feed as item (item.kind === 'post' ? `p${item.post.id}` : `w-${item.entry.slug}`)}
 					<li class="border-border border-t py-10">
-						<article>
-							<div class="flex items-center gap-3">
-								{#if post.publishedAt}
+						{#if item.kind === 'post'}
+							<article>
+								<div class="flex items-center gap-3">
+									{#if item.post.publishedAt}
+										<time
+											datetime={item.post.publishedAt}
+											class="text-fg-subtle text-xs tracking-widest uppercase"
+										>
+											{formatDate(item.post.publishedAt)}
+										</time>
+									{/if}
+									{#if item.post.pinned}
+										<span class="text-coin text-xs tracking-widest uppercase">pinned</span>
+									{/if}
+									{#if item.post.linkedinPermalink}
+										<a
+											href={item.post.linkedinPermalink}
+											target="_blank"
+											rel="noopener noreferrer"
+											data-umami-event="log_entry_visit_linkedin"
+											aria-label="View on LinkedIn"
+											class="no-link text-fg-subtle hover:text-coin -m-2 ml-auto inline-flex p-2 transition-colors"
+										>
+											<svg
+												class="h-4 w-4"
+												viewBox="0 0 24 24"
+												fill="currentColor"
+												aria-hidden="true"
+											>
+												<path
+													d="M20.45 20.45h-3.56v-5.57c0-1.33-.02-3.04-1.85-3.04-1.85 0-2.13 1.45-2.13 2.94v5.67H9.35V9h3.41v1.56h.05c.48-.9 1.64-1.85 3.38-1.85 3.62 0 4.29 2.38 4.29 5.48v6.26zM5.34 7.43c-1.14 0-2.07-.93-2.07-2.07s.93-2.07 2.07-2.07 2.07.93 2.07 2.07-.93 2.07-2.07 2.07zm1.78 13.02H3.56V9h3.56v11.45zM22.22 0H1.77C.79 0 0 .77 0 1.72v20.56C0 23.23.79 24 1.77 24h20.45c.98 0 1.78-.77 1.78-1.72V1.72C24 .77 23.2 0 22.22 0z"
+												/>
+											</svg>
+										</a>
+									{/if}
+								</div>
+								<p class="text-fg mt-4 text-base leading-relaxed break-words whitespace-pre-wrap">
+									{item.post.text}
+								</p>
+								{#if item.post.imageUrl}
+									<img
+										src={item.post.imageUrl}
+										alt=""
+										loading="lazy"
+										class="border-border mt-6 rounded-lg border"
+									/>
+								{/if}
+							</article>
+						{:else}
+							<article>
+								<div class="flex items-center gap-3">
 									<time
-										datetime={post.publishedAt}
+										datetime={item.entry.date}
 										class="text-fg-subtle text-xs tracking-widest uppercase"
 									>
-										{formatDate(post.publishedAt)}
+										{formatDate(item.entry.date)}
 									</time>
-								{/if}
-								{#if post.pinned}
-									<span class="text-coin text-xs tracking-widest uppercase">pinned</span>
-								{/if}
-								{#if post.linkedinPermalink}
-									<a
-										href={post.linkedinPermalink}
-										target="_blank"
-										rel="noopener noreferrer"
-										data-umami-event="log_entry_visit_linkedin"
-										aria-label="View on LinkedIn"
-										class="text-fg-subtle hover:text-coin -m-2 ml-auto inline-flex p-2 transition-colors"
-									>
-										<svg class="h-4 w-4" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
-											<path
-												d="M20.45 20.45h-3.56v-5.57c0-1.33-.02-3.04-1.85-3.04-1.85 0-2.13 1.45-2.13 2.94v5.67H9.35V9h3.41v1.56h.05c.48-.9 1.64-1.85 3.38-1.85 3.62 0 4.29 2.38 4.29 5.48v6.26zM5.34 7.43c-1.14 0-2.07-.93-2.07-2.07s.93-2.07 2.07-2.07 2.07.93 2.07 2.07-.93 2.07-2.07 2.07zm1.78 13.02H3.56V9h3.56v11.45zM22.22 0H1.77C.79 0 0 .77 0 1.72v20.56C0 23.23.79 24 1.77 24h20.45c.98 0 1.78-.77 1.78-1.72V1.72C24 .77 23.2 0 22.22 0z"
-											/>
-										</svg>
-									</a>
-								{/if}
-							</div>
-							<p class="text-fg mt-4 text-base leading-relaxed break-words whitespace-pre-wrap">
-								{post.text}
-							</p>
-							{#if post.imageUrl}
+									<span class="text-coin text-xs tracking-widest uppercase">writeup</span>
+								</div>
+								<a
+									href={`/log/${item.entry.slug}`}
+									data-umami-event="log_writeup_visit"
+									class="no-link text-fg hover:text-coin mt-4 block text-2xl font-bold tracking-tight transition-colors"
+								>
+									{item.entry.title}
+								</a>
+								<p class="text-fg-muted mt-3 text-base leading-relaxed">{item.entry.blurb}</p>
 								<img
-									src={post.imageUrl}
+									src={item.entry.heroImage}
 									alt=""
 									loading="lazy"
 									class="border-border mt-6 rounded-lg border"
 								/>
-							{/if}
-						</article>
+								<a
+									href={`/log/${item.entry.slug}`}
+									data-umami-event="log_writeup_read"
+									class="text-fg-subtle hover:text-coin mt-4 inline-block text-xs tracking-widest uppercase transition-colors"
+								>
+									read
+								</a>
+							</article>
+						{/if}
 					</li>
 				{/each}
 			</ul>


### PR DESCRIPTION
- **Kill intro animations:** removed the `[data-hero]` rise/fade stagger so the hero paints instantly.
- **Fade X's in on load:** the X chips now fade in (the one bit of intro motion; reduced-motion gated).
- **X border, CTA-only off:** border kept on the hero h1 chip, dropped on the CTA chips (now opt-in via class).
- **/log:** the garden-party writeup is merged into the LinkedIn timeline on its post date (no separate hero section); a `$derived` feed (post | writeup union), pinned-first then date-desc. Dates format in **UTC** so a calendar date (`2026-05-18`) isn't rolled back a day (caught a "May 17" bug in review).

`/rl`-clean (3 rounds, 0 fixes; 2 accepted non-defect nuances noted). `pnpm check` 0/0, 26 tests, prettier clean.

Follow-ups (out of scope): `LogEntry.eyebrow` is now a dead field; same-day writeup-vs-post ordering is date-level only (moot until LinkedIn posts exist).

🤖 Generated with [Claude Code](https://claude.com/claude-code)