### PR TITLE
fix(log): lowercase brand voice + h1 + footer

### DIFF
--- a/src/routes/log/+page.svelte
+++ b/src/routes/log/+page.svelte
@@ -1,9 +1,10 @@
 <script lang="ts">
 	import { LOG_ENTRIES } from '$lib/log'
 	import { blogJsonLd, renderJsonLd } from '$lib/seo/jsonld'
+	import SiteFooter from '$lib/components/SiteFooter.svelte'
 
 	const blogDescription =
-		'Case studies and build notes from the work — what I shipped, why, and what the numbers showed.'
+		'case studies and build notes from the work — what i shipped, why, and what the numbers showed.'
 	const blogLd = renderJsonLd(blogJsonLd(blogDescription))
 
 	// UTC so a calendar date like "2026-05-18" (parsed as UTC midnight) isn't
@@ -34,8 +35,8 @@
 	{@html blogLd}
 </svelte:head>
 
-<div class="bg-surface min-h-screen">
-	<div class="mx-auto w-full max-w-3xl px-6 py-20">
+<div class="bg-surface flex min-h-screen flex-col">
+	<div class="mx-auto w-full max-w-3xl flex-1 px-6 py-20">
 		<header class="mb-20">
 			<a
 				href="/"
@@ -45,11 +46,11 @@
 				sixtom
 			</a>
 			<p class="eyebrow mt-12 text-sm">the log</p>
-			<h2 class="text-fg mt-2 text-4xl font-bold tracking-tight md:text-6xl">
-				What I'm shipping, in public.
-			</h2>
+			<h1 class="text-fg mt-2 text-4xl font-bold tracking-tight md:text-6xl">
+				what i'm shipping, in public.
+			</h1>
 			<p class="text-fg-muted mt-6 text-lg leading-relaxed">
-				Case studies and build notes — the decisions, the experiments, the numbers.
+				case studies and build notes — the decisions, the experiments, the numbers.
 			</p>
 		</header>
 
@@ -96,4 +97,5 @@
 			</ul>
 		{/if}
 	</div>
+	<SiteFooter />
 </div>


### PR DESCRIPTION
Found in the `/drive` sweep (desktop + mobile, 5-lens). The `/log` index was the **only page breaking the strict-lowercase brand voice** every other page follows.

### Changes
- **Voice:** lowercase the H1 (`What I'm shipping, in public.` → `what i'm shipping, in public.`), the subhead, and `blogDescription` — the last cascades to the `<meta description>`, `og:description`, and Blog JSON-LD. Now matches `/faq`'s already-lowercase meta and the lowercase entry titles / article body.
- **Heading hierarchy:** promote the page's top heading from `<h2>` to `<h1>` (the page had **no `<h1>`**).
- **Nav:** add `<SiteFooter />` (the page dead-ended with no footer).

### Verify
- `svelte-check`: 0 errors / 0 warnings
- `/drive` /log desktop: lowercase H1 renders, footer anchors the bottom, no layout regression
- _If the sentence-case was a deliberate "editorial" choice for the writing section, close this — but the lowercase entry titles suggest it was an oversight._

Closes #129

🤖 Generated with [Claude Code](https://claude.com/claude-code)