### PR TITLE
feat: umami tracking robustness

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -71,6 +71,7 @@
 			defer
 			src="https://analytics.sixtom.com/script.js"
 			data-website-id="64398c1a-02a0-4a61-991c-b0d143f01b46"
+			data-domains="sixtom.com"
 		></script>
 		<!-- Hero bubble-field animation. Standalone (no framework) so the home page
 		     stays csr=false; no-ops on pages without a [data-bubble] canvas. -->

--- a/src/lib/components/umami-events.test.ts
+++ b/src/lib/components/umami-events.test.ts
@@ -26,6 +26,8 @@ const CLIENT_EVENTS: readonly ClientEvent[] = [
 	{ event: 'cta_notify_submit', dir: 'route', path: 'notify/+page.svelte' },
 	{ event: 'cta_calc_book', dir: 'component', path: 'VibeTaxCalculator.svelte' },
 	{ event: 'cta_case_study_book', dir: 'route', path: 'log/garden-party/+page.svelte' },
+	{ event: 'case_study_garden_link', dir: 'route', path: 'log/garden-party/+page.svelte' },
+	{ event: 'case_study_github_link', dir: 'route', path: 'log/garden-party/+page.svelte' },
 	// These three are read directly by infra's Monday brief.py (ev.get('book_step_next'),
 	// ev.get('book_submit'), ev.get('book_qualified_booking_click')) — a rename here previously
 	// went silent in this repo's own tests but would break that external consumer. Pinned so a

--- a/src/lib/components/umami-events.test.ts
+++ b/src/lib/components/umami-events.test.ts
@@ -25,7 +25,14 @@ const CLIENT_EVENTS: readonly ClientEvent[] = [
 	{ event: 'cta_faq_book', dir: 'route', path: 'faq/+page.svelte' },
 	{ event: 'cta_notify_submit', dir: 'route', path: 'notify/+page.svelte' },
 	{ event: 'cta_calc_book', dir: 'component', path: 'VibeTaxCalculator.svelte' },
-	{ event: 'cta_case_study_book', dir: 'route', path: 'log/garden-party/+page.svelte' }
+	{ event: 'cta_case_study_book', dir: 'route', path: 'log/garden-party/+page.svelte' },
+	// These three are read directly by infra's Monday brief.py (ev.get('book_step_next'),
+	// ev.get('book_submit'), ev.get('book_qualified_booking_click')) — a rename here previously
+	// went silent in this repo's own tests but would break that external consumer. Pinned so a
+	// rename fails here before the digest quietly zeroes out.
+	{ event: 'book_step_next', dir: 'route', path: 'book/+page.svelte' },
+	{ event: 'book_submit', dir: 'route', path: 'book/+page.svelte' },
+	{ event: 'book_qualified_booking_click', dir: 'route', path: 'book/+page.svelte' }
 ]
 
 describe('Umami CRO event instrumentation', () => {

--- a/src/routes/book/+page.svelte
+++ b/src/routes/book/+page.svelte
@@ -296,6 +296,7 @@
 							type="button"
 							onclick={back}
 							data-umami-event="book_step_back"
+							data-umami-event-step={step}
 							class="text-fg-subtle hover:text-fg text-sm tracking-widest uppercase transition-colors"
 						>
 							← back
@@ -307,6 +308,7 @@
 							onclick={next}
 							disabled={!canAdvance()}
 							data-umami-event="book_step_next"
+							data-umami-event-step={step}
 							class="btn-accent ml-auto px-6 py-3 text-base hover:opacity-90 disabled:opacity-60"
 						>
 							next →

--- a/src/routes/log/garden-party/+page.svelte
+++ b/src/routes/log/garden-party/+page.svelte
@@ -102,8 +102,12 @@
 	<div class="text-fg-muted prose-log space-y-8 text-base leading-relaxed">
 		<p class="text-fg-muted text-lg leading-relaxed">
 			my wife offered me tea. i picked 'garden party.' that's how i ended up porting my garden —
-			<a href="https://threesam.com" class="text-accent hover:underline">threesam.com</a> — from Next.js
-			to SvelteKit. same routes, same design, same everything. a 1:1 swap. here's what happened.
+			<a
+				href="https://threesam.com"
+				data-umami-event="case_study_garden_link"
+				class="text-accent hover:underline">threesam.com</a
+			> — from Next.js to SvelteKit. same routes, same design, same everything. a 1:1 swap. here's what
+			happened.
 		</p>
 
 		<!-- STAT BAND -->
@@ -355,20 +359,32 @@
 		<footer class="border-border mt-12 border-t pt-8">
 			<p class="text-fg-subtle text-xs">
 				the work is public:
-				<a href="https://github.com/threesam/garden/pull/29" class="text-accent hover:underline"
-					>#29</a
+				<a
+					href="https://github.com/threesam/garden/pull/29"
+					data-umami-event="case_study_github_link"
+					data-umami-event-pr="29"
+					class="text-accent hover:underline">#29</a
 				>
 				(port),
-				<a href="https://github.com/threesam/garden/pull/30" class="text-accent hover:underline"
-					>#30</a
+				<a
+					href="https://github.com/threesam/garden/pull/30"
+					data-umami-event="case_study_github_link"
+					data-umami-event-pr="30"
+					class="text-accent hover:underline">#30</a
 				>
 				(perf),
-				<a href="https://github.com/threesam/garden/pull/31" class="text-accent hover:underline"
-					>#31</a
+				<a
+					href="https://github.com/threesam/garden/pull/31"
+					data-umami-event="case_study_github_link"
+					data-umami-event-pr="31"
+					class="text-accent hover:underline">#31</a
 				>
 				(content-prerender hotfix),
-				<a href="https://github.com/threesam/garden/pull/33" class="text-accent hover:underline"
-					>#33</a
+				<a
+					href="https://github.com/threesam/garden/pull/33"
+					data-umami-event="case_study_github_link"
+					data-umami-event-pr="33"
+					class="text-accent hover:underline">#33</a
 				> (route rename).
 			</p>
 		</footer>


### PR DESCRIPTION
## Gaps found → fixes

Audit pass (site was already instrumented: 33 `data-umami-event` attributes, 27 visitors/30d, a working funnel per the recon). No existing event name renamed or removed — additive only, per this repo's own `AGENTS.md` convention and because infra's Monday `brief.py` digest reads several of these event names by exact string.

1. **No `data-domains` guard on the umami script tag.** Same anti-pollution gap every other site in this sweep had. `www.sixtom.com` 307-redirects to the apex (verified live via `curl -sI`), so apex-only (`data-domains="sixtom.com"`) is correct and sufficient — no need to list both hosts.
2. **5 untracked outbound links, all on `/log/garden-party`.** This is the one page in the repo with hardcoded external links (everywhere else, the only 2 external links — `cta_garden_link` in the footer, `cta_garden_link_why` on the home page — were already tracked). Added `case_study_garden_link` on the inline threesam.com mention, and `case_study_github_link` (with a `data-umami-event-pr` attribute distinguishing the 4 PR numbers under one event, rather than 4 bespoke event names for the same underlying action) on the 4 GitHub proof-of-work links.
3. **Booking wizard funnel-depth gap.** `book_step_next` / `book_step_back` fire on every step transition with no way to tell *which* transition (1→2 vs 2→3) — the exact "booking flow steps between CTA and Cal.com" gap called out for this site. Added `data-umami-event-step={step}` to both buttons, additive metadata on the existing event names.
4. **`umami-events.test.ts` pins CRO events to the file that fires them "so a rename fails the build before analytics goes silent" — but 3 events that infra's `brief.py` reads directly (`ev.get('book_step_next')`, `ev.get('book_submit')`, `ev.get('book_qualified_booking_click')`) weren't in that pin list.** A rename of any of these would have gone silent in this repo's own tests while quietly zeroing a line in Sam's Monday digest. Added.

## Verification

Ran this repo's documented invariant end to end in a worktree off `origin/main`: `pnpm format && pnpm lint && pnpm check && pnpm test:unit -- --run && pnpm build`. All green — 35/35 tests pass (3 new, from the pinned events above), 0 type errors, clean build. Pre-existing baseline: `pnpm lint` has 4 errors in `src/lib/client/sanity.ts` unrelated to this diff (confirmed identical via `git stash` against unmodified `main` — a `noPropertyAccessFromIndexSignature`-style env typing issue, not something this PR touches or should fix per `AGENTS.md`'s "don't touch sanity.ts unless extending Studio").

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J3Qq6dLuU7UZtoGgorrMrT