### PR TITLE
rev: brand-arc cleanup — lint clean, explicit beats, docs truth

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,7 +80,7 @@ Reads `site.calEvent` from the content layer, upserts the intro event in Cal.com
 
 `src/app.css` defines semantic tokens via `@theme` and per-section overrides via `.surface-uv` (blacklight: white + black text + glowing accents). Elements needing the dark palette inside/after a UV context sit outside the `.surface-uv` element (see `SiteFooter` on home) rather than using an override class.
 
-Tokens: `--color-surface`, `--color-fg`, `--color-fg-muted`, `--color-fg-subtle`, `--color-border`, `--color-border-strong`, `--color-accent` (teal), `--gradient-accent` (subtle horizontal teal flow for `bg-accent`), `--color-on-accent`, `--color-error`, `--shadow-accent` (none on dark, glow on UV), `--font-sans` (Recursive + system mono fallback), `--font-display` (Space Grotesk + system sans fallback).
+Tokens: `--color-surface`, `--color-fg`, `--color-fg-muted`, `--color-fg-subtle`, `--color-border`, `--color-border-strong`, `--color-accent` (teal), `--gradient-accent` (subtle horizontal teal flow for `bg-accent`), `--color-on-accent`, `--color-error`, `--shadow-accent` (none on dark, glow on UV), `--font-sans` (Recursive + system mono fallback), `--font-display` (Cabinet Grotesk + system sans fallback; carries all headings and the `.wordmark` lockup).
 
 Custom utilities: `.btn-accent` (gradient bg + dark text + shadow), `.eyebrow` (accent color + tracking + uppercase + shadow), `.text-accent` (accent text + shadow).
 

--- a/scripts/og-source/build-og.mjs
+++ b/scripts/og-source/build-og.mjs
@@ -112,7 +112,9 @@ const bubbleSvg = `<svg xmlns="http://www.w3.org/2000/svg" width="${W}" height="
 // Webfonts base64-embedded so the page renders offline/deterministically:
 // Cabinet Grotesk carries the wordmark, Recursive carries the subhead/domain.
 const recursiveB64 = readFileSync(resolve(ROOT, 'static/fonts/recursive.woff2')).toString('base64')
-const cabinetB64 = readFileSync(resolve(ROOT, 'static/fonts/cabinet-grotesk.woff2')).toString('base64')
+const cabinetB64 = readFileSync(resolve(ROOT, 'static/fonts/cabinet-grotesk.woff2')).toString(
+	'base64'
+)
 
 // Logo lockup mirrors the .wordmark rule in src/app.css: one value (0.08em)
 // sets the letter gaps, the chip's x-padding, and the gaps flanking the chip;
@@ -166,4 +168,6 @@ try {
 // Downsample the 2x supersample to the declared 1200x630 for crisp edges.
 execFileSync('magick', [shot2x, '-resize', `${W}x${H}`, '-strip', pngPath])
 rmSync(shot2x, { force: true })
-console.log(`og.png written (${String(circles.length)} bubbles, Cabinet Grotesk wordmark) -> ${pngPath}`)
+console.log(
+	`og.png written (${String(circles.length)} bubbles, Cabinet Grotesk wordmark) -> ${pngPath}`
+)

--- a/scripts/og-source/build-og.mjs
+++ b/scripts/og-source/build-og.mjs
@@ -2,11 +2,10 @@
 // SIXTOM logo lockup + subhead.
 //
 // The background bakes one frame of the hero's value-noise field (static/bubbles.js)
-// into SVG circles (oklch -> sRGB). The foreground renders the *actual* wordmark
-// markup — six + inverted "to" chip + m — in the real Recursive webfont via headless
-// Chromium, so the logo matches the site exactly (Recursive is proportional, so it
-// can't be faked on a monospace SVG grid). The bubble field is fully deterministic;
-// the rasterized text depends on the local chromium + magick versions.
+// into SVG circles (oklch -> sRGB). The foreground renders the actual wordmark
+// markup (six + square "to" chip + m, Cabinet Grotesk) plus the Recursive subhead
+// via headless Chromium, so the card matches the site exactly. The bubble field is
+// fully deterministic; the rasterized text depends on local chromium + magick.
 //
 // Run: node scripts/og-source/build-og.mjs   (needs playwright chromium + magick)
 import { execFileSync } from 'node:child_process'

--- a/src/app.css
+++ b/src/app.css
@@ -159,8 +159,7 @@ html {
 	scroll-behavior: smooth;
 }
 
-/* Headings speak the display face everywhere; body stays Recursive. Element
- * selector beats the inherited font-sans on <main> without fighting utilities. */
+/* Element selector: outranks the font-sans inherited from <main> without fighting utilities. */
 h1,
 h2,
 h3,

--- a/src/app.html
+++ b/src/app.html
@@ -47,7 +47,10 @@
 		<meta property="og:image" content="https://sixtom.com/og.png" />
 		<meta property="og:image:width" content="1200" />
 		<meta property="og:image:height" content="630" />
-		<meta property="og:image:alt" content="SIXTOM — everyone saw the demo. nobody's seen it since." />
+		<meta
+			property="og:image:alt"
+			content="SIXTOM — everyone saw the demo. nobody's seen it since."
+		/>
 
 		<meta name="twitter:card" content="summary_large_image" />
 		<meta name="twitter:title" content="SIXTOM — everyone saw the demo. nobody's seen it since." />
@@ -56,7 +59,10 @@
 			content="live in production on day 10 — and you own every line of it. $10,000 flat, 1 client a month."
 		/>
 		<meta name="twitter:image" content="https://sixtom.com/og.png" />
-		<meta name="twitter:image:alt" content="SIXTOM — everyone saw the demo. nobody's seen it since." />
+		<meta
+			name="twitter:image:alt"
+			content="SIXTOM — everyone saw the demo. nobody's seen it since."
+		/>
 
 		<link rel="icon" href="%sveltekit.assets%/favicon.svg" type="image/svg+xml" />
 		<link rel="apple-touch-icon" sizes="180x180" href="%sveltekit.assets%/apple-touch-icon.png" />

--- a/src/lib/components/Hero.svelte
+++ b/src/lib/components/Hero.svelte
@@ -1,5 +1,11 @@
 <script lang="ts">
 	import { grandSlam } from '$lib/content'
+
+	// Two display beats from the one prose headline; periods drop on screen
+	// (the line break is the punctuation) but survive in content and meta.
+	const [beatOne, beatTwo] = grandSlam.headline
+		.split(/(?<=\.)\s+/)
+		.map((beat) => beat.replace(/\.$/, ''))
 </script>
 
 <section class="snap-section bg-surface relative">
@@ -23,14 +29,11 @@
 
 	<div class="relative mx-auto w-full max-w-6xl px-6 py-16 text-left md:py-20 md:text-center">
 		<p class="eyebrow text-fg-muted text-xs md:text-sm">{grandSlam.chip}</p>
-		<!-- One string in content; two beats on screen, periods dropped at display
-		     scale — the line break is the punctuation. Meta/OG keep the prose form. -->
 		<h1
 			class="text-fg mt-6 text-[clamp(2.5rem,9.5vw,5.75rem)] leading-[1.04] font-bold tracking-tight"
 		>
-			{#each grandSlam.headline.split(/(?<=\.)\s+/) as beat, i (beat)}
-				{#if i > 0}{' '}{/if}<span class="block text-balance">{beat.replace(/\.$/, '')}</span>
-			{/each}
+			<span class="block text-balance">{beatOne}</span>
+			<span class="block text-balance">{beatTwo}</span>
 		</h1>
 		<!-- offerLine stays in content for the JSON-LD description; on screen the
 		     stat beats below carry the offer facts so the hero reads once, not twice. -->

--- a/src/lib/components/Hero.svelte
+++ b/src/lib/components/Hero.svelte
@@ -3,9 +3,11 @@
 
 	// Two display beats from the one prose headline; periods drop on screen
 	// (the line break is the punctuation) but survive in content and meta.
-	const [beatOne, beatTwo] = grandSlam.headline
+	// Sentences past the first join into beat two so copy is never dropped.
+	const [beatOne, ...rest] = grandSlam.headline
 		.split(/(?<=\.)\s+/)
 		.map((beat) => beat.replace(/\.$/, ''))
+	const beatTwo = rest.join(' ')
 </script>
 
 <section class="snap-section bg-surface relative">


### PR DESCRIPTION
/rev pass over the full brand arc (base: pre-#164). Round 1: prettier on two files, `svelte/no-useless-mustaches` resolved by computing hero beats in script (explicit sibling spans preserve the textContent space that each-blocks trim), comment tightening, stale og-builder header corrected, third-sentence overflow now joins into beat two. Round 2: AGENTS.md font-token doc caught up to Cabinet. Round 3: CLEAN.

Gates: a11y machine-detectable clean (live keyboard pass; axe not installed), journeys 3/3 zero errors, **Lighthouse 100/100/100/100 mobile AND desktop, 3 samples each, zero variance**, build green, lint + svelte-check green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KkSZmET2PrafrCpxNNWK6n