### PR TITLE
fix(build): add /faq to prerender.entries

### DIFF
--- a/svelte.config.js
+++ b/svelte.config.js
@@ -9,7 +9,7 @@ export default {
 		adapter: adapter(),
 		// Root-absolute asset URLs so nested-route HTML resolves /_app/... correctly.
 		paths: { relative: false },
-		prerender: { entries: ['/sanity', '/sitemap.xml', '/privacy', '/terms', '/tax'] }
+		prerender: { entries: ['/sanity', '/sitemap.xml', '/privacy', '/terms', '/tax', '/faq'] }
 		// inlineStyleThreshold removed: nested routes with <svelte:head> had the
 		// SSR-injected inline <style> block wiped during hydration while the
 		// fallback <link> stayed disabled, leaving the page unstyled.


### PR DESCRIPTION
## Why
Every Vercel build since #116 (2026-05-28) has errored:
\`\`\`
Error: The following routes were marked as prerenderable, but were not prerendered
because they were not found while crawling your app:
  - /faq
\`\`\`
\`/privacy\`, \`/terms\`, \`/tax\` are already in \`prerender.entries\` for the same reason — the SvelteKit crawler doesn't auto-discover them via footer links. \`/faq\` was missed in #116.

## Fix
Add \`/faq\` to the entries array. One line.

## Test plan
- [x] \`pnpm check\` 0 errors
- [x] \`pnpm build\` — no prerender error, build succeeds locally (was failing with the same Vercel error)

🤖 Generated with [Claude Code](https://claude.com/claude-code)