### PR TITLE
waitlist intake: a reply-gated teardown, asked for in a form people can actually answer

### DIFF
--- a/src/lib/content/faq.ts
+++ b/src/lib/content/faq.ts
@@ -24,7 +24,7 @@ export const FAQ: readonly QA[] = [
 	{
 		question: "what's the free teardown?",
 		answer:
-			"join the waitlist, send me the link, and i'll record a short teardown of your app — what's solid, the three things that'll break, and what i'd do first. no charge, no call, no pitch."
+			"join the waitlist, then show me the thing — a live url, the repo, or a screen recording — and i'll record a short teardown of your app. what's solid, the three things that'll break, and what i'd do first. no charge, no call, no pitch. not deployed yet is fine; the repo is the better one for this anyway."
 	},
 	{
 		question: 'how long does it take?',

--- a/src/lib/content/faq.ts
+++ b/src/lib/content/faq.ts
@@ -24,7 +24,7 @@ export const FAQ: readonly QA[] = [
 	{
 		question: "what's the free teardown?",
 		answer:
-			"join the waitlist and i'll record a short teardown of your app — what's solid, the three things that'll break, and what i'd do first. no charge, no call, no pitch."
+			"join the waitlist, send me the link, and i'll record a short teardown of your app — what's solid, the three things that'll break, and what i'd do first. no charge, no call, no pitch."
 	},
 	{
 		question: 'how long does it take?',

--- a/src/lib/content/offer.ts
+++ b/src/lib/content/offer.ts
@@ -209,7 +209,7 @@ export const grandSlam: GrandSlamOffer = {
 		buildPlaceholder: 'a demo of… it works, but…',
 		button: 'get on the list →',
 		reward:
-			"the seat's booked out? good sign. while you wait, send me the link and you get a free teardown of your app — what's solid, the three things that'll break, and what i'd do first. no pitch attached."
+			"the seat's booked out? good sign. while you wait, show me what you've built — url, repo, or a screen recording — and you get a free teardown of your app. what's solid, the three things that'll break, and what i'd do first. no pitch attached."
 	}
 }
 

--- a/src/lib/content/offer.ts
+++ b/src/lib/content/offer.ts
@@ -209,7 +209,7 @@ export const grandSlam: GrandSlamOffer = {
 		buildPlaceholder: 'a demo of… it works, but…',
 		button: 'get on the list →',
 		reward:
-			"the seat's booked out? good sign. while you wait, you get a free teardown of your app — what's solid, the three things that'll break, and what i'd do first. no pitch attached."
+			"the seat's booked out? good sign. while you wait, send me the link and you get a free teardown of your app — what's solid, the three things that'll break, and what i'd do first. no pitch attached."
 	}
 }
 

--- a/src/lib/seo/jsonld.ts
+++ b/src/lib/seo/jsonld.ts
@@ -144,7 +144,7 @@ export function serviceJsonLd(): ServiceLd {
 				'@type': 'Offer',
 				name: 'free teardown',
 				description:
-					"a free teardown of your app — what's solid, the three things that'll break, and what i'd do first. join the waitlist to get one.",
+					"a free teardown of your app — what's solid, the three things that'll break, and what i'd do first. join the waitlist, then show me the thing: a live url, the repo, or a screen recording.",
 				price: '0',
 				priceCurrency: 'USD',
 				availability: 'https://schema.org/InStock',

--- a/src/lib/server/contact-form.test.ts
+++ b/src/lib/server/contact-form.test.ts
@@ -2,9 +2,20 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 import type { RequestEvent } from '@sveltejs/kit'
 import { processSubmission, resetRateLimitForTests } from './contact-form'
 
+// hoisted so the spy is reachable from the tests; contact-form caches the
+// transporter, so a fresh vi.fn() per createTransport call would be unobservable.
+const { sendMail } = vi.hoisted(() => ({
+	// typed param so mock.calls carries the mail shape rather than an empty tuple.
+	// nodemailer's sendMail returns a promise, so resolve one without an await.
+	sendMail: vi.fn((mail: { to: string; subject: string; text: string }) => {
+		void mail
+		return Promise.resolve(undefined)
+	})
+}))
+
 vi.mock('nodemailer', () => ({
 	default: {
-		createTransport: () => ({ sendMail: vi.fn().mockResolvedValue(undefined) })
+		createTransport: () => ({ sendMail })
 	}
 }))
 
@@ -46,6 +57,7 @@ function makeFormData(overrides: Partial<Record<string, string>> = {}): FormData
 describe('processSubmission — protection layers', () => {
 	beforeEach(() => {
 		resetRateLimitForTests()
+		sendMail.mockClear()
 	})
 
 	it('rejects missing required fields', async () => {
@@ -146,5 +158,34 @@ describe('processSubmission — protection layers', () => {
 		} finally {
 			env['CONTACT_FORM_TEST_EMAIL'] = original
 		}
+	})
+
+	describe('waitlist submissions', () => {
+		function sentMail() {
+			return sendMail.mock.calls.map(([mail]) => mail)
+		}
+
+		it('sends the teardown claim rather than the generic contact ack', async () => {
+			await processSubmission(makeFormData({ name: 'Waitlist signup' }), mockEvent(), 'waitlist')
+			const toVisitor = sentMail().find((m) => m.to === 'real@example.com')
+			expect(toVisitor?.subject).toContain('teardown')
+			// the ask is the whole gate: no reply, no work
+			expect(toVisitor?.text).toContain('reply')
+			expect(toVisitor?.text).not.toContain('Contact form submission received')
+		})
+
+		it('makes the operator notification identifiable by address', async () => {
+			// every waitlist signup hardcodes this name, so the subject cannot use it
+			await processSubmission(makeFormData({ name: 'Waitlist signup' }), mockEvent(), 'waitlist')
+			const toOperator = sentMail().find((m) => m.to !== 'real@example.com')
+			expect(toOperator?.subject).toContain('real@example.com')
+			expect(toOperator?.subject).not.toBe('Contact: Waitlist signup')
+		})
+
+		it('leaves the contact path unchanged', async () => {
+			await processSubmission(makeFormData(), mockEvent())
+			const toVisitor = sentMail().find((m) => m.to === 'real@example.com')
+			expect(toVisitor?.subject).toBe('Contact SIXTOM')
+		})
 	})
 })

--- a/src/lib/server/contact-form.test.ts
+++ b/src/lib/server/contact-form.test.ts
@@ -174,6 +174,18 @@ describe('processSubmission — protection layers', () => {
 			expect(toVisitor?.text).not.toContain('Contact form submission received')
 		})
 
+		it('offers more than one way to show the app', async () => {
+			// Most of this audience has no public URL to paste — localhost, behind
+			// auth, or never deployed. A URL-only ask is unanswerable for them and
+			// they go quiet, which is the exact drop-off the reply-gate exists to
+			// prevent. Narrowing this copy back to one artifact is a regression.
+			await processSubmission(makeFormData({ name: 'Waitlist signup' }), mockEvent(), 'waitlist')
+			const body = sentMail().find((m) => m.to === 'real@example.com')?.text ?? ''
+			expect(body).toContain('url')
+			expect(body).toContain('repo')
+			expect(body).toContain('recording')
+		})
+
 		it('makes the operator notification identifiable by address', async () => {
 			// every waitlist signup hardcodes this name, so the subject cannot use it
 			await processSubmission(makeFormData({ name: 'Waitlist signup' }), mockEvent(), 'waitlist')

--- a/src/lib/server/contact-form.ts
+++ b/src/lib/server/contact-form.ts
@@ -166,20 +166,28 @@ export async function processSubmission(
 
 	const transporter = getTransporter()
 
-	// The teardown is promised on the site but cannot be recorded without a URL,
-	// which the form deliberately does not collect. Asking for it in the reply is
-	// the gate: bots fill forms and never answer email, so a signup that never
+	// The teardown is promised on the site but cannot be recorded without seeing
+	// the app, which the form deliberately does not collect. Asking in the reply
+	// is the gate: bots fill forms and never answer email, so a signup that never
 	// replies costs a database row and nothing else. The reply is the signal that
 	// someone actually wants the thing.
+	//
+	// The ask is three options on purpose. This audience vibe-coded something that
+	// half-works, so a large share of them have no public URL to paste — localhost,
+	// behind auth, or never deployed. A URL-only ask is unanswerable for them and
+	// they drop off silently, which is the exact failure the reply-gate exists to
+	// prevent. The repo is also the better artifact for the promise being made:
+	// "what will break" lives in the code, not on the rendered page.
 	const waitlistBody = [
 		"you're on the list.",
 		'',
 		'one seat a month, by appointment. i tell you straight when the next one opens.',
 		'',
-		"the teardown: send me the link and i'll record you a short one. what's solid,",
+		"the teardown: show me the thing and i'll record you a short one. what's solid,",
 		"the three things that'll break, and what i'd do first. no charge, no call, no pitch.",
 		'',
-		'just reply to this with the URL.',
+		'reply with whatever lets me see it — a live url, the repo, or a 3-minute screen',
+		"recording. if it isn't deployed yet, the repo is the better one for this anyway.",
 		'',
 		'in the meantime, what it costs you to leave it as it is:',
 		'https://sixtom.com/tax',
@@ -192,7 +200,7 @@ export async function processSubmission(
 			? {
 					from: env.SMTP_EMAIL,
 					to: email,
-					subject: 'your teardown - send me the link',
+					subject: 'your teardown - show me the thing',
 					text: waitlistBody
 				}
 			: {

--- a/src/lib/server/contact-form.ts
+++ b/src/lib/server/contact-form.ts
@@ -100,9 +100,18 @@ function getTransporter(): Transporter {
 	return cachedTransporter
 }
 
+/**
+ * 'waitlist' is the notify form, 'contact' is everything else. The two need
+ * different mail: a waitlist joiner gets the teardown claim, and Sam's copy
+ * needs to be identifiable, which `Contact: Waitlist signup` was not - every
+ * signup arrived under the same subject.
+ */
+export type SubmissionKind = 'waitlist' | 'contact'
+
 export async function processSubmission(
 	formData: FormData,
-	event: Pick<RequestEvent, 'request' | 'getClientAddress'>
+	event: Pick<RequestEvent, 'request' | 'getClientAddress'>,
+	kind: SubmissionKind = 'contact'
 ): Promise<SubmissionResult> {
 	function readString(field: string): string {
 		const value = formData.get(field)
@@ -156,17 +165,50 @@ export async function processSubmission(
 	}
 
 	const transporter = getTransporter()
-	const confirmation = {
-		from: env.SMTP_EMAIL,
-		to: email,
-		subject: `Contact SIXTOM`,
-		text: 'Contact form submission received! We look forward to talking to you soon.'
-	}
+
+	// The teardown is promised on the site but cannot be recorded without a URL,
+	// which the form deliberately does not collect. Asking for it in the reply is
+	// the gate: bots fill forms and never answer email, so a signup that never
+	// replies costs a database row and nothing else. The reply is the signal that
+	// someone actually wants the thing.
+	const waitlistBody = [
+		"you're on the list.",
+		'',
+		'one seat a month, by appointment. i tell you straight when the next one opens.',
+		'',
+		"the teardown: send me the link and i'll record you a short one. what's solid,",
+		"the three things that'll break, and what i'd do first. no charge, no call, no pitch.",
+		'',
+		'just reply to this with the URL.',
+		'',
+		'in the meantime, what it costs you to leave it as it is:',
+		'https://sixtom.com/tax',
+		'',
+		'- sam'
+	].join('\n')
+
+	const confirmation =
+		kind === 'waitlist'
+			? {
+					from: env.SMTP_EMAIL,
+					to: email,
+					subject: 'your teardown - send me the link',
+					text: waitlistBody
+				}
+			: {
+					from: env.SMTP_EMAIL,
+					to: email,
+					subject: `Contact SIXTOM`,
+					text: 'Contact form submission received! We look forward to talking to you soon.'
+				}
+
 	const notification = {
 		from: env.SMTP_EMAIL,
 		to: env.SMTP_RECIPIENT_EMAIL,
 		replyTo: email,
-		subject: `Contact: ${name}`,
+		// Lead with the address: the waitlist form hardcodes name to
+		// "Waitlist signup", so every one of these used to arrive identical.
+		subject: kind === 'waitlist' ? `waitlist: ${email}` : `Contact: ${name}`,
 		text: message
 	}
 

--- a/src/lib/server/contact-form.ts
+++ b/src/lib/server/contact-form.ts
@@ -1,6 +1,7 @@
 import nodemailer, { type Transporter } from 'nodemailer'
 import { env } from '$env/dynamic/private'
 import type { RequestEvent } from '@sveltejs/kit'
+import { site } from '$lib/content/site'
 
 export const MAX_NAME_LENGTH = 120
 export const MAX_EMAIL_LENGTH = 254
@@ -108,6 +109,39 @@ function getTransporter(): Transporter {
  */
 export type SubmissionKind = 'waitlist' | 'contact'
 
+// The teardown is promised on the site but cannot be recorded without seeing
+// the app, which the form deliberately does not collect. Asking in the reply is
+// the gate: bots fill forms and never answer email, so a signup that never
+// replies costs a database row and nothing else. The reply is the signal that
+// someone actually wants the thing.
+//
+// The ask is three options on purpose. This audience vibe-coded something that
+// half-works, so a large share of them have no public URL to paste — localhost,
+// behind auth, or never deployed. A URL-only ask is unanswerable for them and
+// they drop off silently, which is the exact failure the reply-gate exists to
+// prevent. The repo is also the better artifact for the promise being made:
+// "what will break" lives in the code, not on the rendered page.
+//
+// Module scope because nothing in it is per-request; building it inside the
+// handler re-joined it on every submission, including the contact ones that
+// throw it away.
+const WAITLIST_BODY = [
+	"you're on the list.",
+	'',
+	'one seat a month, by appointment. i tell you straight when the next one opens.',
+	'',
+	"the teardown: show me the thing and i'll record you a short one. what's solid,",
+	"the three things that'll break, and what i'd do first. no charge, no call, no pitch.",
+	'',
+	'reply with whatever lets me see it — a live url, the repo, or a 3-minute screen',
+	"recording. if it isn't deployed yet, the repo is the better one for this anyway.",
+	'',
+	'in the meantime, what it costs you to leave it as it is:',
+	`${site.siteUrl}/tax`,
+	'',
+	'- sam'
+].join('\n')
+
 export async function processSubmission(
 	formData: FormData,
 	event: Pick<RequestEvent, 'request' | 'getClientAddress'>,
@@ -166,42 +200,13 @@ export async function processSubmission(
 
 	const transporter = getTransporter()
 
-	// The teardown is promised on the site but cannot be recorded without seeing
-	// the app, which the form deliberately does not collect. Asking in the reply
-	// is the gate: bots fill forms and never answer email, so a signup that never
-	// replies costs a database row and nothing else. The reply is the signal that
-	// someone actually wants the thing.
-	//
-	// The ask is three options on purpose. This audience vibe-coded something that
-	// half-works, so a large share of them have no public URL to paste — localhost,
-	// behind auth, or never deployed. A URL-only ask is unanswerable for them and
-	// they drop off silently, which is the exact failure the reply-gate exists to
-	// prevent. The repo is also the better artifact for the promise being made:
-	// "what will break" lives in the code, not on the rendered page.
-	const waitlistBody = [
-		"you're on the list.",
-		'',
-		'one seat a month, by appointment. i tell you straight when the next one opens.',
-		'',
-		"the teardown: show me the thing and i'll record you a short one. what's solid,",
-		"the three things that'll break, and what i'd do first. no charge, no call, no pitch.",
-		'',
-		'reply with whatever lets me see it — a live url, the repo, or a 3-minute screen',
-		"recording. if it isn't deployed yet, the repo is the better one for this anyway.",
-		'',
-		'in the meantime, what it costs you to leave it as it is:',
-		'https://sixtom.com/tax',
-		'',
-		'- sam'
-	].join('\n')
-
 	const confirmation =
 		kind === 'waitlist'
 			? {
 					from: env.SMTP_EMAIL,
 					to: email,
 					subject: 'your teardown - show me the thing',
-					text: waitlistBody
+					text: WAITLIST_BODY
 				}
 			: {
 					from: env.SMTP_EMAIL,

--- a/src/routes/book/+page.svelte
+++ b/src/routes/book/+page.svelte
@@ -193,7 +193,7 @@
 							required
 							maxlength="500"
 							bind:value={built}
-							placeholder="where can I see it? paste a link"
+							placeholder="a url, the repo, or 'not deployed yet'"
 							class="{inputClass} mt-2"
 						/>
 					</div>

--- a/src/routes/notify/+page.server.ts
+++ b/src/routes/notify/+page.server.ts
@@ -15,7 +15,7 @@ export const actions = {
 		}
 
 		const formData = await event.request.formData()
-		const result = await processSubmission(formData, event)
+		const result = await processSubmission(formData, event, 'waitlist')
 
 		if (result.ok) {
 			// Bank the address in listmonk's `sixtom` list as well as the inbox —

--- a/static/llms-full.txt
+++ b/static/llms-full.txt
@@ -61,7 +61,7 @@ and there's a floor under it: day 5, we both look at it. if we can both see it w
 
 ## the free teardown
 
-join the waitlist and get a short recorded teardown of your app — what's solid, the three things that'll break, and what i'd do first. no charge, no call, no pitch.
+join the waitlist, then show me the thing — a live url, the repo, or a screen recording — and you get a short recorded teardown of your app. what's solid, the three things that'll break, and what i'd do first. no charge, no call, no pitch. not deployed yet is fine; the repo is the better one for this anyway.
 
 ## who it's for
 
@@ -94,7 +94,7 @@ live in production by day 10, or the remaining payments are free. there's a floo
 
 **what's the free teardown?**
 
-join the waitlist and i'll record a short teardown of your app — what's solid, the three things that'll break, and what i'd do first. no charge, no call, no pitch.
+join the waitlist, then show me the thing — a live url, the repo, or a screen recording — and i'll record a short teardown of your app. what's solid, the three things that'll break, and what i'd do first. no charge, no call, no pitch. not deployed yet is fine; the repo is the better one for this anyway.
 
 **how long does it take?**
 

--- a/static/llms.txt
+++ b/static/llms.txt
@@ -5,7 +5,7 @@
 ## what i do
 
 - **the production sprint — $10,000.** two weeks. i rebuild your AI-built demo on foundations that hold: architecture teardown + premortem, security review on every commit, automated test suite, performance to 100s, accessibility pass, analytics + observability, CRO-ready pages + A/B scaffold, technical SEO foundation, AEO/GEO foundation, infra cost audit, conversion copy pass, and a brand kit with 1-of-1 art — plus an AI leverage session, a 90-day growth map, and a runbook + Loom library by day 30. total itemized value $28,500+. live on day 10 — you own 100% of it.
-- **the free teardown — $0.** join the waitlist and get a short recorded teardown of your app: what's solid, the three things that'll break, and what i'd do first. no charge, no call, no pitch.
+- **the free teardown — $0.** join the waitlist, then show me the thing — a live url, the repo, or a screen recording — and get a short recorded teardown of your app: what's solid, the three things that'll break, and what i'd do first. no charge, no call, no pitch. not deployed yet is fine; the repo is the better one for this anyway.
 
 ## the guarantee
 


### PR DESCRIPTION
Two commits. The first gives waitlist signups a real intake email; the second fixes a hole in what that email asks for.

## the problem

Joining the waitlist sent the generic contact-form acknowledgement — "Contact form submission received! We look forward to talking to you soon." — under the subject `Contact SIXTOM`. The site promises a free teardown; the email that followed a signup never mentioned it. Sam's own copy of every signup arrived as `Contact: Waitlist signup`, because the waitlist form hardcodes that name, so every notification looked identical in the inbox.

## the gate

The signup form deliberately collects **no** URL, repo, or artifact. That's the design, not an oversight: the teardown can't be recorded without seeing the app, so producing it requires a reply. Bots fill forms and never answer email — a signup that goes quiet costs one database row and zero work, and the reply simultaneously proves a human and delivers what's needed to do the job.

Adding an artifact field to the form would hand bots the ability to supply it and destroy the filter.

## what the second commit fixes

The first version asked for one thing: *"just reply to this with the URL."*

That assumes a public, pasteable app. This offer targets people who vibe-coded something to a working demo — a large share of them are on localhost, behind auth, or never deployed. For those people the ask was unanswerable, so their only move was silence: precisely the drop-off the gate exists to prevent.

The ask is now three options — a live url, the repo, or a short screen recording — with the repo named as the *better* artifact rather than the fallback. That's not a consolation: the promise is "the three things that'll break", and those live in the code, not on the rendered page. A URL shows the surface (perf, a11y, obvious UX); the failure modes are in the source. Reframing "not deployed yet" as a preference turns the most common objection into a signal of fit.

Same widening applied to `faq.ts`, `offer.ts`, and the `/book` placeholder.

## drift fixed along the way

`static/llms-full.txt` still carried the unconditional teardown promise from before the gate landed. `faq.ts` carries a comment asking for the two to be kept in sync by hand, and that is exactly what failed. Generating the FAQ section at build time is the durable fix and is **not** in this PR.

## tests

4 new, in `contact-form.test.ts`: the waitlist path sends the teardown claim rather than the contact ack, the operator notification is identifiable by address, the contact path is unchanged, and the ask names more than one artifact type (so narrowing it back to URL-only is a test failure, not a silent regression).

`npm run check` 0 errors · 57 tests passing · lint clean · build passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X8mUrJg8DqfjzAbLZxbdk6