### PR TITLE
copy: new hero hook, two beats, display periods dropped

### DIFF
--- a/.agent-toolkit/journeys.md
+++ b/.agent-toolkit/journeys.md
@@ -7,7 +7,7 @@ skips Listmonk for the test email; processSubmission skips SMTP for it).
 
 ## 1. land → read the offer → join the waitlist
 
-1. Open `/`. Expect: h1 "the demo works. production doesn't.", chip "1 client a month · waitlist open", stat "day 10 or free".
+1. Open `/`. Expect: h1 "everyone saw the demo nobody's seen it since" (periods live in content/meta, not the display), chip "1 client a month · waitlist open", stat "day 10 or free".
 2. Scroll through wall → ledger → guarantee → proof. Expect: ledger shows "total value" of "$28,500+" and a pay line containing "$10,000"; guarantee headline contains "day 10"; proof tiles include "+185%".
 3. Fill `#waitlist-email` with e2e@test.sixtom.local and `#waitlist-build` with any text; submit.
 4. Expect: navigation to `/notify?/notify` (the named-action URL — no redirect) showing "You're on the list." No console errors, no failed network requests anywhere in the journey.

--- a/src/app.html
+++ b/src/app.html
@@ -7,7 +7,7 @@
 		<meta name="author" content="Salvatore D'Angelo" />
 		<meta name="format-detection" content="telephone=no" />
 
-		<title>SIXTOM — the demo works. production doesn't.</title>
+		<title>SIXTOM — everyone saw the demo. nobody's seen it since.</title>
 		<meta
 			name="description"
 			content="the production sprint: live in production on day 10 — and you own every line of it. $10,000 flat, 1 client a month."
@@ -36,7 +36,7 @@
 			crossorigin
 		/>
 
-		<meta property="og:title" content="SIXTOM — the demo works. production doesn't." />
+		<meta property="og:title" content="SIXTOM — everyone saw the demo. nobody's seen it since." />
 		<meta
 			property="og:description"
 			content="live in production on day 10 — and you own every line of it. $10,000 flat, 1 client a month."
@@ -47,16 +47,16 @@
 		<meta property="og:image" content="https://sixtom.com/og.png" />
 		<meta property="og:image:width" content="1200" />
 		<meta property="og:image:height" content="630" />
-		<meta property="og:image:alt" content="SIXTOM — the demo works. production doesn't." />
+		<meta property="og:image:alt" content="SIXTOM — everyone saw the demo. nobody's seen it since." />
 
 		<meta name="twitter:card" content="summary_large_image" />
-		<meta name="twitter:title" content="SIXTOM — the demo works. production doesn't." />
+		<meta name="twitter:title" content="SIXTOM — everyone saw the demo. nobody's seen it since." />
 		<meta
 			name="twitter:description"
 			content="live in production on day 10 — and you own every line of it. $10,000 flat, 1 client a month."
 		/>
 		<meta name="twitter:image" content="https://sixtom.com/og.png" />
-		<meta name="twitter:image:alt" content="SIXTOM — the demo works. production doesn't." />
+		<meta name="twitter:image:alt" content="SIXTOM — everyone saw the demo. nobody's seen it since." />
 
 		<link rel="icon" href="%sveltekit.assets%/favicon.svg" type="image/svg+xml" />
 		<link rel="apple-touch-icon" sizes="180x180" href="%sveltekit.assets%/apple-touch-icon.png" />

--- a/src/lib/components/Hero.svelte
+++ b/src/lib/components/Hero.svelte
@@ -23,13 +23,13 @@
 
 	<div class="relative mx-auto w-full max-w-6xl px-6 py-16 text-left md:py-20 md:text-center">
 		<p class="eyebrow text-fg-muted text-xs md:text-sm">{grandSlam.chip}</p>
-		<!-- One string in content; two beats on screen. The stray space between the
-		     block spans keeps textContent equal to the plain headline. -->
+		<!-- One string in content; two beats on screen, periods dropped at display
+		     scale — the line break is the punctuation. Meta/OG keep the prose form. -->
 		<h1
-			class="text-fg mt-6 text-[clamp(2.75rem,10.5vw,6.5rem)] leading-[1.04] font-bold tracking-tight"
+			class="text-fg mt-6 text-[clamp(2.5rem,9.5vw,5.75rem)] leading-[1.04] font-bold tracking-tight"
 		>
 			{#each grandSlam.headline.split(/(?<=\.)\s+/) as beat, i (beat)}
-				{#if i > 0}{' '}{/if}<span class="block text-balance">{beat}</span>
+				{#if i > 0}{' '}{/if}<span class="block text-balance">{beat.replace(/\.$/, '')}</span>
 			{/each}
 		</h1>
 		<p class="text-fg-muted mx-auto mt-6 max-w-3xl text-base leading-relaxed md:text-lg">

--- a/src/lib/content/offer.ts
+++ b/src/lib/content/offer.ts
@@ -6,7 +6,7 @@ import { site } from './site'
 // customer copy (results over mechanism), no slot counters (honest at zero).
 export const grandSlam: GrandSlamOffer = {
 	chip: '1 client a month · waitlist open',
-	headline: "the demo works. production doesn't.",
+	headline: "everyone saw the demo. nobody's seen it since.",
 	lead: "AI gets you to a demo because it can hold the whole thing in its head. once your codebase outgrows that window, it starts making things worse instead of better. that's the wall every vibe-coded project hits. it's also the thing i fix.",
 	offerLine:
 		'the production sprint. two weeks. live in production on day 10 — and you own every line of it.',

--- a/static/llms-full.txt
+++ b/static/llms-full.txt
@@ -1,6 +1,6 @@
 # SIXTOM — full content
 
-> the demo works. production doesn't. the production sprint: two weeks from working demo to production-grade — live in production on day 10, or the remaining payments are free. $10,000 flat. 1 client a month.
+> everyone saw the demo. nobody's seen it since. the production sprint: two weeks from working demo to production-grade — live in production on day 10, or the remaining payments are free. $10,000 flat. 1 client a month.
 
 ## thesis
 

--- a/static/llms.txt
+++ b/static/llms.txt
@@ -1,6 +1,6 @@
 # SIXTOM
 
-> the demo works. production doesn't. the production sprint: two weeks from working demo to production-grade — live in production on day 10, or the remaining payments are free. $10,000 flat. 1 client a month.
+> everyone saw the demo. nobody's seen it since. the production sprint: two weeks from working demo to production-grade — live in production on day 10, or the remaining payments are free. $10,000 flat. 1 client a month.
 
 ## what i do
 


### PR DESCRIPTION
Hook rework from the type exploration: **"everyone saw the demo / nobody's seen it since"** replaces "the demo works. production doesn't." everywhere it lives (content, `<title>`, og/twitter meta, llms.txt). Display drops the terminal periods (the beat break is the punctuation); prose contexts keep them. Beat sizes verified one line each on desktop, symmetric wrap on mobile; all 3 journeys pass with the updated contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KkSZmET2PrafrCpxNNWK6n