### PR TITLE
fix(tax): promote calculator heading to h1

### DIFF
--- a/src/lib/components/VibeTaxCalculator.svelte
+++ b/src/lib/components/VibeTaxCalculator.svelte
@@ -52,9 +52,9 @@
 <section class="snap-section bg-surface">
 	<div class="mx-auto w-full max-w-3xl px-6 py-16 md:py-20">
 		<p class="eyebrow text-sm">your vibe-code tax</p>
-		<h2 class="text-fg mt-2 text-3xl font-bold tracking-tight md:text-5xl">
+		<h1 class="text-fg mt-2 text-3xl font-bold tracking-tight md:text-5xl">
 			what's it costing you?
-		</h2>
+		</h1>
 		<p class="text-fg-muted mt-4 text-base leading-relaxed">
 			4 questions. instant number. no email.
 		</p>


### PR DESCRIPTION
Found in the `/drive` sweep. `/tax` renders `<VibeTaxCalculator />` whose top heading is an `<h2>`; the route adds no heading, so the page had **no `<h1>`**.

### Change
- `VibeTaxCalculator.svelte`: `<h2>` → `<h1>` for "what's it costing you?" (component is only used on /tax, so safe; classes unchanged).

### Verify
- `svelte-check`: 0 errors / 0 warnings
- Everything else on /tax is already excellent (accessible inputs, `fieldset`/`legend`/radio, `aria-live`).

Closes #130

🤖 Generated with [Claude Code](https://claude.com/claude-code)