### PR TITLE
feat: ?test ejects this browser from analytics (client + server)

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -67,6 +67,19 @@
 		<link rel="icon" href="%sveltekit.assets%/favicon.svg" type="image/svg+xml" />
 		<link rel="apple-touch-icon" sizes="180x180" href="%sveltekit.assets%/apple-touch-icon.png" />
 
+		<script>
+			// testing eject: ?test flips umami's native kill switch for this
+			// browser (persistent); ?test=0 rejoins. Server-side events use the
+			// test_eject cookie (hooks.server.ts) — this covers the client side.
+			try {
+				var q = new URLSearchParams(location.search)
+				if (q.has('test')) {
+					q.get('test') === '0'
+						? localStorage.removeItem('umami.disabled')
+						: localStorage.setItem('umami.disabled', '1')
+				}
+			} catch (e) {}
+		</script>
 		<script
 			defer
 			src="https://analytics.sixtom.com/script.js"

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -1,4 +1,5 @@
 import type { Handle } from '@sveltejs/kit'
+import { building } from '$app/environment'
 
 const MARKETING_CSP = [
 	"default-src 'self'",
@@ -34,6 +35,20 @@ const SECURITY_HEADERS: Readonly<Record<string, string>> = {
 }
 
 export const handle: Handle = async ({ event, resolve }) => {
+	// testing eject: ?test marks this browser so server-side analytics
+	// (fireServerEvent) skip it; ?test=0 rejoins. Client-side umami is
+	// ejected separately via localStorage in app.html — the cookie only
+	// exists because form-submit events fire from the server, which
+	// can't see localStorage. `building` guard: prerendering forbids
+	// touching url.searchParams.
+	if (!building) {
+		const test = event.url.searchParams.get('test')
+		if (test !== null) {
+			if (test === '0') event.cookies.delete('test_eject', { path: '/' })
+			else event.cookies.set('test_eject', '1', { path: '/', maxAge: 60 * 60 * 24 * 365, httpOnly: false })
+		}
+	}
+
 	const response = await resolve(event)
 
 	// CSP + security headers are only meaningful on HTML; static assets ship with

--- a/src/lib/server/umami.ts
+++ b/src/lib/server/umami.ts
@@ -7,6 +7,11 @@ const HOSTNAME = 'sixtom.com'
 // Fire-and-forget server-side Umami event. For signals that originate on the
 // server (successful form submits) where the client may have JS disabled.
 export function fireServerEvent(eventName: UmamiEvent, request: Request): void {
+	// testing eject: browsers marked by ?test (cookie set in hooks.server)
+	// don't produce server-side events. One guard here covers every caller.
+	if (/(?:^|;\s*)test_eject=1(?:;|$)/.test(request.headers.get('cookie') ?? '')) {
+		return
+	}
 	const userAgent = request.headers.get('user-agent') ?? 'unknown'
 	const referrer = request.headers.get('referer') ?? ''
 	const language = request.headers.get('accept-language')?.split(',')[0] ?? 'en'


### PR DESCRIPTION
Sixtom is the two-surface case: client umami tracker AND server-side `fireServerEvent` (form submits). `?test` now ejects both for the browser — localStorage kill switch client-side, year-long `test_eject` cookie server-side (set in hooks, `building`-guarded since prerender forbids searchParams; checked once in `fireServerEvent`, covering every caller). `?test=0` rejoins. svelte-check 0 errors, build passes. Siblings: pyre-divers#47, garden#264.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PPZAb3Vq5TYyhXRxYbKyeX