### PR TITLE
brand: pixel-even chip fallback + two-beat hero

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -138,6 +138,13 @@
 .wordmark .chip > span {
 	text-box: trim-both cap alphabetic;
 }
+/* No text-box: the 1em line box centers 0.04em low of the cap band
+ * (Cabinet: asc .87 / desc .28 / cap .67em). Nudge keeps the gaps pixel-even. */
+@supports not (text-box: trim-both cap alphabetic) {
+	.wordmark .chip > span {
+		transform: translateY(0.04em);
+	}
+}
 .wordmark .m {
 	margin-right: calc(-1 * var(--wm-ls));
 }

--- a/src/lib/components/Hero.svelte
+++ b/src/lib/components/Hero.svelte
@@ -23,10 +23,14 @@
 
 	<div class="relative mx-auto w-full max-w-6xl px-6 py-16 text-left md:py-20 md:text-center">
 		<p class="eyebrow text-fg-muted text-xs md:text-sm">{grandSlam.chip}</p>
+		<!-- One string in content; two beats on screen. The stray space between the
+		     block spans keeps textContent equal to the plain headline. -->
 		<h1
-			class="text-fg mt-6 text-[clamp(2.25rem,8.5vw,4.5rem)] leading-[1.08] font-bold tracking-tight text-balance"
+			class="text-fg mt-6 text-[clamp(2.75rem,10.5vw,6.5rem)] leading-[1.04] font-bold tracking-tight"
 		>
-			{grandSlam.headline}
+			{#each grandSlam.headline.split(/(?<=\.)\s+/) as beat, i (beat)}
+				{#if i > 0}{' '}{/if}<span class="block text-balance">{beat}</span>
+			{/each}
 		</h1>
 		<p class="text-fg-muted mx-auto mt-6 max-w-3xl text-base leading-relaxed md:text-lg">
 			{grandSlam.lead}


### PR DESCRIPTION
Two fixes from Sam's review of the live brand:

1. **Chip vertical centering** — pixel-measured: the trim path was already even (1px at 600px); the no-`text-box` fallback (e.g. iOS Safari < 18.2) sat 0.04em high. Guarded nudge makes both paths pixel-even, verified by ink-scan.
2. **Hero** — headline now renders as two stacked beats at clamp(2.75rem, 10.5vw, 6.5rem). Content string unchanged; h1 textContent identical; all 3 journeys pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KkSZmET2PrafrCpxNNWK6n