### PR TITLE
legal: accessibility page + terms/privacy audit fixes

### DIFF
--- a/src/lib/components/SiteFooter.svelte
+++ b/src/lib/components/SiteFooter.svelte
@@ -38,6 +38,11 @@
 				data-umami-event="footer_terms"
 				class="no-link hover:text-fg transition-colors">terms</a
 			>
+			<a
+				href="/accessibility"
+				data-umami-event="footer_accessibility"
+				class="no-link hover:text-fg transition-colors">accessibility</a
+			>
 			<!-- the garden's guide coin, 1:1 at inline scale — CSS-only flip so the
 			     zero-JS home keeps it -->
 			<a

--- a/src/routes/accessibility/+page.svelte
+++ b/src/routes/accessibility/+page.svelte
@@ -1,0 +1,81 @@
+<script lang="ts">
+	import SiteFooter from '$lib/components/SiteFooter.svelte'
+	import { site } from '$lib/content'
+</script>
+
+<svelte:head>
+	<title>accessibility | SIXTOM</title>
+	<meta
+		name="description"
+		content="what sixtom does to stay usable for everyone, how it's checked, and how to report a problem."
+	/>
+</svelte:head>
+
+<div class="bg-surface flex min-h-svh flex-col">
+	<div class="mx-auto w-full max-w-3xl flex-1 px-6 py-20">
+		<header class="mb-16">
+			<a
+				href="/"
+				class="eyebrow text-fg-subtle hover:text-coin text-xs transition-colors"
+				data-umami-event="legal_back_home"
+			>
+				sixtom
+			</a>
+			<p class="eyebrow mt-12 text-sm">access</p>
+			<h1 class="text-fg mt-2 text-4xl font-bold tracking-tight md:text-6xl">accessibility.</h1>
+			<p class="text-fg-muted mt-6 text-lg leading-relaxed">
+				this site should work for everyone. if it doesn't work for you, that's a bug.
+			</p>
+		</header>
+
+		<div class="text-fg-muted space-y-10 text-base leading-relaxed">
+			<section>
+				<h2 class="text-fg text-xl font-semibold tracking-tight">the target</h2>
+				<p class="mt-3">
+					WCAG 2.2 level AA. built to it, not retrofitted: semantic landmarks, one heading per job,
+					real buttons and links, a label on every input.
+				</p>
+			</section>
+
+			<section>
+				<h2 class="text-fg text-xl font-semibold tracking-tight">what's in place</h2>
+				<p class="mt-3">
+					everything interactive is reachable by keyboard, with a visible focus ring. text contrast
+					holds AA or better on the dark surface and the light sections alike.
+				</p>
+				<p class="mt-3">
+					reduced motion is honored. the few animations here collapse to static when your system
+					asks. the moving background is decorative, hidden from assistive tech, and never carries
+					information.
+				</p>
+			</section>
+
+			<section>
+				<h2 class="text-fg text-xl font-semibold tracking-tight">how it's checked</h2>
+				<p class="mt-3">
+					automated audits run clean and every release gets a keyboard pass. automated tools only
+					catch about two-thirds of the standard, so the judgment calls get human review. i don't
+					claim a clean bill i can't verify.
+				</p>
+			</section>
+
+			<section>
+				<h2 class="text-fg text-xl font-semibold tracking-tight">found a problem</h2>
+				<p class="mt-3">
+					tell me through the <a href="/notify" data-umami-event="a11y_report_notify"
+						>waitlist form</a
+					>
+					(mention accessibility), or on
+					<a href={site.operator.linkedinUrl} target="_blank" rel="noopener noreferrer">LinkedIn</a>
+					or <a href={site.operator.xUrl} target="_blank" rel="noopener noreferrer">X</a>.
+					accessibility bugs get fixed first.
+				</p>
+			</section>
+
+			<p class="text-fg-subtle mt-16 text-xs tracking-widest uppercase">
+				last updated: august 2026
+			</p>
+		</div>
+	</div>
+	<SiteFooter />
+</div>

--- a/src/routes/accessibility/+page.ts
+++ b/src/routes/accessibility/+page.ts
@@ -1,0 +1,1 @@
+export const prerender = true

--- a/src/routes/privacy/+page.svelte
+++ b/src/routes/privacy/+page.svelte
@@ -10,7 +10,7 @@
 	/>
 </svelte:head>
 
-<div class="bg-surface flex min-h-screen flex-col">
+<div class="bg-surface flex min-h-svh flex-col">
 	<div class="mx-auto w-full max-w-3xl flex-1 px-6 py-20">
 		<header class="mb-16">
 			<a

--- a/src/routes/sitemap.xml/+server.ts
+++ b/src/routes/sitemap.xml/+server.ts
@@ -29,6 +29,7 @@ export function GET(): Response {
 			priority: '0.7'
 		})),
 		{ path: '/privacy', lastmod: today, changefreq: 'yearly', priority: '0.3' },
+		{ path: '/accessibility', lastmod: today, changefreq: 'yearly', priority: '0.3' },
 		{ path: '/terms', lastmod: today, changefreq: 'yearly', priority: '0.3' }
 	]
 

--- a/src/routes/terms/+page.svelte
+++ b/src/routes/terms/+page.svelte
@@ -10,7 +10,7 @@
 	/>
 </svelte:head>
 
-<div class="bg-surface flex min-h-screen flex-col">
+<div class="bg-surface flex min-h-svh flex-col">
 	<div class="mx-auto w-full max-w-3xl flex-1 px-6 py-20">
 		<header class="mb-16">
 			<a

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -13,7 +13,7 @@ export default {
 		// since the homepage went single-case-study, so the prerenderer can't
 		// discover it and the build fails (same class of miss as /faq before).
 		prerender: {
-			entries: ['/sitemap.xml', '/privacy', '/terms', '/tax', '/faq', '/log']
+			entries: ['/accessibility', '/sitemap.xml', '/privacy', '/terms', '/tax', '/faq', '/log']
 		}
 		// inlineStyleThreshold removed: nested routes with <svelte:head> had the
 		// SSR-injected inline <style> block wiped during hydration while the


### PR DESCRIPTION
Adds `/accessibility` (statement in the legal-page pattern, honest per the a11y skill's no-overclaim rule), wires footer + prerender + sitemap, and applies the audit's `min-h-svh` fix to terms/privacy. Lint/check/build green, journeys 3/3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KkSZmET2PrafrCpxNNWK6n