### PR TITLE
feat(garden-party): add end-of-article conversion CTA + footer

### DIFF
--- a/src/lib/components/umami-events.test.ts
+++ b/src/lib/components/umami-events.test.ts
@@ -24,7 +24,8 @@ const CLIENT_EVENTS: readonly ClientEvent[] = [
 	{ event: 'cta_final_book', dir: 'route', path: '+page.svelte' },
 	{ event: 'cta_faq_book', dir: 'route', path: 'faq/+page.svelte' },
 	{ event: 'cta_notify_submit', dir: 'route', path: 'notify/+page.svelte' },
-	{ event: 'cta_calc_book', dir: 'component', path: 'VibeTaxCalculator.svelte' }
+	{ event: 'cta_calc_book', dir: 'component', path: 'VibeTaxCalculator.svelte' },
+	{ event: 'cta_case_study_book', dir: 'route', path: 'log/garden-party/+page.svelte' }
 ]
 
 describe('Umami CRO event instrumentation', () => {

--- a/src/routes/log/garden-party/+page.svelte
+++ b/src/routes/log/garden-party/+page.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
 	import LogHero from '$lib/components/LogHero.svelte'
 	import MediaSlider from '$lib/components/MediaSlider.svelte'
+	import BookCta from '$lib/components/BookCta.svelte'
+	import SiteFooter from '$lib/components/SiteFooter.svelte'
 	import { LOG_ENTRIES } from '$lib/log'
 	import { blogPostingJsonLd, renderJsonLd } from '$lib/seo/jsonld'
 
@@ -372,3 +374,14 @@
 		</footer>
 	</div>
 </article>
+
+<section class="mx-auto w-full max-w-2xl px-6 pb-20 md:pb-28">
+	<div class="border-border border-t pt-10">
+		<p class="text-fg text-lg leading-relaxed md:text-xl">
+			that was my own garden. yours is next — production-grade in two weeks, and you own it.
+		</p>
+		<BookCta event="cta_case_study_book" class="mt-8" />
+	</div>
+</section>
+
+<SiteFooter />


### PR DESCRIPTION
Found in the `/drive` sweep (CRO/Founder lens). `/log/garden-party` is the site's strongest proof asset (real metrics, Lighthouse chart, radical-transparency PR links) — but it **dead-ended**: the closing element was only outbound GitHub PR links (#29–#33). A reader who finished the case study, maximally warmed-up, had no path to convert and no site nav.

### Changes
- Add an end-of-article conversion CTA after the "the work is public" links: a divider + one in-voice line + the canonical `BookCta` ("solve for X"). New flow: proof → credibility links → **the ask** → footer.
- Add `<SiteFooter />` for consistent global nav.

The lead-in ("that was my own garden. yours is next — production-grade in two weeks, and you own it.") is recombined from existing site copy — **wordsmith freely**, it's a proposal.

### Verify
- `svelte-check`: 0 errors / 0 warnings
- `/drive` garden-party desktop: CTA + footer render after the article, in-voice, no layout regression

Closes #131

🤖 Generated with [Claude Code](https://claude.com/claude-code)