### PR TITLE
feat(analytics): track footer nav clicks

### DIFF
--- a/src/lib/components/SiteFooter.svelte
+++ b/src/lib/components/SiteFooter.svelte
@@ -18,11 +18,17 @@
 		</a>
 		<div class="text-fg-subtle flex flex-wrap items-center justify-center gap-x-5 gap-y-2 text-xs">
 			<span>© {year}</span>
-			<a href="/log" class="hover:text-fg transition-colors">log</a>
-			<a href="/faq" class="hover:text-fg transition-colors">faq</a>
-			<a href="/notify" class="hover:text-fg transition-colors">notify</a>
-			<a href="/privacy" class="hover:text-fg transition-colors">privacy</a>
-			<a href="/terms" class="hover:text-fg transition-colors">terms</a>
+			<a href="/log" data-umami-event="footer_log" class="hover:text-fg transition-colors">log</a>
+			<a href="/faq" data-umami-event="footer_faq" class="hover:text-fg transition-colors">faq</a>
+			<a href="/notify" data-umami-event="footer_notify" class="hover:text-fg transition-colors"
+				>notify</a
+			>
+			<a href="/privacy" data-umami-event="footer_privacy" class="hover:text-fg transition-colors"
+				>privacy</a
+			>
+			<a href="/terms" data-umami-event="footer_terms" class="hover:text-fg transition-colors"
+				>terms</a
+			>
 			<a
 				href={site.gardenUrl}
 				target="_blank"

--- a/src/lib/components/umami-events.test.ts
+++ b/src/lib/components/umami-events.test.ts
@@ -34,7 +34,13 @@ const CLIENT_EVENTS: readonly ClientEvent[] = [
 	// rename fails here before the digest quietly zeroes out.
 	{ event: 'book_step_next', dir: 'route', path: 'book/+page.svelte' },
 	{ event: 'book_submit', dir: 'route', path: 'book/+page.svelte' },
-	{ event: 'book_qualified_booking_click', dir: 'route', path: 'book/+page.svelte' }
+	{ event: 'book_qualified_booking_click', dir: 'route', path: 'book/+page.svelte' },
+	{ event: 'footer_home', dir: 'component', path: 'SiteFooter.svelte' },
+	{ event: 'footer_log', dir: 'component', path: 'SiteFooter.svelte' },
+	{ event: 'footer_faq', dir: 'component', path: 'SiteFooter.svelte' },
+	{ event: 'footer_notify', dir: 'component', path: 'SiteFooter.svelte' },
+	{ event: 'footer_privacy', dir: 'component', path: 'SiteFooter.svelte' },
+	{ event: 'footer_terms', dir: 'component', path: 'SiteFooter.svelte' }
 ]
 
 describe('Umami CRO event instrumentation', () => {


### PR DESCRIPTION
Fleet CTA-coverage sweep. The site-wide footer tracked its wordmark (`footer_home`) and garden link (`cta_garden_link`) but none of the five nav links between them — the only untracked click targets left on the site after #141.

| event | element | location |
|---|---|---|
| `footer_log` | footer nav link → `/log` | `SiteFooter.svelte` (every page) |
| `footer_faq` | footer nav link → `/faq` | `SiteFooter.svelte` (every page) |
| `footer_notify` | footer nav link → `/notify` | `SiteFooter.svelte` (every page) |
| `footer_privacy` | footer nav link → `/privacy` | `SiteFooter.svelte` (every page) |
| `footer_terms` | footer nav link → `/terms` | `SiteFooter.svelte` (every page) |

Also pins the five new events plus the previously unpinned `footer_home` in `umami-events.test.ts` (same hardening #141 applied to its events).

Additive only — existing event names untouched (frozen brief.py contract verified).

Gates: `pnpm lint` ✓ · `pnpm check` 0 errors ✓ · `pnpm test` 43/43 ✓ · `pnpm build` ✓. Verified in built output: attrs present in prerendered HTML (faq/log/privacy/terms) and the SSR `SiteFooter.js` chunk (home/tax/notify/garden-party).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J3Qq6dLuU7UZtoGgorrMrT