### PR TITLE
fix: unbreak production deploy + share-card og:url + SEO hygiene

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -16,10 +16,9 @@
 		     using $app/state's page.url.pathname; do not hardcode here to avoid
 		     duplicate canonical tags on non-home routes. -->
 
-		<!-- Search engine ownership verification. Tokens come from each console;
-		     leave the TODO values until you paste in real ones, then verify. -->
-		<meta name="google-site-verification" content="TODO_paste_from_search_console" />
-		<meta name="msvalidate.01" content="TODO_paste_from_bing_webmaster" />
+		<!-- Search-engine ownership: verify via DNS TXT record on the domain
+		     (Search Console "Domain property" / Bing import) — covers every
+		     subdomain with zero markup. No placeholder meta tags in prod. -->
 
 		<link rel="preconnect" href="https://analytics.sixtom.com" />
 		<link
@@ -43,7 +42,8 @@
 			content="production-grade in two weeks. $10,000 flat, 1 client a month."
 		/>
 		<meta property="og:type" content="website" />
-		<meta property="og:url" content="https://sixtom.com/" />
+		<!-- og:url lives in +layout.svelte (per-route, alongside canonical) — a
+		     static one here would duplicate it and scrapers take the first. -->
 		<meta property="og:image" content="https://sixtom.com/og.png" />
 		<meta property="og:image:width" content="1200" />
 		<meta property="og:image:height" content="630" />

--- a/src/lib/content/site.ts
+++ b/src/lib/content/site.ts
@@ -22,8 +22,10 @@ export const site: Site = {
 		linkedinUrl: 'https://www.linkedin.com/in/threesam',
 		xUrl: 'https://x.com/six_to_m',
 		githubUrl: 'https://github.com/threesam',
-		soundcloudUrl: 'https://soundcloud.com/threesam',
-		substackUrl: 'https://substack.com/@threesam'
+		soundcloudUrl: 'https://soundcloud.com/threesam'
+		// Substack deliberately unlisted: the profile has no publication yet, and
+		// a sameAs pointing at an empty shell is an anti-signal. Re-add when
+		// essays actually syndicate there.
 	},
 	audit: {
 		name: 'audit',

--- a/src/lib/content/types.ts
+++ b/src/lib/content/types.ts
@@ -15,7 +15,6 @@ export interface Operator {
 	xUrl: string
 	githubUrl: string
 	soundcloudUrl: string
-	substackUrl: string
 }
 
 export interface Offer {

--- a/src/lib/seo/jsonld.ts
+++ b/src/lib/seo/jsonld.ts
@@ -90,8 +90,7 @@ export function personJsonLd(): PersonLd {
 			site.operator.linkedinUrl,
 			site.operator.xUrl,
 			site.operator.githubUrl,
-			site.operator.soundcloudUrl,
-			site.operator.substackUrl
+			site.operator.soundcloudUrl
 		]
 	}
 }

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -15,6 +15,7 @@
 
 <svelte:head>
 	<link rel="canonical" href={`${site.siteUrl}${page.url.pathname}`} />
+	<meta property="og:url" content={`${site.siteUrl}${page.url.pathname}`} />
 	<!-- eslint-disable-next-line svelte/no-at-html-tags -- safe: JSON.stringify of typed in-repo content -->
 	{@html jsonLdHtml}
 </svelte:head>

--- a/src/routes/faq/+page.svelte
+++ b/src/routes/faq/+page.svelte
@@ -19,7 +19,6 @@
 		property="og:description"
 		content="what sixtom does, what it costs, and how the audit and sprint work."
 	/>
-	<meta property="og:url" content={`${site.siteUrl}/faq`} />
 	<meta property="og:type" content="website" />
 	<!-- eslint-disable-next-line svelte/no-at-html-tags -- safe: JSON.stringify of typed in-repo content -->
 	{@html faqLd}

--- a/src/routes/log/+page.svelte
+++ b/src/routes/log/+page.svelte
@@ -30,7 +30,6 @@
 	<meta name="description" content={blogDescription} />
 	<meta property="og:title" content="log | SIXTOM" />
 	<meta property="og:description" content={blogDescription} />
-	<meta property="og:url" content={`${site.siteUrl}/log`} />
 	<meta property="og:type" content="website" />
 	<!-- eslint-disable-next-line svelte/no-at-html-tags -- safe: JSON.stringify of typed in-repo content -->
 	{@html blogLd}

--- a/src/routes/log/+page.svelte
+++ b/src/routes/log/+page.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-	import { site } from '$lib/content'
 	import { LOG_ENTRIES } from '$lib/log'
 	import { blogJsonLd, renderJsonLd } from '$lib/seo/jsonld'
 

--- a/src/routes/log/garden-party/+page.svelte
+++ b/src/routes/log/garden-party/+page.svelte
@@ -80,7 +80,6 @@
 		property="og:description"
 		content="why we ported threesam.com from Next.js to SvelteKit: the impulse, the experiment, and what the numbers showed."
 	/>
-	<meta property="og:url" content="https://sixtom.com/log/garden-party" />
 	<meta name="twitter:card" content="summary" />
 	<link rel="preload" as="image" href="/assets/clouds.webp" />
 	<!-- eslint-disable-next-line svelte/no-at-html-tags -- safe: JSON.stringify of typed in-repo content -->

--- a/src/routes/tax/+page.svelte
+++ b/src/routes/tax/+page.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
 	import VibeTaxCalculator from '$lib/components/VibeTaxCalculator.svelte'
 	import SiteFooter from '$lib/components/SiteFooter.svelte'
-	import { site } from '$lib/content'
 </script>
 
 <svelte:head>

--- a/src/routes/tax/+page.svelte
+++ b/src/routes/tax/+page.svelte
@@ -15,7 +15,6 @@
 		property="og:description"
 		content="how much your vibe-coded prototype is costing you per year."
 	/>
-	<meta property="og:url" content={`${site.siteUrl}/tax`} />
 	<meta property="og:type" content="website" />
 </svelte:head>
 

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -9,7 +9,10 @@ export default {
 		adapter: adapter(),
 		// Root-absolute asset URLs so nested-route HTML resolves /_app/... correctly.
 		paths: { relative: false },
-		prerender: { entries: ['/sanity', '/sitemap.xml', '/privacy', '/terms', '/tax', '/faq'] }
+		// /log must be listed explicitly: nothing in the crawl graph links to it
+		// since the homepage went single-case-study, so the prerenderer can't
+		// discover it and the build fails (same class of miss as /faq before).
+		prerender: { entries: ['/sanity', '/sitemap.xml', '/privacy', '/terms', '/tax', '/faq', '/log'] }
 		// inlineStyleThreshold removed: nested routes with <svelte:head> had the
 		// SSR-injected inline <style> block wiped during hydration while the
 		// fallback <link> stayed disabled, leaving the page unstyled.


### PR DESCRIPTION
Three fixes out of the growth audit, ordered by urgency:

## 1. Production deploys are failing — `/log` prerender (be1bc9e)
Since the homepage went single-case-study, nothing links `/log`, so the prerender crawler never finds it and **every deploy of main errors** (`dpl_GXfbT7En…`: "marked as prerenderable, but not prerendered"). Same class of miss as `/faq` earlier (`3a2e17d`). Fix: list `/log` in `prerender.entries`.

## 2. Every share card resolved to the homepage (c1f9bbd)
`app.html` hardcoded `og:url` to `https://sixtom.com/` and four pages added their own — subpages served **two** `og:url` tags, and scrapers (LinkedIn unfurl included) take the first. `og:url` now lives in `+layout.svelte` next to canonical, same `page.url.pathname` source; static tag + per-page duplicates dropped. **Verified in prerendered output: exactly one `og:url` per page, correct path.**

Also removes the literal `TODO_paste_*` search-console verification metas from prod `<head>` — verify via DNS TXT domain property instead (no markup, covers all subdomains).

## 3. Unlink empty Substack from Person sameAs (3f87c61)
The profile has 0 posts and 7 followers — `sameAs` pointing at an empty shell is an anti-signal to humans and answer engines alike. Re-add when essays actually syndicate. (Mirror PR coming for threesam.com.)

## Verification
- `pnpm run build` passes locally (previously failed with the exact prod error)
- Prerendered HTML inspected: 1 `og:url`/page, no `TODO_paste`, no substack strings
- svelte-autofixer clean on the touched layout

Note: branch history was rewritten once pre-review (a commit-message amend landed on the wrong commit; rebuilt with `--force-with-lease`, content verified identical) — flagged for transparency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)