### PR TITLE
feat(offer): post-sprint retainer — $1,500/mo, 4 seats

### DIFF
--- a/src/lib/content/faq.ts
+++ b/src/lib/content/faq.ts
@@ -17,7 +17,7 @@ export const FAQ: readonly QA[] = [
 	{
 		question: 'how much does it cost?',
 		answer:
-			'the audit is $1,500 flat. the sprint is $10,000 flat, or 4 weekly payments of $2,500. the first 3 clients get the sprint at $7,500.'
+			'the audit is $1,500 flat. the sprint is $10,000 flat, or 4 weekly payments of $2,500. the first 3 clients get the sprint at $7,500. after a sprint, the retainer is $1,500 a month.'
 	},
 	{
 		question: 'how long does it take?',
@@ -33,6 +33,11 @@ export const FAQ: readonly QA[] = [
 		question: 'how many clients do you take?',
 		answer:
 			"one a month, by appointment. that's the whole model — you get my full attention, not a queue."
+	},
+	{
+		question: 'what happens after the sprint?',
+		answer:
+			"you own everything either way. if you want me to stay on, there's the retainer — $1,500 a month: i keep it running, ship small iterations, and you get priority access when something breaks. post-sprint clients only, capped at 4 at a time."
 	},
 	{
 		question: "who's behind sixtom?",

--- a/src/lib/content/site.ts
+++ b/src/lib/content/site.ts
@@ -42,6 +42,14 @@ export const site: Site = {
 		cadence: '1 client a month, by appointment.',
 		paymentPlan: '4 weekly payments of $2,500'
 	},
+	// The recurring rung: only offered after a sprint, deliberately capped so it
+	// stays a floor under the practice, not a second job on top of it.
+	retainer: {
+		name: 'retainer',
+		longName: 'i keep it running',
+		priceUSD: 1500,
+		cadence: 'monthly. post-sprint clients only. 4 seats.'
+	},
 	process: [
 		{
 			label: 'Week 1, day 0',

--- a/src/lib/content/types.ts
+++ b/src/lib/content/types.ts
@@ -55,6 +55,7 @@ export interface Site {
 	operator: Operator
 	audit: Offer
 	sprint: Offer
+	retainer: Offer
 	process: readonly ProcessStep[]
 	stats: readonly Stat[]
 	testimonial: Testimonial

--- a/src/lib/seo/jsonld.ts
+++ b/src/lib/seo/jsonld.ts
@@ -121,6 +121,7 @@ export function serviceJsonLd(): ServiceLd {
 	]
 		.filter(Boolean)
 		.join(' ')
+	const retainerDescription = `keep me on it after the sprint — monitoring, small iterations, priority access. ${site.retainer.cadence}`
 	return {
 		'@context': 'https://schema.org',
 		'@type': 'Service',
@@ -146,6 +147,15 @@ export function serviceJsonLd(): ServiceLd {
 				name: site.sprint.name,
 				description: sprintDescription,
 				price: String(site.sprint.priceUSD),
+				priceCurrency: 'USD',
+				availability: 'https://schema.org/LimitedAvailability',
+				url: bookUrl
+			},
+			{
+				'@type': 'Offer',
+				name: site.retainer.name,
+				description: retainerDescription,
+				price: String(site.retainer.priceUSD),
 				priceCurrency: 'USD',
 				availability: 'https://schema.org/LimitedAvailability',
 				url: bookUrl

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -108,6 +108,9 @@
 		<p class="text-fg-subtle mt-8 text-sm md:text-base">
 			${site.sprint.priceUSD.toLocaleString()} flat. or {site.sprint.paymentPlan}. 1 client a month.
 		</p>
+		<p class="text-fg-subtle mt-2 text-sm md:text-base">
+			after: ${site.retainer.priceUSD.toLocaleString()}/mo keeps me on it. post-sprint only, 4 seats.
+		</p>
 	</div>
 </section>
 

--- a/src/routes/faq/+page.svelte
+++ b/src/routes/faq/+page.svelte
@@ -12,7 +12,7 @@
 	<title>faq | SIXTOM</title>
 	<meta
 		name="description"
-		content="what sixtom does, what it costs, how the audit and sprint work, and what happens if it won't ship in two weeks."
+		content="what sixtom does, what it costs, how the audit, sprint, and retainer work, and what happens if it won't ship in two weeks."
 	/>
 	<meta property="og:title" content="faq | SIXTOM" />
 	<meta


### PR DESCRIPTION
The freedom column opens: the offer ladder gains its recurring rung.

**The offer:** "i keep it running" — $1,500/month, post-sprint clients only, capped at 4 seats. Monitoring, small iterations, priority access.

**Where it shows up:**
- `/faq`: new Q ("what happens after the sprint?") + retainer sentence in the canonical pricing answer + meta description
- Service JSON-LD: third `Offer` (`LimitedAvailability`) — answer engines now quote all three rungs
- Home `#offers` section: one subtle line under the sprint pricing
- `site.ts` / `types.ts`: `retainer` as a first-class `Offer`

**▸ Copy is drafted in your voice but it's yours** — the FAQ answer and the home one-liner are the two spots most worth your rewrite pass before (or after) merge. Structure won't change.

**Verification:** svelte-check 0/0 across 765 files · build passes · built FAQ HTML contains the retainer · built JSON-LD has exactly 3 Offers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)