### PR TITLE
seo: weekly GSC triage cron (scaffold)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,3 +20,17 @@ CAL_USERNAME=""
 # CONTENT_ENGINE_URL is the public origin; STUDIO_TOKEN is the bearer.
 CONTENT_ENGINE_URL="https://studio.sixtom.com"
 STUDIO_TOKEN=""
+
+# Weekly SEO triage cron (/api/seo-triage). Verified GSC property URL, e.g. "https://sixtom.com/".
+GSC_SITE_URL=""
+# Google OAuth 2.0 client for the Search Console API (Desktop type). Refresh
+# token is minted once via `node scripts/gsc-oauth-bootstrap.mjs`.
+GSC_OAUTH_CLIENT_ID=""
+GSC_OAUTH_CLIENT_SECRET=""
+GSC_OAUTH_REFRESH_TOKEN=""
+# Shared secret Vercel cron sends as `Authorization: Bearer ...`. Generate with
+# `openssl rand -hex 32` and set the same value in Vercel project env.
+CRON_SECRET=""
+# Optional override for Vercel AI Gateway auth. Defaults to VERCEL_OIDC_TOKEN
+# inside the function runtime — only set this if running outside Vercel.
+AI_GATEWAY_API_KEY=""

--- a/scripts/gsc-oauth-bootstrap.mjs
+++ b/scripts/gsc-oauth-bootstrap.mjs
@@ -1,0 +1,91 @@
+// One-shot CLI to mint a Google OAuth refresh token for the GSC API.
+//
+// Prereqs (one-time):
+//   1. Google Cloud project + enable the "Google Search Console API".
+//   2. Create an OAuth 2.0 Client ID — type "Desktop app" — and add
+//      http://localhost:8420 as an authorized redirect URI.
+//   3. Export the ID + secret in your shell:
+//        export GSC_OAUTH_CLIENT_ID=...
+//        export GSC_OAUTH_CLIENT_SECRET=...
+//
+// Then:
+//   node scripts/gsc-oauth-bootstrap.mjs
+//
+// It launches a local HTTP server, opens the consent screen in your browser,
+// captures the redirect code, exchanges it for a refresh token, and prints
+// the refresh token to stdout. Paste that into Vercel as:
+//   GSC_OAUTH_REFRESH_TOKEN
+// Nothing is written to disk.
+import { createServer } from 'node:http'
+import { spawn } from 'node:child_process'
+
+const PORT = 8420
+const REDIRECT = `http://localhost:${String(PORT)}`
+const SCOPE = 'https://www.googleapis.com/auth/webmasters.readonly'
+
+const clientId = process.env.GSC_OAUTH_CLIENT_ID
+const clientSecret = process.env.GSC_OAUTH_CLIENT_SECRET
+if (!clientId || !clientSecret) {
+	console.error('Set GSC_OAUTH_CLIENT_ID and GSC_OAUTH_CLIENT_SECRET in your shell first.')
+	process.exit(1)
+}
+
+const authUrl = new URL('https://accounts.google.com/o/oauth2/v2/auth')
+authUrl.searchParams.set('client_id', clientId)
+authUrl.searchParams.set('redirect_uri', REDIRECT)
+authUrl.searchParams.set('response_type', 'code')
+authUrl.searchParams.set('scope', SCOPE)
+authUrl.searchParams.set('access_type', 'offline')
+authUrl.searchParams.set('prompt', 'consent')
+
+const code = await new Promise((resolve, reject) => {
+	const server = createServer((req, res) => {
+		const url = new URL(req.url ?? '/', REDIRECT)
+		const c = url.searchParams.get('code')
+		const error = url.searchParams.get('error')
+		if (error) {
+			res.writeHead(400, { 'Content-Type': 'text/plain' })
+			res.end(`OAuth error: ${error}`)
+			server.close()
+			reject(new Error(error))
+		} else if (c) {
+			res.writeHead(200, { 'Content-Type': 'text/plain' })
+			res.end('Got it. You can close this tab.')
+			server.close()
+			resolve(c)
+		} else {
+			res.writeHead(404)
+			res.end()
+		}
+	})
+	server.listen(PORT, () => {
+		console.log(`Listening on ${REDIRECT}; opening browser…`)
+		const opener =
+			process.platform === 'darwin' ? 'open' : process.platform === 'win32' ? 'start' : 'xdg-open'
+		spawn(opener, [authUrl.toString()], { stdio: 'ignore', detached: true }).unref()
+	})
+})
+
+const tokenRes = await fetch('https://oauth2.googleapis.com/token', {
+	method: 'POST',
+	headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+	body: new URLSearchParams({
+		code,
+		client_id: clientId,
+		client_secret: clientSecret,
+		redirect_uri: REDIRECT,
+		grant_type: 'authorization_code'
+	})
+})
+if (!tokenRes.ok) {
+	console.error('Token exchange failed:', tokenRes.status, (await tokenRes.text()).slice(0, 300))
+	process.exit(1)
+}
+const tokens = await tokenRes.json()
+if (!tokens.refresh_token) {
+	console.error('No refresh_token in response — likely already authorized for this app.')
+	console.error('Revoke at https://myaccount.google.com/permissions and re-run.')
+	process.exit(1)
+}
+console.log('\nRefresh token (paste into Vercel env as GSC_OAUTH_REFRESH_TOKEN):\n')
+console.log(tokens.refresh_token)

--- a/src/lib/server/gsc-triage.test.ts
+++ b/src/lib/server/gsc-triage.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from 'vitest'
+import { computeBuckets, type GscRow } from './gsc-triage'
+
+const row = (keys: string[], position: number, impressions: number, clicks: number): GscRow => ({
+	keys,
+	position,
+	impressions,
+	clicks,
+	ctr: impressions > 0 ? clicks / impressions : 0
+})
+
+describe('computeBuckets', () => {
+	it('puts position 11–20 queries in pageTwoClimbers, sorted by impressions desc', () => {
+		const rows = [
+			row(['low impr p15'], 15, 50, 1),
+			row(['high impr p12'], 12, 500, 5),
+			row(['p10 not a climber'], 10, 100, 10),
+			row(['p21 page 3'], 21, 200, 0)
+		]
+		const { pageTwoClimbers } = computeBuckets(rows, new Set())
+		expect(pageTwoClimbers.map((r) => r.keys[0])).toEqual(['high impr p12', 'low impr p15'])
+	})
+
+	it('identifies top-10 queries with below-median CTR, excluding zero-impression noise', () => {
+		const rows = [
+			row(['p3 ctr 50%'], 3, 100, 50),
+			row(['p5 ctr 10%'], 5, 100, 10),
+			row(['p7 ctr 1%'], 7, 100, 1),
+			row(['p2 ctr 80%'], 2, 100, 80),
+			row(['zero impr'], 4, 0, 0)
+		]
+		const keys = computeBuckets(rows, new Set()).lowCtrTopTen.map((r) => r.keys[0])
+		expect(keys).toContain('p7 ctr 1%')
+		expect(keys).toContain('p5 ctr 10%')
+		expect(keys).not.toContain('p2 ctr 80%')
+		expect(keys).not.toContain('zero impr')
+	})
+
+	it('flags queries whose tokens do not overlap with known titles', () => {
+		const known = new Set(['sixtom', 'audit', 'sprint'])
+		const rows = [
+			row(['vibe coding production'], 8, 100, 5), // no overlap → off-target
+			row(['sixtom audit pricing'], 5, 100, 10), // overlap on sixtom + audit
+			row(['kubernetes deploy'], 25, 100, 0), // no overlap → off-target, pos 25 ok
+			row(['x'], 12, 100, 0) // x is below TOKEN_MIN, treated as no tokens → off-target
+		]
+		const keys = computeBuckets(rows, known).offTargetQueries.map((r) => r.keys[0])
+		expect(keys).toContain('vibe coding production')
+		expect(keys).toContain('kubernetes deploy')
+		expect(keys).not.toContain('sixtom audit pricing')
+	})
+
+	it('off-target excludes very-low-impression noise (<5)', () => {
+		const known = new Set<string>()
+		const rows = [
+			row(['rare query'], 15, 4, 0), // below 5-impr floor
+			row(['real query'], 15, 5, 0) // meets 5-impr floor
+		]
+		const keys = computeBuckets(rows, known).offTargetQueries.map((r) => r.keys[0])
+		expect(keys).toEqual(['real query'])
+	})
+
+	it('handles empty input without crashing', () => {
+		const buckets = computeBuckets([], new Set())
+		expect(buckets.pageTwoClimbers).toEqual([])
+		expect(buckets.lowCtrTopTen).toEqual([])
+		expect(buckets.offTargetQueries).toEqual([])
+	})
+
+	it('caps each bucket at 20 rows', () => {
+		const rows: GscRow[] = []
+		for (let i = 0; i < 50; i++) rows.push(row([`page-two ${String(i)}`], 12, 100 + i, 0))
+		const { pageTwoClimbers } = computeBuckets(rows, new Set())
+		expect(pageTwoClimbers).toHaveLength(20)
+	})
+})

--- a/src/lib/server/gsc-triage.ts
+++ b/src/lib/server/gsc-triage.ts
@@ -1,0 +1,269 @@
+import nodemailer from 'nodemailer'
+import { env } from '$env/dynamic/private'
+
+// Endpoints used by the weekly triage. Hardcoded — they don't change.
+const GSC_TOKEN_ENDPOINT = 'https://oauth2.googleapis.com/token'
+const GSC_SITES_BASE = 'https://searchconsole.googleapis.com/webmasters/v3/sites'
+const AI_GATEWAY_ENDPOINT = 'https://ai-gateway.vercel.sh/v1/chat/completions'
+const TRIAGE_MODEL = 'anthropic/claude-sonnet-4-6'
+
+// Per-row shape returned by the GSC searchAnalytics.query API when dimensions=[query].
+// `keys[0]` is the query string. `ctr` is a fraction in [0, 1].
+export interface GscRow {
+	keys: string[]
+	clicks: number
+	impressions: number
+	ctr: number
+	position: number
+}
+
+export interface TriageBuckets {
+	// Position 11–20, sorted by impressions desc — one nudge from page 1.
+	pageTwoClimbers: readonly GscRow[]
+	// Position ≤ 10 with CTR below the cohort median — snippet rewrites pay off here.
+	lowCtrTopTen: readonly GscRow[]
+	// Queries the site ranks for but whose terms don't appear in any known page title.
+	offTargetQueries: readonly GscRow[]
+}
+
+export interface TriageResult {
+	startDate: string
+	endDate: string
+	rowsAnalyzed: number
+	report: string
+}
+
+interface OAuthRefreshResponse {
+	access_token: string
+	expires_in: number
+}
+
+interface GscQueryResponse {
+	rows?: GscRow[]
+}
+
+interface ChatCompletionResponse {
+	choices?: { message?: { content?: string } }[]
+}
+
+async function refreshAccessToken(): Promise<string> {
+	const clientId = env['GSC_OAUTH_CLIENT_ID']
+	const clientSecret = env['GSC_OAUTH_CLIENT_SECRET']
+	const refreshToken = env['GSC_OAUTH_REFRESH_TOKEN']
+	if (!clientId || !clientSecret || !refreshToken) {
+		throw new Error(
+			'GSC OAuth env not set: need GSC_OAUTH_CLIENT_ID, GSC_OAUTH_CLIENT_SECRET, GSC_OAUTH_REFRESH_TOKEN'
+		)
+	}
+	const res = await fetch(GSC_TOKEN_ENDPOINT, {
+		method: 'POST',
+		headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+		body: new URLSearchParams({
+			client_id: clientId,
+			client_secret: clientSecret,
+			refresh_token: refreshToken,
+			grant_type: 'refresh_token'
+		})
+	})
+	if (!res.ok) {
+		// Bodies on token errors are non-sensitive ("invalid_grant" etc.). Read short text for diagnostics.
+		const detail = (await res.text()).slice(0, 200)
+		throw new Error(`GSC token refresh ${String(res.status)} ${res.statusText}: ${detail}`)
+	}
+	const json = (await res.json()) as OAuthRefreshResponse
+	return json.access_token
+}
+
+async function fetchQueryRows(
+	accessToken: string,
+	siteUrl: string,
+	startDate: string,
+	endDate: string,
+	rowLimit: number
+): Promise<GscRow[]> {
+	const url = `${GSC_SITES_BASE}/${encodeURIComponent(siteUrl)}/searchAnalytics/query`
+	const res = await fetch(url, {
+		method: 'POST',
+		headers: {
+			Authorization: `Bearer ${accessToken}`,
+			'Content-Type': 'application/json'
+		},
+		body: JSON.stringify({
+			startDate,
+			endDate,
+			dimensions: ['query'],
+			rowLimit,
+			dataState: 'final'
+		})
+	})
+	if (!res.ok) {
+		throw new Error(`GSC query ${String(res.status)} ${res.statusText}`)
+	}
+	const json = (await res.json()) as GscQueryResponse
+	return json.rows ?? []
+}
+
+const isoDate = (d: Date): string => d.toISOString().slice(0, 10)
+const daysAgoUtc = (n: number): Date => {
+	const d = new Date()
+	d.setUTCDate(d.getUTCDate() - n)
+	return d
+}
+
+// Pure: extracted so the bucket logic is unit-testable without hitting any API.
+export function computeBuckets(
+	rows: readonly GscRow[],
+	knownTitleTokens: ReadonlySet<string>
+): TriageBuckets {
+	const pageTwo = rows.filter((r) => r.position >= 11 && r.position <= 20)
+	pageTwo.sort((a, b) => b.impressions - a.impressions)
+
+	const topTen = rows.filter((r) => r.position <= 10 && r.impressions > 0)
+	const sortedCtrs = topTen.map((r) => r.ctr).sort((a, b) => a - b)
+	const median = sortedCtrs.length > 0 ? (sortedCtrs[Math.floor(sortedCtrs.length / 2)] ?? 0) : 0
+	const lowCtrTopTen = topTen
+		.filter((r) => r.ctr < median)
+		.sort((a, b) => b.impressions - a.impressions)
+
+	const TOKEN_MIN = 3
+	const tokensOf = (query: string): string[] =>
+		query
+			.toLowerCase()
+			.split(/[^a-z0-9]+/)
+			.filter((t) => t.length >= TOKEN_MIN)
+
+	const offTarget = rows
+		.filter((r) => r.position <= 30 && r.impressions >= 5)
+		.filter((r) => {
+			const tokens = tokensOf(r.keys[0] ?? '')
+			return !tokens.some((t) => knownTitleTokens.has(t))
+		})
+		.sort((a, b) => b.impressions - a.impressions)
+
+	return {
+		pageTwoClimbers: pageTwo.slice(0, 20),
+		lowCtrTopTen: lowCtrTopTen.slice(0, 20),
+		offTargetQueries: offTarget.slice(0, 20)
+	}
+}
+
+function renderBucketTable(name: string, rows: readonly GscRow[]): string {
+	if (rows.length === 0) return `### ${name}\n_no rows_\n`
+	const lines = rows.map(
+		(r) =>
+			`- "${r.keys[0] ?? ''}" — pos ${r.position.toFixed(1)}, ${String(r.impressions)} impr, ${String(r.clicks)} clicks, CTR ${(r.ctr * 100).toFixed(2)}%`
+	)
+	return `### ${name}\n${lines.join('\n')}\n`
+}
+
+function buildPrompt(buckets: TriageBuckets, siteUrl: string): string {
+	return [
+		`You are a senior SEO operator triaging a weekly Google Search Console export for ${siteUrl}.`,
+		`The site is sixtom.com — a solo engineering consultant offering a $1,500 audit and a $10,000 two-week sprint, targeting founders shipping AI-built MVPs to production. Voice: lowercase, terse, declarative.`,
+		``,
+		`Three buckets of raw GSC data:`,
+		``,
+		renderBucketTable('Page-two climbers (positions 11–20)', buckets.pageTwoClimbers),
+		renderBucketTable('Top-10 queries with low CTR', buckets.lowCtrTopTen),
+		renderBucketTable(
+			'Queries the site ranks for but no current title targets',
+			buckets.offTargetQueries
+		),
+		``,
+		`Produce a markdown report with exactly three sections:`,
+		`1. **5 highest-leverage fixes this week** — each: the query, what to do, why it matters (one line each).`,
+		`2. **Title/meta rewrites** — for low-CTR top-10s where a snippet rewrite pays off. Concrete new title + meta in sixtom's voice.`,
+		`3. **Next 3 article titles** — based on off-target queries that match buyer intent for a $1,500 audit / $10,000 sprint. Lowercase titles, buyer-question framed.`,
+		``,
+		`Be ruthless about leverage. No fluff. No congratulations.`
+	].join('\n')
+}
+
+async function callAiGateway(prompt: string): Promise<string> {
+	const token = env['AI_GATEWAY_API_KEY'] ?? env.VERCEL_OIDC_TOKEN
+	if (!token) {
+		throw new Error('Neither AI_GATEWAY_API_KEY nor VERCEL_OIDC_TOKEN is available')
+	}
+	const res = await fetch(AI_GATEWAY_ENDPOINT, {
+		method: 'POST',
+		headers: {
+			Authorization: `Bearer ${token}`,
+			'Content-Type': 'application/json'
+		},
+		body: JSON.stringify({
+			model: TRIAGE_MODEL,
+			messages: [{ role: 'user', content: prompt }]
+		})
+	})
+	if (!res.ok) {
+		throw new Error(`AI Gateway ${String(res.status)} ${res.statusText}`)
+	}
+	const json = (await res.json()) as ChatCompletionResponse
+	const content = json.choices?.[0]?.message?.content
+	if (typeof content !== 'string' || content.length === 0) {
+		throw new Error('AI Gateway returned empty content')
+	}
+	return content
+}
+
+async function sendEmailReport(subject: string, body: string): Promise<void> {
+	const host = env.SMTP_SERVER
+	const port = env.SMTP_PORT
+	const user = env.SMTP_EMAIL
+	const pass = env.SMTP_TOKEN
+	const to = env.SMTP_RECIPIENT_EMAIL
+	if (!host || !port || !user || !pass || !to) {
+		throw new Error(
+			'SMTP env not set: need SMTP_SERVER, SMTP_PORT, SMTP_EMAIL, SMTP_TOKEN, SMTP_RECIPIENT_EMAIL'
+		)
+	}
+	const portNumber = Number.parseInt(port, 10)
+	if (!Number.isFinite(portNumber)) throw new Error(`Invalid SMTP_PORT: ${port}`)
+	const transport = nodemailer.createTransport({
+		host,
+		port: portNumber,
+		secure: true,
+		auth: { user, pass }
+	})
+	await transport.sendMail({ from: user, to, subject, text: body })
+}
+
+// Hardcoded for the first iteration — these are the words in sixtom's current
+// titles. The off-target bucket flags queries whose tokens don't overlap. Easy
+// to lift to a sitemap-derived set later.
+const KNOWN_TITLE_TOKENS = new Set<string>([
+	'sixtom',
+	'faq',
+	'log',
+	'tax',
+	'vibe',
+	'code',
+	'audit',
+	'sprint',
+	'garden',
+	'party',
+	'production',
+	'solution',
+	'book',
+	'notify'
+])
+
+const QUERY_ROW_LIMIT = 5000
+
+export async function runWeeklyTriage(): Promise<TriageResult> {
+	const siteUrl = env['GSC_SITE_URL']
+	if (!siteUrl) throw new Error('GSC_SITE_URL not set (e.g. "https://sixtom.com/")')
+
+	// GSC data lags ~2 days. End at yesterday-1, start 7 days before that.
+	const endDate = isoDate(daysAgoUtc(2))
+	const startDate = isoDate(daysAgoUtc(8))
+
+	const accessToken = await refreshAccessToken()
+	const rows = await fetchQueryRows(accessToken, siteUrl, startDate, endDate, QUERY_ROW_LIMIT)
+	const buckets = computeBuckets(rows, KNOWN_TITLE_TOKENS)
+	const prompt = buildPrompt(buckets, siteUrl)
+	const report = await callAiGateway(prompt)
+
+	await sendEmailReport(`SEO triage ${startDate} → ${endDate}`, report)
+	return { startDate, endDate, rowsAnalyzed: rows.length, report }
+}

--- a/src/routes/api/seo-triage/+server.ts
+++ b/src/routes/api/seo-triage/+server.ts
@@ -1,0 +1,32 @@
+import { json } from '@sveltejs/kit'
+import { env } from '$env/dynamic/private'
+import { runWeeklyTriage } from '$lib/server/gsc-triage'
+import type { RequestHandler } from './$types'
+
+// Vercel automatically attaches `Authorization: Bearer ${CRON_SECRET}` to cron
+// invocations when CRON_SECRET is set in the project env. We refuse anything
+// else so the endpoint can't be triggered (and billed) by anonymous traffic.
+// Also accepts manual invocation with the same header for debugging.
+export const GET: RequestHandler = async ({ request }) => {
+	const expected = env['CRON_SECRET']
+	if (!expected) {
+		return json({ ok: false, error: 'CRON_SECRET not configured' }, { status: 500 })
+	}
+	const auth = request.headers.get('authorization')
+	if (auth !== `Bearer ${expected}`) {
+		return json({ ok: false, error: 'unauthorized' }, { status: 401 })
+	}
+	try {
+		const result = await runWeeklyTriage()
+		return json({
+			ok: true,
+			startDate: result.startDate,
+			endDate: result.endDate,
+			rowsAnalyzed: result.rowsAnalyzed
+		})
+	} catch (err) {
+		const message = err instanceof Error ? err.message : 'unknown error'
+		console.error('[/api/seo-triage] failed:', message)
+		return json({ ok: false, error: message }, { status: 500 })
+	}
+}

--- a/vercel.json
+++ b/vercel.json
@@ -13,5 +13,6 @@
 				{ "key": "Cache-Control", "value": "public, max-age=86400, stale-while-revalidate=604800" }
 			]
 		}
-	]
+	],
+	"crons": [{ "path": "/api/seo-triage", "schedule": "0 13 * * 0" }]
 }


### PR DESCRIPTION
## What
A scaffolded weekly SEO triage loop that runs once GSC is verified:
- \`GET /api/seo-triage\` (Vercel cron, Sundays 13:00 UTC, \`CRON_SECRET\`-gated)
- Pulls 7d of GSC \`searchAnalytics\` → computes 3 triage buckets (page-2 climbers / low-CTR top-10s / off-target queries) → asks Vercel AI Gateway (\`anthropic/claude-sonnet-4-6\`) for the week's high-leverage fixes → emails via existing SMTP.

Two helpers ship alongside:
- \`src/lib/server/gsc-triage.ts\` — auth refresh, API call, bucket compute, prompt, AI Gateway call, email.
- \`scripts/gsc-oauth-bootstrap.mjs\` — one-shot CLI to mint the refresh token (local HTTP server on :8420, no disk write).

Pure bucket logic is unit-tested.

## Won't fire until
- \`GSC_OAUTH_CLIENT_ID\`, \`GSC_OAUTH_CLIENT_SECRET\`, \`GSC_OAUTH_REFRESH_TOKEN\`, \`GSC_SITE_URL\`, \`CRON_SECRET\` set in Vercel env. Until then the endpoint 500s with "GSC OAuth env not set" — safe, no work attempted.
- All new vars documented in \`.env.example\`.

## Notes
- AI Gateway auth via \`VERCEL_OIDC_TOKEN\` at runtime (no separate Anthropic key needed).
- \`Authorization\` mismatch → 401, so anon can't trigger it/burn AI credits.
- Index-signature mix: bracket notation for vars not yet in ambient types (CRON_SECRET, GSC_*, AI_GATEWAY_API_KEY), dot for known (VERCEL_OIDC_TOKEN).

## Test plan
- [x] \`pnpm check\` 0 errors
- [x] \`pnpm lint\` green
- [x] \`pnpm test\` 37 passing (6 new \`computeBuckets\` cases)
- [x] \`pnpm build\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)