### PR TITLE
copy(home): add day-10 ownership beat to sprint section

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -103,6 +103,7 @@
 			<p>daily progress.</p>
 			<p>the answer when they ask.</p>
 			<p>your weekends back.</p>
+			<p>live in production on day 10. you own it.</p>
 		</div>
 		<p class="text-fg-subtle mt-8 text-sm md:text-base">
 			${site.sprint.priceUSD.toLocaleString()} flat. or {site.sprint.paymentPlan}. 1 client a month.


### PR DESCRIPTION
Adds one beat to the `only two weeks?` section: **live in production on day 10. you own it.**

Names the concrete sprint deliverable on the homepage — already published on /faq and llms-full.txt, but a first-time visitor never saw it. Surfaced as the one shippable finding from a buyability scan triage (the rest was scoring a stale cached page).

Trivial single-string copy edit — ships without /rl per convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)