### PR TITLE
feat(notify): bank signups in listmonk's sixtom list

### DIFF
--- a/src/lib/server/contact-form.ts
+++ b/src/lib/server/contact-form.ts
@@ -75,14 +75,16 @@ function hasHeaderInjection(value: string): boolean {
 }
 
 export type SubmissionResult =
-	| { ok: true; message: string }
+	| { ok: true; message: string; suspicious?: true }
 	| { ok: false; status: number; message: string }
 
 export const SUCCESS_MESSAGE = "You're on the list."
 
-// Honeypot + time-trap silently 200 so attackers can't learn which layer filtered them.
+// Honeypot + time-trap silently 200 so attackers can't learn which layer
+// filtered them. `suspicious` lets callers skip side effects (e.g. the /notify
+// listmonk subscribe) without breaking the fake success the bot sees.
 function suspicious(): SubmissionResult {
-	return { ok: true, message: SUCCESS_MESSAGE }
+	return { ok: true, message: SUCCESS_MESSAGE, suspicious: true }
 }
 
 let cachedTransporter: Transporter | null = null

--- a/src/lib/server/listmonk.ts
+++ b/src/lib/server/listmonk.ts
@@ -1,0 +1,37 @@
+// Server-side bridge to the self-hosted listmonk (Hetzner box, behind Caddy).
+// Uses the PUBLIC subscription endpoint — no credentials involved; list UUIDs
+// are the same values any public subscribe form would carry.
+//
+// Lists are per-brand and never cross-mailed: this module only knows sixtom's.
+// (threesam.com's `garden` list has its own bridge in that repo.)
+const LISTMONK_URL = 'https://mail.sixtom.com'
+
+// `sixtom` list (single opt-in): slot notifications + future tax reports.
+export const SIXTOM_LIST_UUID = 'd82e4dd1-517b-45dc-b86d-a38b562c2717'
+
+const SUBSCRIBE_TIMEOUT_MS = 5000
+
+// Best-effort subscribe. Never throws — the caller's primary flow (the email
+// to Sam) must succeed even when listmonk is down; the address still lands in
+// the inbox, only the list write is lost.
+export async function subscribeToList(email: string, listUuid: string): Promise<boolean> {
+	try {
+		const res = await fetch(`${LISTMONK_URL}/api/public/subscription`, {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({ email, list_uuids: [listUuid] }),
+			signal: AbortSignal.timeout(SUBSCRIBE_TIMEOUT_MS)
+		})
+		if (!res.ok) {
+			console.error('listmonk subscribe failed:', res.status)
+			return false
+		}
+		return true
+	} catch (error) {
+		console.error(
+			'listmonk subscribe failed:',
+			error instanceof Error ? error.message : 'unknown'
+		)
+		return false
+	}
+}

--- a/src/routes/notify/+page.server.ts
+++ b/src/routes/notify/+page.server.ts
@@ -1,6 +1,7 @@
 import { fail } from '@sveltejs/kit'
 import type { Actions } from './$types'
 import { MAX_REQUEST_BYTES, processSubmission } from '$lib/server/contact-form'
+import { SIXTOM_LIST_UUID, subscribeToList } from '$lib/server/listmonk'
 import { fireServerEvent } from '$lib/server/umami'
 
 export const actions = {
@@ -16,6 +17,14 @@ export const actions = {
 		const result = await processSubmission(formData, event)
 
 		if (result.ok) {
+			// Bank the address in listmonk's `sixtom` list as well as the inbox —
+			// but never for honeypot/time-trap fakes (`suspicious`), or bots would
+			// poison the list through the silent-200 path. Best-effort: a listmonk
+			// outage must not fail the signup the visitor was just promised.
+			const email = String(formData.get('email') ?? '').trim()
+			if (!result.suspicious && email) {
+				await subscribeToList(email, SIXTOM_LIST_UUID)
+			}
 			fireServerEvent('notify_signup_success', event.request)
 			return { status: 'success' as const, message: result.message }
 		}


### PR DESCRIPTION
First piece of the owned-audience spine on the money engine.

**What changes:** `/notify` signups now ALSO subscribe to the self-hosted listmonk `sixtom` list (single opt-in) via its public subscription endpoint. The notification email to the inbox stays — backstop + ping. Listmonk being down can never fail a visitor's signup (best-effort, 5s timeout, errors logged).

**The subtle part:** `processSubmission`'s honeypot/time-trap path returns a *fake* success so bots can't learn which layer filtered them. A new optional `suspicious: true` on that variant lets the notify action skip the listmonk write for fakes — otherwise bots would poison the list through the silent 200. `/book` and all existing tests are untouched by the additive type change.

**Infra that backs this (already live on the box):** `sixtom` + `garden` lists created in listmonk (v6.1.0 — which it turns out already hosts three client lists). SMTP is configured to Resend pending one key from Sam; capture works without it.

**Deferred deliberately:** the /tax "email me this report" magnet — until SMTP can actually send, a capture that promises an email would be a lie.

**Verification:** svelte-check 0/0 · vitest 31/31 · live POST from the public internet → row visible in the list DB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)