### PR TITLE
fix: headings render Cabinet Grotesk site-wide

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -152,6 +152,15 @@ html {
 	scroll-behavior: smooth;
 }
 
+/* Headings speak the display face everywhere; body stays Recursive. Element
+ * selector beats the inherited font-sans on <main> without fighting utilities. */
+h1,
+h2,
+h3,
+h4 {
+	font-family: var(--font-display);
+}
+
 /* Form controls use the brand teal, not the default blue. @tailwindcss/forms
  * sets appearance:none and paints the checked state with currentColor, so the
  * `color` is what drives the dot/check; accent-color is the native fallback. */


### PR DESCRIPTION
Follow-up to #164 — the display-font swap changed the token but not its reach; h1–h4 under `main.font-sans` still inherited Recursive. One base rule gives headings `var(--font-display)` everywhere. Verified in the built site: h1/h2 compute to Cabinet Grotesk, body text stays Recursive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KkSZmET2PrafrCpxNNWK6n