### PR TITLE
log: hide posts superseded by a relaunch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ vite.config.ts.timestamp-*
 /playwright/.cache/
 /.playwright-mcp/
 /*.png
+.env*.local

--- a/src/routes/log/+page.server.ts
+++ b/src/routes/log/+page.server.ts
@@ -18,7 +18,11 @@ interface RawPost {
 	publishedAt: string | null
 	linkedinPermalink: string | null
 	imageUrl: string | null
-	meta: { pinned?: boolean } | null
+	// `relaunch_of` points at the post this one replaces — the studio writes it
+	// when a post is rewritten (e.g. to clear a profanity flag) and the original
+	// stays `status:"published"` in the engine. We use it below to hide the
+	// superseded one so /log shows only the live version.
+	meta: { pinned?: boolean; relaunch_of?: number } | null
 }
 
 // Strip anything that isn't a plain https:// URL — defense against a future
@@ -33,8 +37,8 @@ function safeHttpsUrl(url: string | null): string | null {
 }
 
 export const load: PageServerLoad = async ({ fetch }) => {
-	const origin = env['CONTENT_ENGINE_URL']
-	const token = env['STUDIO_TOKEN']
+	const origin = env.CONTENT_ENGINE_URL
+	const token = env.STUDIO_TOKEN
 	if (!origin || !token) {
 		console.warn('[/log] CONTENT_ENGINE_URL or STUDIO_TOKEN missing; rendering empty feed')
 		return { posts: [] }
@@ -49,14 +53,24 @@ export const load: PageServerLoad = async ({ fetch }) => {
 			return { posts: [] }
 		}
 		const body = (await res.json()) as { posts: RawPost[] }
-		const posts: LogPost[] = body.posts.map((p) => ({
-			id: p.id,
-			text: p.text,
-			publishedAt: p.publishedAt,
-			linkedinPermalink: safeHttpsUrl(p.linkedinPermalink),
-			imageUrl: safeHttpsUrl(p.imageUrl),
-			pinned: Boolean(p.meta?.pinned)
-		}))
+		// Hide posts that have been superseded by a relaunch (the engine keeps the
+		// original `status:"published"` and writes `meta.relaunch_of:<id>` on the
+		// replacement). Self-references are ignored defensively.
+		const supersededIds = new Set<number>(
+			body.posts
+				.map((p) => (p.meta?.relaunch_of !== p.id ? p.meta?.relaunch_of : undefined))
+				.filter((id): id is number => typeof id === 'number')
+		)
+		const posts: LogPost[] = body.posts
+			.filter((p) => !supersededIds.has(p.id))
+			.map((p) => ({
+				id: p.id,
+				text: p.text,
+				publishedAt: p.publishedAt,
+				linkedinPermalink: safeHttpsUrl(p.linkedinPermalink),
+				imageUrl: safeHttpsUrl(p.imageUrl),
+				pinned: Boolean(p.meta?.pinned)
+			}))
 		posts.sort((a, b) => {
 			if (a.pinned !== b.pinned) return a.pinned ? -1 : 1
 			return (b.publishedAt ?? '').localeCompare(a.publishedAt ?? '')


### PR DESCRIPTION
## Summary
`/log` was showing both versions of a relaunched post (e.g. the "shitty exchange rate" v1 and the "garbage exchange rate" v2). The engine keeps the original at \`status:"published"\` when a replacement is published — the replacement just gets \`meta.relaunch_of:<original-id>\`. We now compute the set of relaunched IDs from the response and drop them before mapping.

Self-references defended against (\`meta.relaunch_of === p.id\` is ignored). Also fixes pre-existing dot-notation lint on \`env['…']\`.

## Test plan
- [x] \`pnpm check\` 0 / \`lint\` green / \`test\` 31 pass
- [x] Live verify: with the local dev server pointed at the prod engine, \`/log\` no longer contains "shitty exchange" (#19) and still contains "garbage exchange" (#24); 13 items rendered (12 posts + 1 writeup, vs 14 before)

🤖 Generated with [Claude Code](https://claude.com/claude-code)