### PR TITLE
feat(pages): consistent footer on /faq, /privacy, /terms

### DIFF
--- a/src/routes/faq/+page.svelte
+++ b/src/routes/faq/+page.svelte
@@ -2,6 +2,7 @@
 	import { site, FAQ } from '$lib/content'
 	import { faqPageJsonLd, renderJsonLd } from '$lib/seo/jsonld'
 	import BookCta from '$lib/components/BookCta.svelte'
+	import SiteFooter from '$lib/components/SiteFooter.svelte'
 
 	// Visible FAQ + matching FAQPage schema (engines require the answer text be on
 	// the page, which it is). Questions/answers live in src/lib/content/faq.ts.
@@ -24,8 +25,8 @@
 	{@html faqLd}
 </svelte:head>
 
-<div class="bg-surface min-h-screen">
-	<div class="mx-auto w-full max-w-3xl px-6 py-20">
+<div class="bg-surface flex min-h-screen flex-col">
+	<div class="mx-auto w-full max-w-3xl flex-1 px-6 py-20">
 		<header class="mb-16">
 			<a
 				href="/"
@@ -58,4 +59,5 @@
 			<BookCta event="cta_faq_book" class="mt-8" />
 		</div>
 	</div>
+	<SiteFooter />
 </div>

--- a/src/routes/privacy/+page.svelte
+++ b/src/routes/privacy/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import SiteFooter from '$lib/components/SiteFooter.svelte'
 </script>
 
 <svelte:head>
@@ -9,8 +10,8 @@
 	/>
 </svelte:head>
 
-<div class="bg-surface min-h-screen">
-	<div class="mx-auto w-full max-w-3xl px-6 py-20">
+<div class="bg-surface flex min-h-screen flex-col">
+	<div class="mx-auto w-full max-w-3xl flex-1 px-6 py-20">
 		<header class="mb-16">
 			<a
 				href="/"
@@ -59,4 +60,5 @@
 			<p class="text-fg-subtle mt-16 text-xs tracking-widest uppercase">last updated: may 2026</p>
 		</div>
 	</div>
+	<SiteFooter />
 </div>

--- a/src/routes/terms/+page.svelte
+++ b/src/routes/terms/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import SiteFooter from '$lib/components/SiteFooter.svelte'
 </script>
 
 <svelte:head>
@@ -9,8 +10,8 @@
 	/>
 </svelte:head>
 
-<div class="bg-surface min-h-screen">
-	<div class="mx-auto w-full max-w-3xl px-6 py-20">
+<div class="bg-surface flex min-h-screen flex-col">
+	<div class="mx-auto w-full max-w-3xl flex-1 px-6 py-20">
 		<header class="mb-16">
 			<a
 				href="/"
@@ -59,4 +60,5 @@
 			<p class="text-fg-subtle mt-16 text-xs tracking-widest uppercase">last updated: may 2026</p>
 		</div>
 	</div>
+	<SiteFooter />
 </div>


### PR DESCRIPTION
Found in the `/drive` sweep. `SiteFooter` rendered on only 3 pages (home, tax, notify) — `+layout.svelte` has no global footer — so `/faq`, `/privacy`, `/terms` dead-ended with only the top-left "sixtom" back-link for navigation.

### Changes
- Add `<SiteFooter />` to faq/privacy/terms. `flex min-h-screen flex-col` + `flex-1` on the content pins the footer to the bottom on short pages (matches the tax/notify pattern).
- `/book` intentionally stays footer-less (focused qualification wizard). `/log` + garden-party footers are handled in their own PRs (#134, #136).

### Verify
- `svelte-check`: 0 errors / 0 warnings; prettier clean
- `/drive` /privacy desktop: footer pinned to bottom, divider + full nav row, no regression

Closes #132

🤖 Generated with [Claude Code](https://claude.com/claude-code)