### PR TITLE
feat(grand-slam): one-offer lander (chunk A — content + lander + jsonld)

### DIFF
--- a/docs/superpowers/plans/2026-07-24-grand-slam-migration.md
+++ b/docs/superpowers/plans/2026-07-24-grand-slam-migration.md
@@ -11,7 +11,7 @@
 ## Global Constraints
 
 - **Voice:** strict lowercase copy (lowercase `i`; caps only for brand names/acronyms: AI, SEO, Lighthouse, Loom, SIXTOM). Terminal periods. Sub-page titles `<subject> | SIXTOM`; home title is the brand-first exception.
-- **Results over mechanism:** the word "agent" must never appear in customer-facing offer copy (pinned by test in Task 1). AI appears only as the *client's* context.
+- **Results over mechanism:** the word "agent" must never appear in customer-facing offer copy (pinned by test in Task 1). AI appears only as the _client's_ context.
 - **Frozen event names** (external consumers / dashboards): `book_step_next`, `book_submit`, `book_qualified_booking_click` (infra brief.py), `cta_notify_submit`, `notify_signup_success`, `footer_*`, `cta_garden_link`, `cta_tax_calc`, `cta_calc_book`, `cta_case_study_book`. Never rename; new events may be added.
 - **Home stays `csr = false`** (`src/routes/+page.ts`). The home waitlist form must work with zero JS (plain POST, no `use:enhance` on home).
 - **Listmonk hygiene:** never let a test email reach the `sixtom` list. Task 3 adds the guard. E2E uses `CONTACT_FORM_TEST_EMAIL` (env var NAME only — value comes from `e2e/constants.ts`).
@@ -31,6 +31,7 @@
 ### Task 1: Content layer — the offer as data
 
 **Files:**
+
 - Modify: `src/lib/content/types.ts`
 - Create: `src/lib/content/offer.ts`
 - Modify: `src/lib/content/site.ts`
@@ -38,6 +39,7 @@
 - Modify: `src/lib/content/content.test.ts`
 
 **Interfaces:**
+
 - Consumes: existing `Stat`, `ProcessStep`, `Offer` types; `site.sprint` pricing fields.
 - Produces: `grandSlam: GrandSlamOffer` (named export from `$lib/content`), `LEDGER_TOTAL_USD: number`, types `LedgerLine`, `LedgerGroup`, `CostCard`, `GrandSlamOffer`. `Site` loses `audit`, `retainer`, `hero`. Later tasks import `{ site, grandSlam, LEDGER_TOTAL_USD }` from `$lib/content`.
 
@@ -339,8 +341,10 @@ export const grandSlam: GrandSlamOffer = {
 			{ value: '7.5×', label: 'lighter page' },
 			{ value: '+185%', label: 'pageviews, last 30d' }
 		],
-		para2: "traffic reversed from a slow decline to steady growth — and it's HIS execution showing up in the data: he's running the strategy, and the results climb as he does. something from nothing.",
-		bridge: "this one wasn't vibe-coded — just slow and invisible. same hands, same discipline, numbers you can check. the first rescue writeup is on the bench right now."
+		para2:
+			"traffic reversed from a slow decline to steady growth — and it's HIS execution showing up in the data: he's running the strategy, and the results climb as he does. something from nothing.",
+		bridge:
+			"this one wasn't vibe-coded — just slow and invisible. same hands, same discipline, numbers you can check. the first rescue writeup is on the bench right now."
 	},
 	isThisYou: {
 		eyebrow: 'is this you?',
@@ -365,7 +369,8 @@ export const grandSlam: GrandSlamOffer = {
 		buildLabel: 'what did you build?',
 		buildPlaceholder: 'a demo of… it works, but…',
 		button: 'get on the list →',
-		reward: "the seat's booked out? good sign. while you wait, you get a free teardown of your app — what's solid, the three things that'll break, and what i'd do first. no pitch attached."
+		reward:
+			"the seat's booked out? good sign. while you wait, you get a free teardown of your app — what's solid, the three things that'll break, and what i'd do first. no pitch attached."
 	}
 }
 
@@ -423,12 +428,14 @@ export type {
 ### Task 2: The lander — Hero + home rewrite
 
 **Files:**
+
 - Modify: `src/lib/components/Hero.svelte`
 - Modify: `src/routes/+page.svelte` (full rewrite)
 - Modify: `src/app.html` (title/description/og/twitter strings)
 - Modify: `src/lib/components/umami-events.test.ts`
 
 **Interfaces:**
+
 - Consumes: `grandSlam`, `LEDGER_TOTAL_USD`, `site` from `$lib/content`.
 - Produces: home sections with ids `#waitlist` (close form anchor). New events: `cta_hero_waitlist`, `cta_hero_teardown`, `cta_waitlist_submit`. Retired events: `cta_hero_book`, `cta_final_book`, `cta_case_study`, `cta_garden_link_why` (removed from pins — none are externally consumed).
 
@@ -451,44 +458,44 @@ Run `pnpm test` → those three FAIL (not present yet).
 ```
 
 ```svelte
-	<div class="relative mx-auto w-full max-w-6xl px-6 text-left md:text-center">
-		<p class="eyebrow text-fg-subtle text-xs md:text-sm">{grandSlam.chip}</p>
-		<h1
-			class="text-fg mt-6 text-[clamp(2.25rem,9.5vw,4.75rem)] leading-[1.08] font-bold tracking-tight"
+<div class="relative mx-auto w-full max-w-6xl px-6 text-left md:text-center">
+	<p class="eyebrow text-fg-subtle text-xs md:text-sm">{grandSlam.chip}</p>
+	<h1
+		class="text-fg mt-6 text-[clamp(2.25rem,9.5vw,4.75rem)] leading-[1.08] font-bold tracking-tight"
+	>
+		{grandSlam.headline}
+	</h1>
+	<p class="text-fg-muted mx-auto mt-6 max-w-3xl text-base leading-relaxed md:text-lg">
+		{grandSlam.lead}
+	</p>
+	<p class="text-fg mx-auto mt-6 max-w-3xl text-xl leading-snug font-medium md:text-2xl">
+		{grandSlam.offerLine}
+	</p>
+	<div class="mt-10 flex flex-col items-start gap-4 md:items-center">
+		<a
+			href="#waitlist"
+			data-umami-event="cta_hero_waitlist"
+			class="btn-accent w-full px-8 py-4 text-center text-xl font-bold md:w-auto md:px-12 md:py-5 md:text-2xl"
 		>
-			{grandSlam.headline}
-		</h1>
-		<p class="text-fg-muted mx-auto mt-6 max-w-3xl text-base leading-relaxed md:text-lg">
-			{grandSlam.lead}
-		</p>
-		<p class="text-fg mx-auto mt-6 max-w-3xl text-xl leading-snug font-medium md:text-2xl">
-			{grandSlam.offerLine}
-		</p>
-		<div class="mt-10 flex flex-col items-start gap-4 md:items-center">
-			<a
-				href="#waitlist"
-				data-umami-event="cta_hero_waitlist"
-				class="btn-accent w-full px-8 py-4 text-center text-xl font-bold md:w-auto md:px-12 md:py-5 md:text-2xl"
-			>
-				join the waitlist →
-			</a>
-			<a
-				href="#waitlist"
-				data-umami-event="cta_hero_teardown"
-				class="text-fg-subtle hover:text-coin text-xs tracking-widest uppercase transition-colors"
-			>
-				or get a free teardown
-			</a>
-		</div>
-		<dl class="mt-12 flex flex-wrap gap-x-10 gap-y-4 md:justify-center">
-			{#each grandSlam.stats as stat (stat.label)}
-				<div>
-					<dt class="text-fg-subtle order-2 text-xs tracking-widest uppercase">{stat.label}</dt>
-					<dd class="text-fg text-lg font-bold tabular-nums md:text-xl">{stat.value}</dd>
-				</div>
-			{/each}
-		</dl>
+			join the waitlist →
+		</a>
+		<a
+			href="#waitlist"
+			data-umami-event="cta_hero_teardown"
+			class="text-fg-subtle hover:text-coin text-xs tracking-widest uppercase transition-colors"
+		>
+			or get a free teardown
+		</a>
 	</div>
+	<dl class="mt-12 flex flex-wrap gap-x-10 gap-y-4 md:justify-center">
+		{#each grandSlam.stats as stat (stat.label)}
+			<div>
+				<dt class="text-fg-subtle order-2 text-xs tracking-widest uppercase">{stat.label}</dt>
+				<dd class="text-fg text-lg font-bold tabular-nums md:text-xl">{stat.value}</dd>
+			</div>
+		{/each}
+	</dl>
+</div>
 ```
 
 (XMark/BookCta imports drop from Hero; BookCta itself stays — /faq and garden-party still use it.)
@@ -723,12 +730,14 @@ Run `pnpm test` → those three FAIL (not present yet).
 ### Task 3: Waitlist wiring — /notify becomes the waitlist + listmonk test-email guard
 
 **Files:**
+
 - Modify: `src/routes/notify/+page.svelte`
 - Modify: `src/routes/notify/+page.server.ts`
 - Modify: `src/lib/types/index.ts`
 - Modify: `e2e/notify-form.spec.ts`
 
 **Interfaces:**
+
 - Consumes: `grandSlam.close` copy; existing `processSubmission`, `subscribeToList`, `fireServerEvent`.
 - Produces: `/notify?/notify` action unchanged in name/shape (home form depends on it). Event names `cta_notify_submit` + `notify_signup_success` preserved.
 
@@ -793,14 +802,14 @@ import { env } from '$env/dynamic/private'
 and change the subscribe condition to:
 
 ```ts
-			const emailField = formData.get('email')
-			const email = (typeof emailField === 'string' ? emailField : '').trim()
-			// The e2e bypass address must never pollute the real list.
-			const testEmail = (env['CONTACT_FORM_TEST_EMAIL'] ?? '').trim()
-			const isTestEmail = testEmail !== '' && email === testEmail
-			if (!result.suspicious && email && !isTestEmail) {
-				await subscribeToList(email, SIXTOM_LIST_UUID)
-			}
+const emailField = formData.get('email')
+const email = (typeof emailField === 'string' ? emailField : '').trim()
+// The e2e bypass address must never pollute the real list.
+const testEmail = (env['CONTACT_FORM_TEST_EMAIL'] ?? '').trim()
+const isTestEmail = testEmail !== '' && email === testEmail
+if (!result.suspicious && email && !isTestEmail) {
+	await subscribeToList(email, SIXTOM_LIST_UUID)
+}
 ```
 
 - [ ] **Step 3: /notify page rewrite** — same file structure as current (`enhance`, honeypot, hidden `formStartedAt`/`enhanced`), with: `<title>waitlist | SIXTOM</title>`; **remove** `<meta name="robots" content="noindex, follow" />` (this page is now a primary CTA target); heading block from `grandSlam.close` (`heading`, scarcity as the eyebrow, `reward` para below the form); the hidden fixed `message` input becomes the required build `textarea` (same `name="message"`, label `what did you build?`, placeholder from content); hidden `name` value stays `"Waitlist signup"`. Keep `cta_notify_submit` on the submit button. Description meta: `"one client a month. join the waitlist — and get a free teardown of your app while you wait."`
@@ -817,33 +826,35 @@ and change the subscribe condition to:
 ### Task 4: JSON-LD — the schema tells the same story
 
 **Files:**
+
 - Modify: `src/lib/seo/jsonld.ts`
 - Modify: `src/lib/seo/jsonld.test.ts`
 
 **Interfaces:**
+
 - Consumes: `grandSlam.offerLine`, `grandSlam.close.reward` phrasing, `site.sprint`.
 - Produces: `serviceJsonLd()` with exactly 2 offers: the sprint and the free teardown.
 
 - [ ] **Step 1: Failing test** — replace the `serviceJsonLd` block in `jsonld.test.ts`:
 
 ```ts
-	it('serviceJsonLd sells exactly the two live offers: sprint + free teardown', () => {
-		const ld = serviceJsonLd()
-		expect(ld['@context']).toBe('https://schema.org')
-		expect(ld['@type']).toBe('Service')
-		expect(ld.provider['@id']).toBe(PERSON_ID)
-		expect(ld.areaServed).toBe('Worldwide')
-		expect(ld.description).toContain('day 10')
-		expect(ld.offers).toHaveLength(2)
-		expect(ld.offers[0]?.name).toBe(site.sprint.name)
-		expect(ld.offers[0]?.price).toBe(String(site.sprint.priceUSD))
-		expect(ld.offers[0]?.availability).toBe('https://schema.org/LimitedAvailability')
-		expect(ld.offers[0]?.description).toContain('day 10')
-		expect(ld.offers[1]?.name).toBe('free teardown')
-		expect(ld.offers[1]?.price).toBe('0')
-		expect(ld.offers[1]?.availability).toBe('https://schema.org/InStock')
-		expect(ld.offers[1]?.url).toBe(`${site.siteUrl}/notify`)
-	})
+it('serviceJsonLd sells exactly the two live offers: sprint + free teardown', () => {
+	const ld = serviceJsonLd()
+	expect(ld['@context']).toBe('https://schema.org')
+	expect(ld['@type']).toBe('Service')
+	expect(ld.provider['@id']).toBe(PERSON_ID)
+	expect(ld.areaServed).toBe('Worldwide')
+	expect(ld.description).toContain('day 10')
+	expect(ld.offers).toHaveLength(2)
+	expect(ld.offers[0]?.name).toBe(site.sprint.name)
+	expect(ld.offers[0]?.price).toBe(String(site.sprint.priceUSD))
+	expect(ld.offers[0]?.availability).toBe('https://schema.org/LimitedAvailability')
+	expect(ld.offers[0]?.description).toContain('day 10')
+	expect(ld.offers[1]?.name).toBe('free teardown')
+	expect(ld.offers[1]?.price).toBe('0')
+	expect(ld.offers[1]?.availability).toBe('https://schema.org/InStock')
+	expect(ld.offers[1]?.url).toBe(`${site.siteUrl}/notify`)
+})
 ```
 
 Run: `pnpm test` → FAIL (3 offers, audit first).
@@ -851,27 +862,27 @@ Run: `pnpm test` → FAIL (3 offers, audit first).
 - [ ] **Step 2: Implement** — in `jsonld.ts`, add `import { grandSlam } from '$lib/content'`; in `serviceJsonLd()` delete `auditDescription`/`retainerDescription` and the audit/retainer offer objects; set `description: grandSlam.offerLine`; offers become:
 
 ```ts
-		offers: [
-			{
-				'@type': 'Offer',
-				name: site.sprint.name,
-				description: sprintDescription,
-				price: String(site.sprint.priceUSD),
-				priceCurrency: 'USD',
-				availability: 'https://schema.org/LimitedAvailability',
-				url: bookUrl
-			},
-			{
-				'@type': 'Offer',
-				name: 'free teardown',
-				description:
-					"a free teardown of your app — what's solid, the three things that'll break, and what i'd do first. join the waitlist to get one.",
-				price: '0',
-				priceCurrency: 'USD',
-				availability: 'https://schema.org/InStock',
-				url: `${site.siteUrl}/notify`
-			}
-		]
+offers: [
+	{
+		'@type': 'Offer',
+		name: site.sprint.name,
+		description: sprintDescription,
+		price: String(site.sprint.priceUSD),
+		priceCurrency: 'USD',
+		availability: 'https://schema.org/LimitedAvailability',
+		url: bookUrl
+	},
+	{
+		'@type': 'Offer',
+		name: 'free teardown',
+		description:
+			"a free teardown of your app — what's solid, the three things that'll break, and what i'd do first. join the waitlist to get one.",
+		price: '0',
+		priceCurrency: 'USD',
+		availability: 'https://schema.org/InStock',
+		url: `${site.siteUrl}/notify`
+	}
+]
 ```
 
 and extend `sprintDescription`'s first element to carry the guarantee: `'two weeks from working demo to production-grade. live in production by day 10 — or the remaining payments are free.'`
@@ -884,6 +895,7 @@ and extend `sprintDescription`'s first element to carry the guarantee: `'two wee
 ### Task 5: /faq — re-answered for the one offer
 
 **Files:**
+
 - Modify: `src/lib/content/faq.ts` (full replacement of the FAQ array)
 - Modify: `src/routes/faq/+page.svelte` (meta description + og only)
 
@@ -956,6 +968,7 @@ export const FAQ: readonly QA[] = [
 ### Task 6: /terms — the contract matches the promise
 
 **Files:**
+
 - Modify: `src/routes/terms/+page.svelte`
 
 The current refunds section says the sprint scope-stop refunds 50% — the new offer says "pay only for the time used," and the day-10 guarantee + stall clause don't exist here yet. This page is the legal backstop for the guarantee; it ships in the same train or the offer is contradicted at the contract layer.
@@ -963,27 +976,27 @@ The current refunds section says the sprint scope-stop refunds 50% — the new o
 - [ ] **Step 1:** Replace the refunds `<section>` with two sections (keep classes identical to siblings):
 
 ```svelte
-			<section>
-				<h2 class="text-fg text-xl font-semibold tracking-tight">the guarantee</h2>
-				<p class="mt-3">
-					the sprint — live in production by day 10, or the remaining payments are waived. "live"
-					means the deploy target we name in writing on the day-0 call. the guarantee clock pauses
-					while something i need sits with you — access, approvals, content, feedback — and resumes
-					when i have it.
-				</p>
-				<p class="mt-3">
-					the day-5 scope check — if we both see it won't ship in scope, we stop there. you keep
-					everything built and pay only for the time used.
-				</p>
-			</section>
+<section>
+	<h2 class="text-fg text-xl font-semibold tracking-tight">the guarantee</h2>
+	<p class="mt-3">
+		the sprint — live in production by day 10, or the remaining payments are waived. "live" means
+		the deploy target we name in writing on the day-0 call. the guarantee clock pauses while
+		something i need sits with you — access, approvals, content, feedback — and resumes when i have
+		it.
+	</p>
+	<p class="mt-3">
+		the day-5 scope check — if we both see it won't ship in scope, we stop there. you keep
+		everything built and pay only for the time used.
+	</p>
+</section>
 
-			<section>
-				<h2 class="text-fg text-xl font-semibold tracking-tight">the free teardown</h2>
-				<p class="mt-3">
-					the teardown is free, carries no obligation on either side, and i may decline to record
-					one if your project isn't a fit.
-				</p>
-			</section>
+<section>
+	<h2 class="text-fg text-xl font-semibold tracking-tight">the free teardown</h2>
+	<p class="mt-3">
+		the teardown is free, carries no obligation on either side, and i may decline to record one if
+		your project isn't a fit.
+	</p>
+</section>
 ```
 
 - [ ] **Step 2:** Update the header paragraph (drop "pricing, scope, and cadence live on the home page" phrasing only if it's now false — it isn't; keep) and the meta description: `"how engagement with sixtom works. plain-English terms for the sprint, the day-10 guarantee, and the free teardown."` Bump the "last updated" line to `july 2026`. Code-ownership and if-something-breaks sections stay verbatim.
@@ -994,6 +1007,7 @@ The current refunds section says the sprint scope-stop refunds 50% — the new o
 ### Task 7: cal.com intake + /book sweep
 
 **Files:**
+
 - Modify: `src/lib/content/site.ts` (`calEvent` only)
 - Modify: `src/routes/book/+page.svelte` (meta description only)
 - Modify: `src/routes/book/options.ts` (budget labels/values)
@@ -1021,11 +1035,7 @@ export const calEvent: CalEvent = {
 		{
 			label: 'where are you in the process?',
 			type: 'select',
-			options: [
-				'on the waitlist',
-				'got my free teardown — ready to talk',
-				'just found sixtom'
-			],
+			options: ['on the waitlist', 'got my free teardown — ready to talk', 'just found sixtom'],
 			required: true
 		}
 	]
@@ -1053,6 +1063,7 @@ export const BUDGET_OPTIONS = [
 ### Task 8: Exemplary pass — the site is the receipts
 
 **Files:**
+
 - Create: `.agent-toolkit/lighthouse.toml`
 - Create: `.agent-toolkit/journeys.md`
 - Modify: `AGENTS.md` (offer sections)
@@ -1089,20 +1100,24 @@ samples = 3
 App: `pnpm dev` (SvelteKit, http://localhost:5173). Set CONTACT_FORM_TEST_EMAIL=e2e@test.sixtom.local in the dev env before driving journey 1 — the waitlist form must never hit listmonk or SMTP with a real address.
 
 ## 1. land → read the offer → join the waitlist
+
 1. Open `/`. Expect: h1 "the demo works. production doesn't.", chip "1 client a month · waitlist open", stat "day 10 or free".
 2. Scroll through wall → ledger → guarantee → proof. Expect: ledger shows "total value" of "$28,500+" and a pay line containing "$10,000"; guarantee headline contains "day 10"; proof tiles include "+185%".
 3. Fill `#waitlist-email` with e2e@test.sixtom.local and `#waitlist-build` with any text; submit.
 4. Expect: navigation to `/notify` showing "You're on the list." No console errors, no failed network requests anywhere in the journey.
 
 ## 2. the tax loop
+
 1. Open `/`, click the "run yours →" link in the wall section.
 2. On `/tax`: expect h1 "what's it costing you?" and a non-$0 annual tax figure with default inputs.
 3. Click the calculator CTA (event `cta_calc_book`). Expect `/book` step 1 ("where are you with this thing?") renders. No console errors.
 
 ## 3. faq → book
+
 1. Open `/faq`. Expect: ≥10 questions rendered, one containing "day 10" (the guarantee answer), zero mentions of "$1,500" or "retainer".
 2. Click the BookCta. Expect `/book` step 1 renders. No console errors.
 ```
+
 - [ ] **Step 4:** `AGENTS.md` — update the offer/pricing paragraphs: one $10,000 sprint ($7,500 first 3, 4×$2,500), day-10-or-free guarantee with day-5 floor, free teardown via waitlist (/notify), no public audit/retainer (retainer = private post-sprint continuation, off-page by design), ledger/content lives in `src/lib/content/offer.ts`, "results over mechanism" copy rule (no "agent" in customer copy — pinned by content.test.ts).
 - [ ] **Step 5:** Verify `static/og.png` still shows copy consistent with the new offer; if it carries the old tagline, flag to Sam for a regen from `scripts/og-source` (art asset — his call, not blocking).
 - [ ] **Step 6: Full gates on the integration branch** — `pnpm format && pnpm lint && pnpm check && pnpm test && pnpm test:e2e && pnpm build` (if `e2e/visual-theme.spec.ts` asserts old-home selectors/copy, update those assertions to the new sections as part of this step), then `/rev` the final chunk, then `/drive` the three journeys, then `/lighthouse` against the branch build, then `/a11y` (new UI shipped).

--- a/e2e/visual-theme.spec.ts
+++ b/e2e/visual-theme.spec.ts
@@ -40,10 +40,11 @@ test.describe('Visual surface — dark/light alternation', () => {
 		}
 		expect(surfaces[0]).not.toBe(surfaces[1])
 
-		// Footer (inside the closing UV section) keeps its explicit dark surface —
-		// the page opens dark and visually closes dark.
+		// SiteFooter (inside the closing UV section) keeps its explicit dark
+		// surface — the page opens dark and visually closes dark. Scoped selector:
+		// the testimonial blockquote also contains a <footer> (attribution).
 		const footerBg = await page
-			.locator('footer')
+			.locator('footer', { has: page.locator('[data-umami-event="footer_home"]') })
 			.evaluate((el) => getComputedStyle(el).backgroundColor)
 		expect(footerBg).toBe(surfaces[0])
 

--- a/e2e/visual-theme.spec.ts
+++ b/e2e/visual-theme.spec.ts
@@ -16,32 +16,36 @@ async function openPage(browser: Browser, width = 1280, height = 720) {
 }
 
 test.describe('Visual surface — dark/light alternation', () => {
-	test('sections alternate D L D L, first dark, marquee dark', async ({ browser }) => {
+	test('grand-slam page: 8 sections alternate dark/UV, first dark', async ({ browser }) => {
 		const { context, page } = await openPage(browser)
 		await page.goto('/', { waitUntil: 'domcontentloaded' })
 
+		// hero → wall → ledger → guarantee → proof → is-this-you → timeline → close
 		const sections = await page.locator('section').all()
-		expect(sections.length).toBe(5)
+		expect(sections.length).toBe(8)
 
 		const surfaces = await Promise.all(
 			sections.map((s) => s.evaluate((el) => getComputedStyle(el).backgroundColor))
 		)
 
-		// Alternation D L D L D — first/third/fifth dark, second/fourth UV.
+		// Strict D U D U D U D U — two distinct surfaces, alternating, first dark.
 		const distinct = new Set(surfaces)
 		expect(distinct.size, `expected 2 alternating surfaces, got ${[...distinct].join(' | ')}`).toBe(
 			2
 		)
-		expect(surfaces[0]).toBe(surfaces[2])
-		expect(surfaces[2]).toBe(surfaces[4])
-		expect(surfaces[1]).toBe(surfaces[3])
+		for (let i = 2; i < surfaces.length; i++) {
+			expect(surfaces[i], `section ${String(i)} should match section ${String(i - 2)}`).toBe(
+				surfaces[i - 2]
+			)
+		}
 		expect(surfaces[0]).not.toBe(surfaces[1])
 
-		// Marquee link (inside the last UV section) is explicitly dark — visual close on dark.
-		const marqueeBg = await page
-			.locator('[data-umami-event="cta_garden_link"]')
+		// Footer (inside the closing UV section) keeps its explicit dark surface —
+		// the page opens dark and visually closes dark.
+		const footerBg = await page
+			.locator('footer')
 			.evaluate((el) => getComputedStyle(el).backgroundColor)
-		expect(marqueeBg).toBe(surfaces[0])
+		expect(footerBg).toBe(surfaces[0])
 
 		await context.close()
 	})

--- a/src/app.css
+++ b/src/app.css
@@ -33,8 +33,10 @@
 
 	--color-surface: oklch(14.5% 0 0);
 	--color-fg: oklch(97% 0 0);
-	--color-fg-muted: oklch(70.8% 0 0);
-	--color-fg-subtle: oklch(60% 0 0);
+	/* Muted/subtle lifted 2026-07-24 (Sam: "contrast not accessible") — subtle
+	 * was 5.01:1 (AA-only); now ~6.3:1 and ~8.9:1 on the dark surface. */
+	--color-fg-muted: oklch(75% 0 0);
+	--color-fg-subtle: oklch(66% 0 0);
 	--color-border: oklch(26.9% 0 0);
 	--color-border-strong: oklch(37.1% 0 0);
 	--color-accent: oklch(70% 0.15 195);
@@ -51,7 +53,7 @@
 	--color-surface: oklch(98% 0.005 85);
 	--color-fg: oklch(15% 0 0);
 	--color-fg-muted: oklch(40% 0 0);
-	--color-fg-subtle: oklch(50% 0 0);
+	--color-fg-subtle: oklch(45% 0 0); /* was 50% — 5.66:1 AA-only; now ~7:1 */
 	--color-border: oklch(86% 0.005 85);
 	--color-border-strong: oklch(72% 0.005 85);
 	--shadow-accent:

--- a/src/app.html
+++ b/src/app.html
@@ -7,10 +7,10 @@
 		<meta name="author" content="Salvatore D'Angelo" />
 		<meta name="format-detection" content="telephone=no" />
 
-		<title>SIXTOM — i build your solution.</title>
+		<title>SIXTOM — the demo works. production doesn't.</title>
 		<meta
 			name="description"
-			content="AI built your first draft. i build your solution. production-grade in two weeks. $10,000 flat, 1 client a month."
+			content="the production sprint: live in production on day 10 — and you own every line of it. $10,000 flat, 1 client a month."
 		/>
 		<!-- Canonical URL is set dynamically per-route in src/routes/+layout.svelte
 		     using $app/state's page.url.pathname; do not hardcode here to avoid
@@ -36,10 +36,10 @@
 			crossorigin
 		/>
 
-		<meta property="og:title" content="SIXTOM — i build your solution." />
+		<meta property="og:title" content="SIXTOM — the demo works. production doesn't." />
 		<meta
 			property="og:description"
-			content="production-grade in two weeks. $10,000 flat, 1 client a month."
+			content="live in production on day 10 — and you own every line of it. $10,000 flat, 1 client a month."
 		/>
 		<meta property="og:type" content="website" />
 		<!-- og:url lives in +layout.svelte (per-route, alongside canonical) — a
@@ -47,22 +47,16 @@
 		<meta property="og:image" content="https://sixtom.com/og.png" />
 		<meta property="og:image:width" content="1200" />
 		<meta property="og:image:height" content="630" />
-		<meta
-			property="og:image:alt"
-			content="SIXTOM — AI built your first draft. I build your solution."
-		/>
+		<meta property="og:image:alt" content="SIXTOM — the demo works. production doesn't." />
 
 		<meta name="twitter:card" content="summary_large_image" />
-		<meta name="twitter:title" content="SIXTOM — i build your solution." />
+		<meta name="twitter:title" content="SIXTOM — the demo works. production doesn't." />
 		<meta
 			name="twitter:description"
-			content="production-grade in two weeks. $10,000 flat, 1 client a month."
+			content="live in production on day 10 — and you own every line of it. $10,000 flat, 1 client a month."
 		/>
 		<meta name="twitter:image" content="https://sixtom.com/og.png" />
-		<meta
-			name="twitter:image:alt"
-			content="SIXTOM — AI built your first draft. I build your solution."
-		/>
+		<meta name="twitter:image:alt" content="SIXTOM — the demo works. production doesn't." />
 
 		<link rel="icon" href="%sveltekit.assets%/favicon.svg" type="image/svg+xml" />
 		<link rel="apple-touch-icon" sizes="180x180" href="%sveltekit.assets%/apple-touch-icon.png" />

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -45,7 +45,12 @@ export const handle: Handle = async ({ event, resolve }) => {
 		const test = event.url.searchParams.get('test')
 		if (test !== null) {
 			if (test === '0') event.cookies.delete('test_eject', { path: '/' })
-			else event.cookies.set('test_eject', '1', { path: '/', maxAge: 60 * 60 * 24 * 365, httpOnly: false })
+			else
+				event.cookies.set('test_eject', '1', {
+					path: '/',
+					maxAge: 60 * 60 * 24 * 365,
+					httpOnly: false
+				})
 		}
 	}
 

--- a/src/lib/components/Hero.svelte
+++ b/src/lib/components/Hero.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
-	import XMark from './XMark.svelte'
-	import BookCta from './BookCta.svelte'
+	import { grandSlam } from '$lib/content'
 </script>
 
 <section class="snap-section bg-surface relative">
@@ -20,21 +19,42 @@
 		<div class="absolute inset-0 hidden bg-gradient-to-r from-black/85 to-black/45 md:block"></div>
 	</div>
 
-	<div class="relative mx-auto w-full max-w-6xl px-6 text-left md:text-center">
-		<!-- Lead with the question as the hero title; the positioning line follows,
-		     bright and bold (the wedge, not a footnote), with "your solution" the
-		     emphasized payoff. -->
-		<h1 class="text-fg text-[clamp(2.25rem,9.5vw,4.75rem)] leading-[1.08] font-bold tracking-tight">
-			what's the <XMark class="text-accent bg-surface border-2 border-current" /> between you and peace
-			of mind?
+	<div class="relative mx-auto w-full max-w-6xl px-6 py-16 text-left md:py-20 md:text-center">
+		<p class="eyebrow text-fg-subtle text-xs md:text-sm">{grandSlam.chip}</p>
+		<h1
+			class="text-fg mt-6 text-[clamp(2.25rem,8.5vw,4.5rem)] leading-[1.08] font-bold tracking-tight"
+		>
+			{grandSlam.headline}
 		</h1>
-		<p class="text-fg mx-auto mt-6 max-w-3xl text-xl leading-snug font-medium md:mt-8 md:text-3xl">
-			AI built your first draft. i build <span class="font-bold whitespace-nowrap"
-				>your solution.</span
-			>
+		<p class="text-fg-muted mx-auto mt-6 max-w-3xl text-base leading-relaxed md:text-lg">
+			{grandSlam.lead}
 		</p>
-		<div class="mt-12">
-			<BookCta event="cta_hero_book" />
+		<p class="text-fg mx-auto mt-6 max-w-3xl text-xl leading-snug font-medium md:text-2xl">
+			{grandSlam.offerLine}
+		</p>
+		<div class="mt-10 flex flex-col items-start gap-4 md:items-center">
+			<a
+				href="#waitlist"
+				data-umami-event="cta_hero_waitlist"
+				class="btn-accent w-full px-8 py-4 text-center text-xl font-bold md:w-auto md:px-12 md:py-5 md:text-2xl"
+			>
+				join the waitlist →
+			</a>
+			<a
+				href="#waitlist"
+				data-umami-event="cta_hero_teardown"
+				class="text-fg-subtle hover:text-coin text-xs tracking-widest uppercase transition-colors"
+			>
+				or get a free teardown
+			</a>
 		</div>
+		<ul class="mt-12 flex list-none flex-wrap gap-x-10 gap-y-4 p-0 md:justify-center">
+			{#each grandSlam.stats as stat (stat.label)}
+				<li>
+					<p class="text-fg text-lg font-bold tabular-nums md:text-xl">{stat.value}</p>
+					<p class="text-fg-subtle text-xs tracking-widest uppercase">{stat.label}</p>
+				</li>
+			{/each}
+		</ul>
 	</div>
 </section>

--- a/src/lib/components/VibeTaxCalculator.svelte
+++ b/src/lib/components/VibeTaxCalculator.svelte
@@ -154,7 +154,7 @@
 				data-umami-event="cta_calc_book"
 				class="btn-accent mt-10 w-full px-8 py-4 text-center text-xl font-bold md:w-auto md:px-12 md:py-5 md:text-2xl"
 			>
-				see if a sprint can fix this
+				see if i can help
 			</a>
 		</div>
 	</div>

--- a/src/lib/components/umami-events.test.ts
+++ b/src/lib/components/umami-events.test.ts
@@ -16,12 +16,11 @@ interface ClientEvent {
 }
 
 const CLIENT_EVENTS: readonly ClientEvent[] = [
-	{ event: 'cta_hero_book', dir: 'component', path: 'Hero.svelte' },
+	{ event: 'cta_hero_waitlist', dir: 'component', path: 'Hero.svelte' },
+	{ event: 'cta_hero_teardown', dir: 'component', path: 'Hero.svelte' },
 	{ event: 'cta_garden_link', dir: 'component', path: 'SiteFooter.svelte' },
 	{ event: 'cta_tax_calc', dir: 'route', path: '+page.svelte' },
-	{ event: 'cta_case_study', dir: 'route', path: '+page.svelte' },
-	{ event: 'cta_garden_link_why', dir: 'route', path: '+page.svelte' },
-	{ event: 'cta_final_book', dir: 'route', path: '+page.svelte' },
+	{ event: 'cta_waitlist_submit', dir: 'route', path: '+page.svelte' },
 	{ event: 'cta_faq_book', dir: 'route', path: 'faq/+page.svelte' },
 	{ event: 'cta_notify_submit', dir: 'route', path: 'notify/+page.svelte' },
 	{ event: 'cta_calc_book', dir: 'component', path: 'VibeTaxCalculator.svelte' },

--- a/src/lib/content/content.test.ts
+++ b/src/lib/content/content.test.ts
@@ -1,13 +1,41 @@
 import { describe, it, expect } from 'vitest'
-import { site, calEvent } from './index'
+import { site, calEvent, grandSlam, LEDGER_TOTAL_USD } from './index'
 
 describe('content', () => {
-	it('site exports the operator + audit + sprint', () => {
+	it('site exports the operator + sprint (audit and retainer are gone)', () => {
 		expect(site.operator.name).toBe("Salvatore D'Angelo")
-		expect(site.audit.priceUSD).toBe(1500)
 		expect(site.sprint.priceUSD).toBe(10000)
 		expect(site.sprint.introPriceUSD).toBe(7500)
 		expect(site.bookingUrl).toMatch(/^https?:\/\//)
+		expect('audit' in site).toBe(false)
+		expect('retainer' in site).toBe(false)
+	})
+
+	it('ledger line values sum to the advertised total', () => {
+		const sum = grandSlam.ledger.groups
+			.flatMap((g) => g.lines)
+			.reduce((acc, l) => acc + (l.valueUSD ?? 0), 0)
+		expect(sum).toBe(28500)
+		expect(LEDGER_TOTAL_USD).toBe(sum)
+	})
+
+	it('pay line is derived from sprint pricing (single source of truth)', () => {
+		expect(grandSlam.ledger.payLine).toContain('$10,000')
+		expect(grandSlam.ledger.payLine).toContain('$7,500')
+		expect(grandSlam.ledger.payLine).toContain('4 weekly payments of $2,500')
+	})
+
+	it('guarantee is the day-10 promise', () => {
+		expect(grandSlam.guarantee.headline).toContain('day 10')
+		expect(grandSlam.guarantee.headline).toContain('free')
+	})
+
+	it('results over mechanism: no "agent" anywhere in customer-facing offer copy', () => {
+		expect(JSON.stringify(grandSlam).toLowerCase()).not.toContain('agent')
+	})
+
+	it('honest at zero: no slot counters in the copy', () => {
+		expect(JSON.stringify(grandSlam)).not.toMatch(/\bof 3 left\b|\bslots? left\b/i)
 	})
 
 	it('calEvent has the fields the sync script needs', () => {

--- a/src/lib/content/index.ts
+++ b/src/lib/content/index.ts
@@ -1,3 +1,15 @@
 export { site, calEvent } from './site'
+export { grandSlam, LEDGER_TOTAL_USD } from './offer'
 export { FAQ } from './faq'
-export type { Operator, Offer, Site, CalEvent, IntakeQuestion, QA } from './types'
+export type {
+	Operator,
+	Offer,
+	Site,
+	CalEvent,
+	IntakeQuestion,
+	QA,
+	LedgerLine,
+	LedgerGroup,
+	CostCard,
+	GrandSlamOffer
+} from './types'

--- a/src/lib/content/offer.ts
+++ b/src/lib/content/offer.ts
@@ -160,7 +160,7 @@ export const grandSlam: GrandSlamOffer = {
 	proof: {
 		eyebrow: 'proof · something from nothing',
 		heading: 'a solo practice with no way to reach its own clients.',
-		para: 'a men’s-mental-health therapist had a slow, drifting site and one channel: rented directory listings, with insurance deciding who found him. i rebuilt the whole thing custom and gave him a growth engine he owns. the craft shows in the numbers:',
+		para: "a men's-mental-health therapist had a slow, drifting site and one channel: rented directory listings, with insurance deciding who found him. i rebuilt the whole thing custom and gave him a growth engine he owns. the craft shows in the numbers:",
 		tiles: [
 			{ value: '100s', label: 'desktop Lighthouse' },
 			{ value: '8.3s→2.9s', label: 'mobile load' },

--- a/src/lib/content/offer.ts
+++ b/src/lib/content/offer.ts
@@ -1,0 +1,205 @@
+import type { GrandSlamOffer } from './types'
+import { site } from './site'
+
+// The one offer. Copy source of truth: vault "sixtom grand slam — page copy
+// (voice pass)". Rules baked in and pinned by content.test.ts: no "agent" in
+// customer copy (results over mechanism), no slot counters (honest at zero).
+export const grandSlam: GrandSlamOffer = {
+	chip: '1 client a month · waitlist open',
+	headline: "the demo works. production doesn't.",
+	lead: "AI gets you to a demo because it can hold the whole thing in its head. once your codebase outgrows that window, it starts making things worse instead of better. that's the wall every vibe-coded project hits. it's also the thing i fix.",
+	offerLine:
+		'the production sprint. two weeks. live in production on day 10 — and you own every line of it.',
+	stats: [
+		{ value: '2 weeks', label: 'per sprint' },
+		{ value: 'all async', label: 'no standups' },
+		{ value: 'day 10 or free', label: 'the guarantee' }
+	],
+	wall: {
+		eyebrow: 'the wall',
+		thesis: 'vibe coding is how you slowly become the intern of your own codebase.',
+		para: "you shipped a demo and it felt like magic. then the edits started breaking things you didn't touch. every new feature costs more than the last. you're not building anymore — you're negotiating with a machine that no longer understands what it built.",
+		turn: "the demo is real. the foundation isn't. and every month it stays that way has a price:",
+		costCards: [
+			{ title: 'the users', sub: 'who hit a bug and never come back' },
+			{ title: 'the launch', sub: 'that slips another month, then another' },
+			{ title: 'the weekends', sub: 'spent firefighting instead of living' }
+		],
+		taxLine: 'every month it stays broken has a number.'
+	},
+	ledger: {
+		eyebrow: 'what you get',
+		heading: 'a real foundation, in two weeks.',
+		para: "i rebuild it the way i'd build it for myself — the architecture, the security, the tests, the judgment calls you can't vibe your way through. everything in the sprint, and what it'd cost you piecemeal:",
+		groups: [
+			{
+				title: 'the foundation',
+				lines: [
+					{
+						line: 'architecture teardown + premortem',
+						sub: 'exactly what will break, and why',
+						valueUSD: 3000
+					},
+					{
+						line: 'the rebuild',
+						sub: 'your product, standing on foundations that hold',
+						valueUSD: null,
+						valueLabel: 'core'
+					},
+					{
+						line: 'security review on every commit',
+						sub: "nothing ships that i haven't read",
+						valueUSD: 2000
+					},
+					{
+						line: 'automated test suite',
+						sub: 'so it stays fixed after i leave',
+						valueUSD: 2500
+					},
+					{
+						line: 'performance to 100s',
+						sub: "and i'll tell you when a third-party script makes that impossible",
+						valueUSD: 1500
+					},
+					{
+						line: 'accessibility pass',
+						sub: 'works for everyone who shows up',
+						valueUSD: 1500
+					}
+				]
+			},
+			{
+				title: 'the growth foundation',
+				note: 'straight with you: search and answer-engines pay off over months, not days. the sprint makes you findable, measurable, and ready to test from day one — the compounding comes from what you publish after. the growth map shows you where to push.',
+				lines: [
+					{
+						line: 'analytics + observability',
+						sub: "you see what's working from day one",
+						valueUSD: 1500
+					},
+					{
+						line: 'CRO-ready pages + A/B scaffold',
+						sub: 'every idea after launch is a test, not a rewrite',
+						valueUSD: 2500
+					},
+					{
+						line: 'technical SEO foundation',
+						sub: 'schema, sitemaps, core web vitals',
+						valueUSD: 2000
+					},
+					{
+						line: 'AEO/GEO foundation',
+						sub: 'structured for the answer-engines, so AI recommends you too',
+						valueUSD: 2000
+					},
+					{
+						line: 'infra cost audit',
+						sub: 'kill the subscriptions your stack is quietly renting',
+						valueUSD: 1000
+					}
+				]
+			},
+			{
+				title: 'the brand',
+				lines: [
+					{
+						line: 'conversion copy pass',
+						sub: 'every word on the page earning its keep',
+						valueUSD: 1500
+					},
+					{
+						line: 'brand kit + 1-of-1 art',
+						sub: 'colors, type, and an original piece nobody else has',
+						valueUSD: 3000
+					}
+				]
+			},
+			{
+				title: 'the close',
+				lines: [
+					{
+						line: 'live in production by day 10',
+						sub: 'you own 100% of it',
+						valueUSD: null,
+						valueLabel: 'included'
+					},
+					{ line: 'day-30 check-in', sub: "what stuck, what didn't", valueUSD: 500 }
+				]
+			},
+			{
+				title: 'the bonuses',
+				note: 'bonuses land by day 30.',
+				lines: [
+					{
+						line: 'the AI leverage session',
+						sub: 'what to lean on, what to skip, how not to wreck what we just built',
+						valueUSD: 1000
+					},
+					{
+						line: 'the 90-day growth map',
+						sub: 'the highest-impact moves, in order',
+						valueUSD: 1500
+					},
+					{
+						line: 'the runbook + Loom library',
+						sub: "so you're never dependent on me again",
+						valueUSD: 1500
+					}
+				]
+			}
+		],
+		payLine: `$${site.sprint.priceUSD.toLocaleString('en-US')} fixed. $${(site.sprint.introPriceUSD ?? 0).toLocaleString('en-US')} for the ${site.sprint.introNote ?? 'first clients'}. or ${site.sprint.paymentPlan ?? ''}.`,
+		anchorLine:
+			'a dev shop quotes $50k and three months. a senior engineer runs $200k a year. this is two weeks, ten grand, and you own all of it.'
+	},
+	guarantee: {
+		eyebrow: 'the guarantee',
+		headline: 'live in production by day 10, or the remaining payments are free.',
+		body: "and there's a floor under it: day 5, we both look at it. if we can both see it won't ship in scope, we stop there — you keep everything we built and pay only for the time used. the risk is mine to carry, not yours."
+	},
+	proof: {
+		eyebrow: 'proof · something from nothing',
+		heading: 'a solo practice with no way to reach its own clients.',
+		para: 'a men’s-mental-health therapist had a slow, drifting site and one channel: rented directory listings, with insurance deciding who found him. i rebuilt the whole thing custom and gave him a growth engine he owns. the craft shows in the numbers:',
+		tiles: [
+			{ value: '100s', label: 'desktop Lighthouse' },
+			{ value: '8.3s→2.9s', label: 'mobile load' },
+			{ value: '7.5×', label: 'lighter page' },
+			{ value: '+185%', label: 'pageviews, last 30d' }
+		],
+		para2:
+			"traffic reversed from a slow decline to steady growth — and it's HIS execution showing up in the data: he's running the strategy, and the results climb as he does. something from nothing.",
+		bridge:
+			"this one wasn't vibe-coded — just slow and invisible. same hands, same discipline, numbers you can check. the first rescue writeup is on the bench right now."
+	},
+	isThisYou: {
+		eyebrow: 'is this you?',
+		yesLead: 'this is for you if:',
+		yes: [
+			'you vibe-coded something to a working demo',
+			'it has real users, or paying ones',
+			"it's breaking, or it just won't reach production",
+			"you'd rather own the fix than rent a dev shop"
+		],
+		noLead: 'not yet if:',
+		no: [
+			"it's still just an idea — nothing built",
+			'you want someone to manage a team of engineers',
+			'you need it done and gone, no involvement'
+		]
+	},
+	close: {
+		scarcity: 'one seat a month · by appointment',
+		heading: 'join the waitlist.',
+		emailPlaceholder: 'email you actually check',
+		buildLabel: 'what did you build?',
+		buildPlaceholder: 'a demo of… it works, but…',
+		button: 'get on the list →',
+		reward:
+			"the seat's booked out? good sign. while you wait, you get a free teardown of your app — what's solid, the three things that'll break, and what i'd do first. no pitch attached."
+	}
+}
+
+export const LEDGER_TOTAL_USD = grandSlam.ledger.groups
+	.flatMap((g) => g.lines)
+	.reduce((acc, l) => acc + (l.valueUSD ?? 0), 0)

--- a/src/lib/content/offer.ts
+++ b/src/lib/content/offer.ts
@@ -148,7 +148,17 @@ export const grandSlam: GrandSlamOffer = {
 				]
 			}
 		],
-		payLine: `$${site.sprint.priceUSD.toLocaleString('en-US')} fixed. $${(site.sprint.introPriceUSD ?? 0).toLocaleString('en-US')} for the ${site.sprint.introNote ?? 'first clients'}. or ${site.sprint.paymentPlan ?? ''}.`,
+		// Built from parts (same idiom as jsonld's sprintDescription) so optional
+		// pricing fields drop cleanly instead of emitting "$0 …" or a bare "or .".
+		payLine: [
+			`$${site.sprint.priceUSD.toLocaleString('en-US')} fixed.`,
+			site.sprint.introPriceUSD
+				? `$${site.sprint.introPriceUSD.toLocaleString('en-US')} for the ${site.sprint.introNote ?? 'first clients'}.`
+				: '',
+			site.sprint.paymentPlan ? `or ${site.sprint.paymentPlan}.` : ''
+		]
+			.filter(Boolean)
+			.join(' '),
 		anchorLine:
 			'a dev shop quotes $50k and three months. a senior engineer runs $200k a year. this is two weeks, ten grand, and you own all of it.'
 	},

--- a/src/lib/content/site.ts
+++ b/src/lib/content/site.ts
@@ -7,12 +7,6 @@ export const site: Site = {
 	bookingUrl: 'https://cal.com/sixtom/discovery',
 	gardenUrl: 'https://threesam.com',
 	tagline: 'we just want to build cool shit and help people chase their dreams',
-	thesis: 'vibe coding is how you slowly become the intern of your own codebase.',
-	thesisBody:
-		"AI gets you to a demo because the model can hold the whole thing in its head. once the codebase outgrows that window, the AI starts making it worse instead of better. that's the wall every vibe-coded project hits. it's also the thing i fix.",
-	hero: {
-		subhead: 'AI built your first draft. i build your solution.'
-	},
 	operator: {
 		name: "Salvatore D'Angelo",
 		jobTitle: 'lead engineer',
@@ -27,47 +21,28 @@ export const site: Site = {
 		// a sameAs pointing at an empty shell is an anti-signal. Re-add when
 		// essays actually syndicate there.
 	},
-	audit: {
-		name: 'audit',
-		longName: 'the audit',
-		priceUSD: 1500,
-		cadence: 'turnaround within a week.'
-	},
 	sprint: {
 		name: 'sprint',
-		longName: 'async sprint',
+		longName: 'the production sprint',
 		priceUSD: 10000,
 		introPriceUSD: 7500,
 		introNote: 'first 3 clients',
 		cadence: '1 client a month, by appointment.',
 		paymentPlan: '4 weekly payments of $2,500'
 	},
-	// The recurring rung: only offered after a sprint, deliberately capped so it
-	// stays a floor under the practice, not a second job on top of it.
-	retainer: {
-		name: 'retainer',
-		longName: 'i keep it running',
-		priceUSD: 1500,
-		cadence: 'monthly. post-sprint clients only. 4 seats.'
-	},
 	process: [
+		{ label: 'wk 1 · day 0', body: 'a 30-minute call. we figure out the thing.' },
 		{
-			label: 'Week 1, day 0',
-			body: '30-min call (or skip if you did the audit). We figure out the thing.'
+			label: 'days 1–7',
+			body: 'heads down. daily Loom + code drop in your channel, so you watch it happen.'
 		},
-		{ label: 'Days 1–7', body: 'Agents build. I steer. Daily Loom + code drop in your channel.' },
-		{ label: 'Mid-sprint', body: '1 short sync. Course-correct if needed.' },
 		{
-			label: 'Day 5 (scope check)',
-			body: "If we can both see it won't ship in scope, we stop here. You keep what we built."
+			label: 'day 5 · scope check',
+			body: "if it can't ship in scope, we stop here. you keep what we built."
 		},
-		{ label: 'Day 10', body: 'Live in production. You own it.' },
-		{ label: 'Day 30', body: "Check-in. What stuck, what didn't." }
-	],
-	stats: [
-		{ value: '2 weeks', label: 'per sprint' },
-		{ value: 'all async', label: 'no standups' },
-		{ value: '$10,000', label: 'fixed' }
+		{ label: 'mid-sprint', body: 'one short sync. course-correct if needed.' },
+		{ label: 'day 10', body: 'live in production. you own it. (or the rest is free.)' },
+		{ label: 'day 30', body: "check-in. what stuck, what didn't." }
 	],
 	testimonial: {
 		quote:

--- a/src/lib/content/types.ts
+++ b/src/lib/content/types.ts
@@ -47,17 +47,9 @@ export interface Site {
 	bookingUrl: string
 	gardenUrl: string
 	tagline: string
-	thesis: string
-	thesisBody: string
-	hero: {
-		subhead: string
-	}
 	operator: Operator
-	audit: Offer
 	sprint: Offer
-	retainer: Offer
 	process: readonly ProcessStep[]
-	stats: readonly Stat[]
 	testimonial: Testimonial
 }
 
@@ -74,4 +66,71 @@ export interface CalEvent {
 	durationMinutes: number
 	description: string
 	intakeQuestions: readonly IntakeQuestion[]
+}
+
+export interface LedgerLine {
+	line: string
+	sub: string
+	valueUSD: number | null // null → valueLabel renders instead of a price
+	valueLabel?: 'core' | 'included'
+}
+
+export interface LedgerGroup {
+	title: string
+	note?: string // honest hedge rendered under the group
+	lines: readonly LedgerLine[]
+}
+
+export interface CostCard {
+	title: string
+	sub: string
+}
+
+export interface GrandSlamOffer {
+	chip: string
+	headline: string
+	lead: string
+	offerLine: string
+	stats: readonly Stat[]
+	wall: {
+		eyebrow: string
+		thesis: string
+		para: string
+		turn: string
+		costCards: readonly CostCard[]
+		taxLine: string
+	}
+	ledger: {
+		eyebrow: string
+		heading: string
+		para: string
+		groups: readonly LedgerGroup[]
+		payLine: string
+		anchorLine: string
+	}
+	guarantee: { eyebrow: string; headline: string; body: string }
+	proof: {
+		eyebrow: string
+		heading: string
+		para: string
+		tiles: readonly Stat[]
+		para2: string
+		bridge: string
+	}
+	isThisYou: {
+		eyebrow: string
+		yesLead: string
+		yes: readonly string[]
+		noLead: string
+		no: readonly string[]
+	}
+	close: {
+		scarcity: string
+		heading: string
+		emailPlaceholder: string
+		buildLabel: string
+		buildPlaceholder: string
+		button: string
+		reward: string
+	}
 }

--- a/src/lib/content/types.ts
+++ b/src/lib/content/types.ts
@@ -3,8 +3,6 @@ export interface QA {
 	answer: string
 }
 
-export type StringList = readonly string[]
-
 export interface Operator {
 	name: string
 	jobTitle: string

--- a/src/lib/content/types.ts
+++ b/src/lib/content/types.ts
@@ -66,12 +66,12 @@ export interface CalEvent {
 	intakeQuestions: readonly IntakeQuestion[]
 }
 
-export interface LedgerLine {
+// Discriminated: a line is either priced (valueUSD) or labeled ('core' /
+// 'included') — never neither, so a blank value cell can't compile.
+export type LedgerLine = {
 	line: string
 	sub: string
-	valueUSD: number | null // null → valueLabel renders instead of a price
-	valueLabel?: 'core' | 'included'
-}
+} & ({ valueUSD: number; valueLabel?: never } | { valueUSD: null; valueLabel: 'core' | 'included' })
 
 export interface LedgerGroup {
 	title: string

--- a/src/lib/seo/jsonld.test.ts
+++ b/src/lib/seo/jsonld.test.ts
@@ -45,22 +45,22 @@ describe('JSON-LD generators', () => {
 		expect(ld.publisher['@id']).toBe(PERSON_ID)
 	})
 
-	it('serviceJsonLd lists all three offers and links the person as provider by @id', () => {
+	it('serviceJsonLd sells exactly the two live offers: sprint + free teardown', () => {
 		const ld = serviceJsonLd()
 		expect(ld['@context']).toBe('https://schema.org')
 		expect(ld['@type']).toBe('Service')
 		expect(ld.provider['@id']).toBe(PERSON_ID)
 		expect(ld.areaServed).toBe('Worldwide')
-		expect(ld.offers).toHaveLength(3)
-		expect(ld.offers[0]?.name).toBe(site.audit.name)
-		expect(ld.offers[0]?.price).toBe(String(site.audit.priceUSD))
-		expect(ld.offers[0]?.availability).toBe('https://schema.org/InStock')
-		expect(ld.offers[1]?.name).toBe(site.sprint.name)
-		expect(ld.offers[1]?.price).toBe(String(site.sprint.priceUSD))
-		expect(ld.offers[1]?.availability).toBe('https://schema.org/LimitedAvailability')
-		expect(ld.offers[2]?.name).toBe(site.retainer.name)
-		expect(ld.offers[2]?.price).toBe(String(site.retainer.priceUSD))
-		expect(ld.offers[2]?.availability).toBe('https://schema.org/LimitedAvailability')
+		expect(ld.description).toContain('day 10')
+		expect(ld.offers).toHaveLength(2)
+		expect(ld.offers[0]?.name).toBe(site.sprint.name)
+		expect(ld.offers[0]?.price).toBe(String(site.sprint.priceUSD))
+		expect(ld.offers[0]?.availability).toBe('https://schema.org/LimitedAvailability')
+		expect(ld.offers[0]?.description).toContain('day 10')
+		expect(ld.offers[1]?.name).toBe('free teardown')
+		expect(ld.offers[1]?.price).toBe('0')
+		expect(ld.offers[1]?.availability).toBe('https://schema.org/InStock')
+		expect(ld.offers[1]?.url).toBe(`${site.siteUrl}/notify`)
 	})
 
 	it('faqPageJsonLd maps Q&A pairs to a FAQPage', () => {

--- a/src/lib/seo/jsonld.ts
+++ b/src/lib/seo/jsonld.ts
@@ -1,4 +1,4 @@
-import { site } from '$lib/content'
+import { site, grandSlam } from '$lib/content'
 import type { QA } from '$lib/content'
 import type { LogEntry } from '$lib/log'
 
@@ -109,10 +109,9 @@ export function webSiteJsonLd(): WebSiteLd {
 
 export function serviceJsonLd(): ServiceLd {
 	const bookUrl = `${site.siteUrl}/book`
-	const auditDescription = `a written breakdown plus a short video walkthrough of what's blocking you and whether a sprint makes sense. ${site.audit.cadence}`
 	// Built from parts so the optional intro/payment fields drop cleanly when unset.
 	const sprintDescription = [
-		'two weeks from working-for-you to production-grade.',
+		'two weeks from working demo to production-grade. live in production by day 10 — or the remaining payments are free.',
 		site.sprint.paymentPlan ? `${site.sprint.paymentPlan} available.` : '',
 		site.sprint.introPriceUSD
 			? `$${String(site.sprint.introPriceUSD)} intro for the ${site.sprint.introNote ?? 'first clients'}.`
@@ -121,27 +120,17 @@ export function serviceJsonLd(): ServiceLd {
 	]
 		.filter(Boolean)
 		.join(' ')
-	const retainerDescription = `keep me on it after the sprint — monitoring, small iterations, priority access. ${site.retainer.cadence}`
 	return {
 		'@context': 'https://schema.org',
 		'@type': 'Service',
 		'@id': SERVICE_ID,
 		name: 'SIXTOM',
 		alternateName: ['Sixtom', 'sixtom'],
-		description: site.hero.subhead,
+		description: grandSlam.offerLine,
 		url: site.siteUrl,
 		areaServed: 'Worldwide',
 		provider: { '@id': PERSON_ID },
 		offers: [
-			{
-				'@type': 'Offer',
-				name: site.audit.name,
-				description: auditDescription,
-				price: String(site.audit.priceUSD),
-				priceCurrency: 'USD',
-				availability: 'https://schema.org/InStock',
-				url: bookUrl
-			},
 			{
 				'@type': 'Offer',
 				name: site.sprint.name,
@@ -153,12 +142,13 @@ export function serviceJsonLd(): ServiceLd {
 			},
 			{
 				'@type': 'Offer',
-				name: site.retainer.name,
-				description: retainerDescription,
-				price: String(site.retainer.priceUSD),
+				name: 'free teardown',
+				description:
+					"a free teardown of your app — what's solid, the three things that'll break, and what i'd do first. join the waitlist to get one.",
+				price: '0',
 				priceCurrency: 'USD',
-				availability: 'https://schema.org/LimitedAvailability',
-				url: bookUrl
+				availability: 'https://schema.org/InStock',
+				url: `${site.siteUrl}/notify`
 			}
 		]
 	}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -156,7 +156,7 @@
 </section>
 
 <!-- close / waitlist -->
-<section id="waitlist" class="surface-uv flex min-h-svh flex-col justify-between pt-20 md:pt-28">
+<section id="waitlist" class="surface-uv py-20 md:py-28">
 	<div class="mx-auto w-full max-w-3xl px-6">
 		<p class={eyebrowClass}>{o.close.scarcity}</p>
 		<h2 class={h2Class}>{o.close.heading}</h2>
@@ -207,7 +207,8 @@
 
 		<p class="text-fg-muted mt-8 max-w-xl text-base leading-relaxed">{o.close.reward}</p>
 	</div>
-	<div class="mt-16">
-		<SiteFooter />
-	</div>
 </section>
+
+<!-- Page-level, outside the UV section, so the footer keeps the root dark
+     surface — the page opens dark and closes dark, same as every other route. -->
+<SiteFooter />

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,140 +1,112 @@
 <script lang="ts">
 	import Hero from '$lib/components/Hero.svelte'
-	import BookCta from '$lib/components/BookCta.svelte'
 	import SiteFooter from '$lib/components/SiteFooter.svelte'
-	import { site } from '$lib/content'
+	import { site, grandSlam, LEDGER_TOTAL_USD } from '$lib/content'
 
-	const h2Class =
-		'text-fg text-3xl leading-tight font-semibold tracking-tight md:text-5xl lg:text-6xl'
-	const bodyClass = 'text-fg-muted mt-8 max-w-2xl text-base leading-relaxed md:text-lg'
+	const o = grandSlam
+	const eyebrowClass = 'eyebrow text-sm'
+	const h2Class = 'text-fg mt-2 text-3xl leading-tight font-bold tracking-tight md:text-5xl'
+	const bodyClass = 'text-fg-muted mt-6 max-w-2xl text-base leading-relaxed md:text-lg'
+	const usd = (n: number) => `$${n.toLocaleString('en-US')}`
 </script>
-
-<!-- Scroll-snap is the home page's full-screen-section experience only. Scope it
-     to this route via the head so every other (overflowing) route — book,
-     notify, tax, … — scrolls freely instead of being snap-jacked. -->
-<svelte:head>
-	<style>
-		html {
-			scroll-snap-type: y mandatory;
-		}
-	</style>
-</svelte:head>
 
 <Hero />
 
-<!-- who this is for -->
-<section class="snap-section surface-uv">
+<!-- the wall -->
+<section class="surface-uv py-20 md:py-28">
 	<div class="mx-auto w-full max-w-3xl px-6">
-		<h2 class={h2Class}>who is this for?</h2>
-		<p class={bodyClass}>you already built it. you're probably one of these:</p>
-		<ul class="text-fg-muted mt-10 space-y-6 text-base leading-relaxed md:text-lg">
-			<li>
-				<span class="text-fg font-semibold">the demo darling.</span>
-				you killed the pitch, then it folded the first time a dozen real people logged in.
-			</li>
-			<li>
-				<span class="text-fg font-semibold">paying &amp; breaking.</span>
-				real revenue, and all-nighters fixing production.
-			</li>
-			<li>
-				<span class="text-fg font-semibold">about to scale.</span>
-				someone just asked you to 10× the users. you said yes and started sweating.
-			</li>
-			<li>
-				<span class="text-fg font-semibold">enterprise-blocked.</span>
-				one contract away from real money, stuck behind a brick wall of compliance.
-			</li>
+		<p class={eyebrowClass}>{o.wall.eyebrow}</p>
+		<h2 class={h2Class}>{o.wall.thesis}</h2>
+		<p class={bodyClass}>{o.wall.para}</p>
+		<p class="text-fg mt-8 max-w-2xl text-base leading-relaxed font-semibold md:text-lg">
+			{o.wall.turn}
+		</p>
+		<ul class="mt-8 grid gap-4 md:grid-cols-3">
+			{#each o.wall.costCards as card (card.title)}
+				<li class="border-border rounded-lg border p-6">
+					<p class="text-fg font-semibold">{card.title}</p>
+					<p class="text-fg-muted mt-2 text-sm leading-relaxed">{card.sub}</p>
+				</li>
+			{/each}
 		</ul>
+		<p class="text-fg-muted mt-8 text-base leading-relaxed md:text-lg">
+			{o.wall.taxLine}
+			<a href="/tax" data-umami-event="cta_tax_calc" class="link-coin">run yours →</a>
+		</p>
 	</div>
 </section>
 
-<!-- recognize any of these -->
-<section class="snap-section bg-surface">
+<!-- the ledger -->
+<section class="bg-surface py-20 md:py-28">
 	<div class="mx-auto w-full max-w-3xl px-6">
-		<h2 class={h2Class}>recognize any of these?</h2>
-		<ul class="text-fg-muted mt-10 space-y-6 text-base leading-relaxed md:text-lg">
-			<li>
-				<span class="text-fg font-semibold">uptime.</span>
-				your biggest customer wants a number you can't give.
-			</li>
-			<li>
-				<span class="text-fg font-semibold">security.</span>
-				a sale is stuck waiting on a review you don't pass.
-			</li>
-			<li>
-				<span class="text-fg font-semibold">scale.</span>
-				investors keep asking how. you keep saying "we'll figure it out."
-			</li>
-			<li>
-				<span class="text-fg font-semibold">peace of mind.</span>
-				every time you launch a feature, something else breaks.
-			</li>
-		</ul>
-	</div>
-</section>
+		<p class={eyebrowClass}>{o.ledger.eyebrow}</p>
+		<h2 class={h2Class}>{o.ledger.heading}</h2>
+		<p class={bodyClass}>{o.ledger.para}</p>
 
-<!-- what are you losing -->
-<section class="snap-section surface-uv">
-	<div class="mx-auto w-full max-w-3xl px-6">
-		<h2 class={h2Class}>what are you losing?</h2>
-		<p class="text-fg mt-10 text-2xl font-semibold tabular-nums md:text-4xl">
-			deals × value × time = $
-		</p>
-		<p class="text-fg-muted mt-6 text-base leading-relaxed md:text-lg">
-			typical case: 1/mo × $50k × 12 = ~$600k/yr. plus the weekends. plus the sleep.
-		</p>
-		<p class="mt-10">
-			<a
-				href="/tax"
-				data-umami-event="cta_tax_calc"
-				class="no-link border-fg text-fg hover:border-accent hover:bg-accent inline-block rounded-full border-2 px-8 py-3 text-lg font-bold transition-colors duration-[400ms] md:px-10 md:py-4 md:text-xl"
+		{#each o.ledger.groups as group (group.title)}
+			<div class="mt-12">
+				<p class="eyebrow text-fg-subtle text-xs">{group.title}</p>
+				<ul class="border-border divide-border mt-4 divide-y border-y">
+					{#each group.lines as item (item.line)}
+						<li class="flex items-baseline justify-between gap-6 py-4">
+							<div>
+								<p class="text-fg text-base font-semibold">{item.line}</p>
+								<p class="text-fg-muted mt-1 text-sm leading-relaxed">{item.sub}</p>
+							</div>
+							<p class="text-fg-subtle shrink-0 text-sm font-semibold tabular-nums">
+								{item.valueUSD === null ? item.valueLabel : usd(item.valueUSD)}
+							</p>
+						</li>
+					{/each}
+				</ul>
+				{#if group.note}
+					<p class="text-fg-subtle mt-4 max-w-2xl text-sm leading-relaxed">{group.note}</p>
+				{/if}
+			</div>
+		{/each}
+
+		<div class="border-border mt-12 border-t pt-8">
+			<div class="flex items-baseline justify-between gap-6">
+				<p class="text-fg text-lg font-bold">total value</p>
+				<p class="text-fg text-lg font-bold tabular-nums">{usd(LEDGER_TOTAL_USD)}+</p>
+			</div>
+			<div
+				class="mt-3 flex flex-col gap-1 md:flex-row md:items-baseline md:justify-between md:gap-6"
 			>
-				run yours
-			</a>
-		</p>
+				<p class="text-fg-muted text-base">you pay</p>
+				<p class="text-fg text-base font-semibold md:text-right">{o.ledger.payLine}</p>
+			</div>
+			<p class="text-fg-subtle mt-8 max-w-2xl text-sm leading-relaxed">{o.ledger.anchorLine}</p>
+		</div>
 	</div>
 </section>
 
-<!-- how this works -->
-<section id="offers" class="snap-section bg-surface">
+<!-- the guarantee -->
+<section class="surface-uv py-20 md:py-28">
 	<div class="mx-auto w-full max-w-3xl px-6">
-		<h2 class={h2Class}>only two weeks?</h2>
-		<ul class="text-fg-muted mt-10 space-y-2 text-base leading-relaxed md:text-lg">
-			<li>daily progress.</li>
-			<li>the answer when they ask.</li>
-			<li>your weekends back.</li>
-			<li>live in production on day 10. you own it.</li>
+		<p class={eyebrowClass}>{o.guarantee.eyebrow}</p>
+		<h2 class={h2Class}>{o.guarantee.headline}</h2>
+		<p class={bodyClass}>{o.guarantee.body}</p>
+	</div>
+</section>
+
+<!-- proof -->
+<section class="bg-surface py-20 md:py-28">
+	<div class="mx-auto w-full max-w-3xl px-6">
+		<p class={eyebrowClass}>{o.proof.eyebrow}</p>
+		<h2 class={h2Class}>{o.proof.heading}</h2>
+		<p class={bodyClass}>{o.proof.para}</p>
+		<ul class="mt-10 grid list-none grid-cols-2 gap-6 p-0 md:grid-cols-4">
+			{#each o.proof.tiles as tile (tile.label)}
+				<li>
+					<p class="text-fg text-2xl font-bold tabular-nums md:text-3xl">{tile.value}</p>
+					<p class="text-fg-subtle mt-1 text-xs tracking-widest uppercase">{tile.label}</p>
+				</li>
+			{/each}
 		</ul>
-		<p class="text-fg-subtle mt-8 text-sm md:text-base">
-			${site.sprint.priceUSD.toLocaleString()} flat. or {site.sprint.paymentPlan}. 1 client a month.
-		</p>
-		<p class="text-fg-subtle mt-2 text-sm md:text-base">
-			after: ${site.retainer.priceUSD.toLocaleString()}/mo keeps me on it. post-sprint only, 4
-			seats.
-		</p>
-	</div>
-</section>
-
-<!-- why me -->
-<section class="snap-section surface-uv">
-	<div class="mx-auto w-full max-w-3xl px-6">
-		<h2 class={h2Class}>why me?</h2>
-		<p class={bodyClass}>
-			day job: lead engineer at Made In Cookware. multi-million visitors a month. i rebuilt my own
-			creative work — <a
-				href={site.gardenUrl}
-				target="_blank"
-				rel="noopener noreferrer"
-				data-umami-event="cta_garden_link_why"
-				class="link-coin">the Garden</a
-			> — on the same methods. 5 hours of build time, 40% smaller, every score up.
-		</p>
-		<p class="mt-6 text-sm">
-			<a href="/log/garden-party" data-umami-event="cta_case_study" class="text-fg-muted">
-				the writeup
-			</a>
-		</p>
-		<blockquote class="text-fg-muted mt-12 max-w-2xl text-base leading-relaxed italic md:text-lg">
+		<p class={bodyClass}>{o.proof.para2}</p>
+		<p class="text-fg-subtle mt-6 max-w-2xl text-sm leading-relaxed">{o.proof.bridge}</p>
+		<blockquote class="text-fg-muted mt-10 max-w-2xl text-base leading-relaxed italic md:text-lg">
 			“{site.testimonial.quote}”
 			<footer class="text-fg-subtle mt-2 text-sm not-italic">
 				— {site.testimonial.attribution}
@@ -143,19 +115,99 @@
 	</div>
 </section>
 
-<!-- the ask -->
-<section class="snap-section bg-surface !justify-between">
-	<div class="flex w-full flex-1 items-center px-6 py-16">
-		<div class="mx-auto w-full max-w-3xl">
-			<h2 class="text-fg text-4xl leading-tight font-bold tracking-tight md:text-6xl lg:text-7xl">
-				want to look at it together?
-			</h2>
-			<p class="text-fg-muted mt-8 text-base leading-relaxed md:text-lg">
-				${site.audit.priceUSD.toLocaleString()} to look at what you've got. within a week: a written breakdown
-				plus a short video walkthrough. credited toward the sprint if you book one within 30 days.
-			</p>
-			<BookCta event="cta_final_book" class="mt-12" />
+<!-- is this you -->
+<section class="surface-uv py-20 md:py-28">
+	<div class="mx-auto w-full max-w-3xl px-6">
+		<p class={eyebrowClass}>{o.isThisYou.eyebrow}</p>
+		<div class="mt-6 grid gap-10 md:grid-cols-2">
+			<div>
+				<p class="text-fg text-lg font-semibold">{o.isThisYou.yesLead}</p>
+				<ul class="text-fg-muted mt-4 space-y-3 text-base leading-relaxed">
+					{#each o.isThisYou.yes as item (item)}
+						<li>{item}</li>
+					{/each}
+				</ul>
+			</div>
+			<div>
+				<p class="text-fg text-lg font-semibold">{o.isThisYou.noLead}</p>
+				<ul class="text-fg-muted mt-4 space-y-3 text-base leading-relaxed">
+					{#each o.isThisYou.no as item (item)}
+						<li>{item}</li>
+					{/each}
+				</ul>
+			</div>
 		</div>
 	</div>
-	<SiteFooter />
+</section>
+
+<!-- the two weeks -->
+<section class="bg-surface py-20 md:py-28">
+	<div class="mx-auto w-full max-w-3xl px-6">
+		<p class={eyebrowClass}>the two weeks</p>
+		<ol class="border-border divide-border mt-8 divide-y border-y">
+			{#each site.process as step (step.label)}
+				<li class="grid gap-1 py-5 md:grid-cols-[12rem_1fr] md:gap-6">
+					<p class="text-fg-subtle text-xs tracking-widest uppercase">{step.label}</p>
+					<p class="text-fg-muted text-base leading-relaxed">{step.body}</p>
+				</li>
+			{/each}
+		</ol>
+	</div>
+</section>
+
+<!-- close / waitlist -->
+<section id="waitlist" class="surface-uv flex min-h-svh flex-col justify-between pt-20 md:pt-28">
+	<div class="mx-auto w-full max-w-3xl px-6">
+		<p class={eyebrowClass}>{o.close.scarcity}</p>
+		<h2 class={h2Class}>{o.close.heading}</h2>
+
+		<!-- csr=false: plain cross-route POST to the /notify action. No JS anywhere
+		     on this page — the visitor lands on /notify with the server-rendered
+		     result. Honeypot + rate limit + validation still apply server-side. -->
+		<form method="post" action="/notify?/notify" class="mt-10 max-w-xl space-y-4">
+			<label class="sr-only" for="waitlist-email">email address</label>
+			<input
+				id="waitlist-email"
+				name="email"
+				type="email"
+				required
+				autocomplete="email"
+				placeholder={o.close.emailPlaceholder}
+				class="border-border bg-surface text-fg placeholder:text-fg-subtle focus:border-accent focus:ring-accent w-full rounded-md border px-4 py-3 text-lg focus:ring-2 focus:outline-none"
+			/>
+			<label class="text-fg-muted block text-sm" for="waitlist-build">
+				{o.close.buildLabel}
+				<textarea
+					id="waitlist-build"
+					name="message"
+					required
+					rows="3"
+					maxlength="4000"
+					placeholder={o.close.buildPlaceholder}
+					class="border-border bg-surface text-fg placeholder:text-fg-subtle focus:border-accent focus:ring-accent mt-2 w-full rounded-md border px-4 py-3 text-base focus:ring-2 focus:outline-none"
+				></textarea>
+			</label>
+			<input type="hidden" name="name" value="Waitlist signup" />
+			<input
+				type="text"
+				name="company"
+				tabindex="-1"
+				autocomplete="off"
+				aria-hidden="true"
+				class="absolute top-auto left-[-9999px] h-px w-px overflow-hidden"
+			/>
+			<button
+				type="submit"
+				data-umami-event="cta_waitlist_submit"
+				class="btn-accent w-full px-8 py-4 text-center text-xl font-bold md:w-auto md:px-12"
+			>
+				{o.close.button}
+			</button>
+		</form>
+
+		<p class="text-fg-muted mt-8 max-w-xl text-base leading-relaxed">{o.close.reward}</p>
+	</div>
+	<div class="mt-16">
+		<SiteFooter />
+	</div>
 </section>

--- a/src/routes/+page.ts
+++ b/src/routes/+page.ts
@@ -1,2 +1,3 @@
-// Zero-JS marketing page; all CTAs are plain links — no client hydration needed.
+// Zero-JS marketing page: CTAs are plain links and the waitlist form is a
+// native cross-route POST (/notify?/notify) — no client hydration needed.
 export const csr = false

--- a/static/llms-full.txt
+++ b/static/llms-full.txt
@@ -134,7 +134,7 @@ what your half-finished, AI-built prototype quietly costs you per year — lost 
 
 a 1:1 port of threesam.com from Next.js to SvelteKit. five hours of build time. bundle size dropped 40%. every Lighthouse score went up. full writeup at https://sixtom.com/log/garden-party.
 
-the premise: take a 30-route personal site (canvas sketches, video heroes, real-time data feeds, the works) and rebuild it in a framework i'd never shipped to production. same routes, same sketches, same aesthetic — different runtime. two questions answered honestly: is a 1:1 port across frameworks possible, and is it worth it?
+the premise: take a 30-route personal site (canvas sketches, video heroes, real-time data feeds, the works) and port it to SvelteKit — the framework i prefer and ship freelance, just never at the day job. same routes, same sketches, same aesthetic — different runtime. two questions answered honestly: is a 1:1 port across frameworks possible, and is it worth it?
 
 ## who i am
 

--- a/static/llms-full.txt
+++ b/static/llms-full.txt
@@ -1,116 +1,148 @@
 # SIXTOM — full content
 
-> AI built your first draft. I build your solution. Two-week engagements that take your AI-built prototype from working-for-you to production-grade. $1,500 audit. $10,000 sprint. 1 client a month.
+> the demo works. production doesn't. the production sprint: two weeks from working demo to production-grade — live in production on day 10, or the remaining payments are free. $10,000 flat ($7,500 for the first 3 clients). 1 client a month.
 
-## Thesis
+## thesis
 
-Vibe coding is how you slowly become the intern of your own codebase.
+vibe coding is how you slowly become the intern of your own codebase.
 
-AI gets you to a demo because the model can hold the whole thing in its head. Once the codebase outgrows that window, the AI starts making it worse instead of better. That's the wall every vibe-coded project hits. It's also the thing I fix.
+AI gets you to a demo because it can hold the whole thing in its head. once your codebase outgrows that window, it starts making things worse instead of better. that's the wall every vibe-coded project hits. it's also the thing i fix.
 
-## What I do
+you shipped a demo and it felt like magic. then the edits started breaking things you didn't touch. every new feature costs more than the last. you're not building anymore — you're negotiating with a machine that no longer understands what it built. the demo is real. the foundation isn't. and every month it stays that way has a price: the users who hit a bug and never come back, the launch that slips another month, the weekends spent firefighting instead of living.
 
-### The Audit — $1,500
+## the offer — one sprint, everything in it
 
-You send me your repo and the thing you're stuck on. I send back a written breakdown plus a short video walkthrough — what's blocking, what I'd do, whether a sprint makes sense. About a week turnaround. Start here.
+i rebuild it the way i'd build it for myself — the architecture, the security, the tests, the judgment calls you can't vibe your way through. everything in the sprint, and what it'd cost you piecemeal:
 
-### The Sprint — $10,000
+### the foundation
 
-Two weeks. From working-for-you to production-grade. Daily progress drops in your channel. Live on day 10. The first 3 clients get the sprint at $7,500. Payment plan available: 4 weekly payments of $2,500.
+- architecture teardown + premortem — exactly what will break, and why — $3,000
+- the rebuild — your product, standing on foundations that hold — core
+- security review on every commit — nothing ships that i haven't read — $2,000
+- automated test suite — so it stays fixed after i leave — $2,500
+- performance to 100s — and i'll tell you when a third-party script makes that impossible — $1,500
+- accessibility pass — works for everyone who shows up — $1,500
 
-## Who it's for
+### the growth foundation
 
-You already built something — usually with AI assistance. It works for you. Real customers are about to break it, or already are. You're losing sleep over uptime, security, or scale. You want peace of mind. The "X" in "solve for X" is the specific thing standing between you and that peace of mind.
+- analytics + observability — you see what's working from day one — $1,500
+- CRO-ready pages + A/B scaffold — every idea after launch is a test, not a rewrite — $2,500
+- technical SEO foundation — schema, sitemaps, core web vitals — $2,000
+- AEO/GEO foundation — structured for the answer-engines, so AI recommends you too — $2,000
+- infra cost audit — kill the subscriptions your stack is quietly renting — $1,000
 
-Typical personas:
+straight with you: search and answer-engines pay off over months, not days. the sprint makes you findable, measurable, and ready to test from day one — the compounding comes from what you publish after. the growth map shows you where to push.
 
-- **The demo darling.** You killed the pitch, then it folded the first time a dozen real people logged in.
-- **Paying & breaking.** Real revenue, and all-nighters fixing production.
-- **About to scale.** Someone just asked you to 10× the users. You said yes and started sweating.
-- **Enterprise-blocked.** One contract away from real money, stuck behind a brick wall of compliance.
+### the brand
 
-## Things to recognize
+- conversion copy pass — every word on the page earning its keep — $1,500
+- brand kit + 1-of-1 art — colors, type, and an original piece nobody else has — $3,000
 
-If any of these sound familiar, you're a fit:
+### the close
 
-- **Uptime.** Your biggest customer wants a number you can't give.
-- **Security.** A sale is stuck waiting on a review you don't pass.
-- **Scale.** Investors keep asking how. You keep saying "we'll figure it out."
-- **Peace of mind.** Every time you launch a feature, something else breaks.
+- live in production by day 10 — you own 100% of it — included
+- day-30 check-in — what stuck, what didn't — $500
 
-## How the sprint goes
+### the bonuses (land by day 30)
 
-- **Week 1 day 0:** 30-minute call (or skip if you did the audit). We define the X — the specific thing standing between you and peace of mind.
-- **Days 1–7:** I build. Daily progress drops in your channel.
-- **Mid-sprint:** 1 short sync. Course-correct if needed.
-- **Day 5 (scope check):** If we can both see it won't ship in scope, we stop here. You keep what was built.
-- **Day 10:** Live in production. You own it.
-- **Day 30:** Check-in. What stuck, what didn't.
+- the AI leverage session — what to lean on, what to skip, how not to wreck what we just built — $1,000
+- the 90-day growth map — the highest-impact moves, in order — $1,500
+- the runbook + Loom library — so you're never dependent on me again — $1,500
+
+**total value: $28,500+. you pay: $10,000 fixed. $7,500 for the first 3 clients. or 4 weekly payments of $2,500.**
+
+a dev shop quotes $50k and three months. a senior engineer runs $200k a year. this is two weeks, ten grand, and you own all of it.
+
+## the guarantee
+
+live in production by day 10, or the remaining payments are free.
+
+and there's a floor under it: day 5, we both look at it. if we can both see it won't ship in scope, we stop there — you keep everything we built and pay only for the time used. the risk is mine to carry, not yours.
+
+## the free teardown
+
+join the waitlist and get a short recorded teardown of your app — what's solid, the three things that'll break, and what i'd do first. no charge, no call, no pitch.
+
+## who it's for
+
+this is for you if: you vibe-coded something to a working demo · it has real users, or paying ones · it's breaking, or it just won't reach production · you'd rather own the fix than rent a dev shop.
+
+not yet if: it's still just an idea — nothing built · you want someone to manage a team of engineers · you need it done and gone, no involvement.
+
+## how the sprint goes
+
+- wk 1 · day 0: a 30-minute call. we figure out the thing.
+- days 1–7: heads down. daily Loom + code drop in your channel, so you watch it happen.
+- day 5 · scope check: if it can't ship in scope, we stop here. you keep what we built.
+- mid-sprint: one short sync. course-correct if needed.
+- day 10: live in production. you own it. (or the rest is free.)
+- day 30: check-in. what stuck, what didn't.
 
 ## FAQ
 
-**What does sixtom do?**
+**what does sixtom do?**
 
-You (or your AI) got something to a working demo. I take it from there to production-grade — secure, stable, ready for real users — in a two-week sprint. You own it on day 10.
+you (or your AI) got something to a working demo. i take it from there to production-grade — secure, tested, measured, ready for real users — in a two-week sprint. live on day 10, and you own every line of it.
 
-**What's the difference between the audit and the sprint?**
+**how much does it cost?**
 
-The audit ($1,500) is a written breakdown plus a short video walkthrough of what's blocking you and whether a sprint makes sense — start here if you're not sure. The sprint ($10,000) is two weeks of me building it to production. The audit credits toward the sprint if you book within 30 days.
+$10,000 flat, or 4 weekly payments of $2,500. the first 3 clients get it at $7,500. that price buys the whole ledger on the home page — over $28,500 of itemized work.
 
-**How much does it cost?**
+**what's the guarantee?**
 
-The audit is $1,500 flat. The sprint is $10,000 flat, or 4 weekly payments of $2,500. The first 3 clients get the sprint at $7,500.
+live in production by day 10, or the remaining payments are free. there's a floor under it too: at the day-5 scope check, if we can both see it won't ship in scope, we stop — you keep everything built and pay only for the time used.
 
-**How long does it take?**
+**what's the free teardown?**
 
-The sprint is two weeks — live in production on day 10. The audit turns around within a week.
+join the waitlist and i'll record a short teardown of your app — what's solid, the three things that'll break, and what i'd do first. no charge, no call, no pitch.
 
-**What if it won't ship in two weeks?**
+**how long does it take?**
 
-There's a scope check on day 5. If we can both see it won't make it, we stop there. You keep everything built and pay only for the time used.
+two weeks. live in production on day 10. one seat a month, by appointment.
 
-**How many clients do you take?**
+**do you do SEO and getting found by AI?**
 
-One a month, by appointment. That's the whole model — you get my full attention, not a queue.
+the sprint lays the foundation: technical SEO, schema, and answer-engine structure, plus analytics so you can see it working. straight with you — search compounds on what you publish over months, so the sprint makes you findable and measurable from day one, and the 90-day growth map shows you where to push after.
 
-**Who's behind sixtom?**
+**how many clients do you take?**
 
-Salvatore (Sam) D'Angelo — lead engineer at Made In Cookware (multi-million visitors a month), formerly at Rhone. Sixtom is the solo practice.
+one a month, by appointment. that's the whole model — you get my full attention, not a queue. when the seat's taken, the waitlist is open.
 
-**Is it really all async?**
+**what happens after the sprint?**
 
-Yes. Daily progress drops in your channel, with one short mid-sprint sync to course-correct. No standups.
+you own everything either way — the code, the analytics, the runbook. there's a day-30 check-in to see what stuck. if you want me to stay on it after that, we talk then.
 
-**What is the "vibe-code tax"?**
+**who's behind sixtom?**
 
-What your half-finished, AI-built prototype quietly costs you per year — lost deals, downtime, weekends. There's a no-email calculator at https://sixtom.com/tax.
+Salvatore (Sam) D'Angelo — lead engineer at Made In Cookware (multi-million visitors a month), formerly at Rhone. sixtom is the solo practice.
 
-## Pricing
+**is it really all async?**
 
-- **Audit:** $1,500 USD, fixed. Turnaround within a week.
-- **Sprint:** $10,000 USD flat, or 4 weekly payments of $2,500. 1 client a month, by appointment. First 3 clients: $7,500.
-- **Scope guarantee:** If by sprint day 5 we can both see it won't ship in scope, we stop. You keep what was built. You pay for the time used, that's it.
-- **Audit-to-sprint credit:** Audit credits toward the sprint if you book within 30 days.
+yes. a daily Loom + code drop in your channel, with one short mid-sprint sync to course-correct. no standups.
 
-## Testimonial
+**what is the "vibe-code tax"?**
 
-> He's built three sites for me and with each one, the unique needs and goals of the site dictated his approach, no cookie cutting corners.
+what your half-finished, AI-built prototype quietly costs you per year — lost deals, downtime, weekends. there's a no-email calculator at https://sixtom.com/tax.
+
+## testimonial
+
+> he's built three sites for me and with each one, the unique needs and goals of the site dictated his approach, no cookie cutting corners.
 
 — Eleanor Goldfield
 
-## Case study — Garden Party
+## case study — garden party
 
-A 1:1 port of threesam.com from Next.js to SvelteKit. Five hours of build time. Bundle size dropped 40%. Every Lighthouse score went up. Full writeup at https://sixtom.com/log/garden-party.
+a 1:1 port of threesam.com from Next.js to SvelteKit. five hours of build time. bundle size dropped 40%. every Lighthouse score went up. full writeup at https://sixtom.com/log/garden-party.
 
-The premise: take a 30-route personal site (canvas sketches, video heroes, real-time data feeds, the works) and rebuild it in a framework I'd never shipped to production. Same routes, same sketches, same aesthetic — different runtime. Two questions answered honestly: is a 1:1 port across frameworks possible, and is it worth it?
+the premise: take a 30-route personal site (canvas sketches, video heroes, real-time data feeds, the works) and rebuild it in a framework i'd never shipped to production. same routes, same sketches, same aesthetic — different runtime. two questions answered honestly: is a 1:1 port across frameworks possible, and is it worth it?
 
-## Who I am
+## who i am
 
-Salvatore D'Angelo. Lead engineer at Made In Cookware — multi-million visitors a month, real-revenue e-commerce. Formerly at Rhone. Sixtom is the solo practice; Made In is the day job. Personal site / portfolio: https://threesam.com. LinkedIn: https://www.linkedin.com/in/threesam.
+Salvatore D'Angelo. lead engineer at Made In Cookware — multi-million visitors a month, real-revenue e-commerce. formerly at Rhone. sixtom is the solo practice; Made In is the day job. personal site / portfolio: https://threesam.com. LinkedIn: https://www.linkedin.com/in/threesam.
 
-## How to engage
+## how to engage
 
-- **Solve for X — book a call:** https://sixtom.com/book — the qualifying booking form. Start here if you know you want the sprint.
-- **FAQ:** https://sixtom.com/faq — straight answers on price, audit vs sprint, timeline, the day-5 scope guarantee, and who's behind it.
-- **The vibe-code tax calculator:** https://sixtom.com/tax — a quick estimate of what the gap is costing you per year. No email.
-- **Notify list:** https://sixtom.com/notify — get told when the next slot opens.
+- **join the waitlist:** https://sixtom.com/notify — one seat a month; waitlist members get the free teardown while they wait.
+- **book the intro call:** https://sixtom.com/book — 3 quick steps, then the booking link.
+- **FAQ:** https://sixtom.com/faq — straight answers on price, the day-10 guarantee, timeline, and who's behind it.
+- **the vibe-code tax calculator:** https://sixtom.com/tax — a quick estimate of what the gap is costing you per year. no email.

--- a/static/llms.txt
+++ b/static/llms.txt
@@ -1,38 +1,41 @@
 # SIXTOM
 
-> AI built your first draft. I build your solution. Two-week engagements that take your AI-built prototype from working-for-you to production-grade. $1,500 audit. $10,000 sprint. 1 client a month.
+> the demo works. production doesn't. the production sprint: two weeks from working demo to production-grade — live in production on day 10, or the remaining payments are free. $10,000 flat ($7,500 for the first 3 clients). 1 client a month.
 
-## What I do
+## what i do
 
-- **The Audit — $1,500.** You send me your repo and the thing you're stuck on. I send back a written breakdown plus a short video walkthrough — what's blocking, what I'd do, whether a sprint makes sense. About a week turnaround. Start here.
-- **The Sprint — $10,000.** Two weeks. From working-for-you to production-grade. Daily progress drops in your channel. Live on day 10.
+- **the production sprint — $10,000.** two weeks. i rebuild your AI-built demo on foundations that hold: architecture teardown + premortem, security review on every commit, automated test suite, performance to 100s, accessibility pass, analytics + observability, CRO-ready pages + A/B scaffold, technical SEO foundation, AEO/GEO foundation, infra cost audit, conversion copy pass, and a brand kit with 1-of-1 art — plus an AI leverage session, a 90-day growth map, and a runbook + Loom library by day 30. total itemized value $28,500+. live on day 10 — you own 100% of it.
+- **the free teardown — $0.** join the waitlist and get a short recorded teardown of your app: what's solid, the three things that'll break, and what i'd do first. no charge, no call, no pitch.
 
-## Who it's for
+## the guarantee
 
-You already built something — usually with AI assistance. It works for you. Real customers are about to break it, or already are. You're losing sleep over uptime, security, or scale. You want peace of mind. The "X" in "solve for X" is the specific thing standing between you and that peace of mind.
+live in production by day 10, or the remaining payments are free. and there's a floor under it: day 5, we both look at it — if we can both see it won't ship in scope, we stop there. you keep everything built and pay only for the time used.
 
-## How the sprint goes
+## who it's for
 
-- Week 1 day 0: 30-min call (or skip if you did the audit). We define the X — the specific thing standing between you and peace of mind.
-- Days 1–7: I build. Daily progress drops in your channel.
-- Mid-sprint: 1 short sync. Course-correct if needed.
-- Day 5: scope check. If we can both see it won't ship in scope, we stop. You keep what was built.
-- Day 10: live in production. You own it.
-- Day 30: check-in.
+you vibe-coded something to a working demo. it has real users, or paying ones. it's breaking, or it just won't reach production. you'd rather own the fix than rent a dev shop. (still just an idea — nothing built? not yet.)
 
-## Pricing
+## how the sprint goes
 
-- Audit: $1,500 USD, fixed. Turnaround within a week.
-- Sprint: $10,000 USD flat, or 4 weekly payments of $2,500. 1 client a month, by appointment.
-- If by sprint day 5 we can both see it won't ship in scope, we stop. You keep what was built. You pay for the time used, that's it.
+- wk 1 · day 0: a 30-minute call. we figure out the thing.
+- days 1–7: heads down. daily Loom + code drop in your channel.
+- day 5 · scope check: if it can't ship in scope, we stop here. you keep what we built.
+- mid-sprint: one short sync. course-correct if needed.
+- day 10: live in production. you own it. (or the rest is free.)
+- day 30: check-in. what stuck, what didn't.
 
-## Who I am
+## pricing
 
-Salvatore D'Angelo. Lead engineer at Made In Cookware (multi-million visitors a month). Formerly at Rhone. Personal site / portfolio: [threesam.com](https://threesam.com). LinkedIn: [linkedin.com/in/threesam](https://www.linkedin.com/in/threesam).
+- sprint: $10,000 USD fixed, or 4 weekly payments of $2,500. first 3 clients: $7,500. 1 client a month, by appointment.
+- free teardown: $0, via the waitlist at https://sixtom.com/notify.
 
-## How to engage
+## who i am
 
-- [Solve for X — book a call](https://sixtom.com/book): the qualifying booking form on the homepage. Start here if you know you want the sprint.
-- [FAQ](https://sixtom.com/faq): straight answers — price, audit vs sprint, timeline, the day-5 scope guarantee, who's behind it.
-- [The vibe-code tax calculator](https://sixtom.com/tax): a quick estimate of what the gap is costing you per year. No email.
-- [Notify list](https://sixtom.com/notify): get told when the next slot opens.
+Salvatore D'Angelo. lead engineer at Made In Cookware (multi-million visitors a month). formerly at Rhone. personal site / portfolio: [threesam.com](https://threesam.com). LinkedIn: [linkedin.com/in/threesam](https://www.linkedin.com/in/threesam).
+
+## how to engage
+
+- [join the waitlist](https://sixtom.com/notify): one seat a month — waitlist members get the free teardown while they wait.
+- [book the intro call](https://sixtom.com/book): 3 quick steps, then the booking link.
+- [FAQ](https://sixtom.com/faq): straight answers — price, the day-10 guarantee, timeline, who's behind it.
+- [the vibe-code tax calculator](https://sixtom.com/tax): what the gap is costing you per year. no email.


### PR DESCRIPTION
Chunk A of the grand-slam migration train (plan: docs/superpowers/plans/2026-07-24-grand-slam-migration.md).

- Offer as typed data (src/lib/content/offer.ts): 19-line ledger, sum pinned to $28,500 by test; pay line derived from sprint pricing; 'no agent in customer copy' + 'no slot counters' enforced by tests
- site.ts: audit/retainer/hero/stats/thesis removed (dead or replaced); process gains the guarantee tooth
- Home rewritten: hero (kept bubble field) → wall → ledger → guarantee → proof → is-this-you → timeline → waitlist close (plain cross-route POST to /notify?/notify; csr=false preserved)
- serviceJsonLd: exactly 2 offers (sprint w/ day-10 guarantee in description, free teardown @ $0 → /notify)
- app.html title/description/og/twitter → new offer line
- Drive-through done: 1 h1, no h-overflow (desktop+390px), 0 console messages, schema verified in-browser
- Note: src/hooks.server.ts diff is prettier-only reflow of #144's line (main wasn't format-clean)

Gates: prettier ✓ eslint ✓ svelte-check 0/0 ✓ vitest 47/47 ✓ build ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KkSZmET2PrafrCpxNNWK6n