### PR TITLE
offer: the teardown is paid now — $5,000, credited against the sprint

### DIFF
--- a/.agent-toolkit/journeys.md
+++ b/.agent-toolkit/journeys.md
@@ -8,7 +8,7 @@ skips Listmonk for the test email; processSubmission skips SMTP for it).
 ## 1. land → read the offer → join the waitlist
 
 1. Open `/`. Expect: h1 "everyone saw the demo nobody's seen it since" (periods live in content/meta, not the display), chip "1 client a month · waitlist open", stat "day 10 or free".
-2. Scroll through wall → ledger → guarantee → proof. Expect: ledger shows "total value" of "$28,500+" and a pay line containing "$10,000"; guarantee headline contains "day 10"; proof tiles include "+185%".
+2. Scroll through wall → ledger → guarantee → proof. Expect: ledger shows "total value" of "$30,500+" and a pay line containing "$10,000"; guarantee headline contains "day 10"; proof tiles include "+185%".
 3. Fill `#waitlist-email` with e2e@test.sixtom.local and `#waitlist-build` with any text; submit.
 4. Expect: navigation to `/notify?/notify` (the named-action URL — no redirect) showing "You're on the list." No console errors, no failed network requests anywhere in the journey.
 

--- a/src/lib/components/Hero.svelte
+++ b/src/lib/components/Hero.svelte
@@ -55,7 +55,7 @@
 				data-umami-event="cta_hero_teardown"
 				class="text-fg hover:text-fg-subtle text-xs tracking-widest uppercase transition-colors"
 			>
-				or get a free teardown
+				or start with a teardown
 			</a>
 		</div>
 		<ul class="mt-12 flex list-none flex-wrap gap-x-10 gap-y-4 p-0 md:justify-center">

--- a/src/lib/content/content.test.ts
+++ b/src/lib/content/content.test.ts
@@ -15,7 +15,7 @@ describe('content', () => {
 		const sum = grandSlam.ledger.groups
 			.flatMap((g) => g.lines)
 			.reduce((acc, l) => acc + (l.valueUSD ?? 0), 0)
-		expect(sum).toBe(28500)
+		expect(sum).toBe(30500)
 		expect(LEDGER_TOTAL_USD).toBe(sum)
 	})
 

--- a/src/lib/content/content.test.ts
+++ b/src/lib/content/content.test.ts
@@ -1,14 +1,24 @@
 import { describe, it, expect } from 'vitest'
-import { site, calEvent, grandSlam, LEDGER_TOTAL_USD } from './index'
+import { site, calEvent, grandSlam, FAQ, LEDGER_TOTAL_USD } from './index'
 
 describe('content', () => {
 	it('site exports the operator + sprint (audit and retainer are gone)', () => {
 		expect(site.operator.name).toBe("Salvatore D'Angelo")
 		expect(site.sprint.priceUSD).toBe(10000)
+		expect(site.teardown.priceUSD).toBe(5000)
 		expect(site.sprint.introPriceUSD).toBe(7500)
 		expect(site.bookingUrl).toMatch(/^https?:\/\//)
 		expect('audit' in site).toBe(false)
 		expect('retainer' in site).toBe(false)
+	})
+
+	// The teardown price is written out in prose on several surfaces (FAQ, llms.txt,
+	// terms) the way the sprint price already is, so changing site.ts alone would
+	// leave them quietly disagreeing about what a teardown costs.
+	it('the FAQ quotes the current teardown price', () => {
+		const answer = FAQ.find((qa) => qa.question.includes('teardown'))?.answer ?? ''
+		expect(answer).toContain(`$${site.teardown.priceUSD.toLocaleString('en-US')}`)
+		expect(answer).toContain(site.teardown.creditNote)
 	})
 
 	it('ledger line values sum to the advertised total', () => {

--- a/src/lib/content/faq.ts
+++ b/src/lib/content/faq.ts
@@ -2,7 +2,7 @@ import type { QA } from './types'
 
 // Operational buyer questions for the visible /faq route. These are the things a
 // prospect (or an LLM answering on their behalf) actually asks before booking —
-// price, the guarantee, the free teardown, who's behind it. Kept in the site's
+// price, the guarantee, the teardown, who's behind it. Kept in the site's
 // voice. static/llms-full.txt carries a content-identical FAQ section (absolute
 // URLs there) — keep both in sync when editing answers.
 export const FAQ: readonly QA[] = [
@@ -14,7 +14,7 @@ export const FAQ: readonly QA[] = [
 	{
 		question: 'how much does it cost?',
 		answer:
-			'$10,000 flat, or 4 weekly payments of $2,500. that price buys the whole ledger on the home page — over $28,500 of itemized work. (the $7,500 first-3 intro is closed.)'
+			'$10,000 flat, or 4 weekly payments of $2,500. that price buys the whole ledger on the home page — over $30,500 of itemized work. (the $7,500 first-3 intro is closed.)'
 	},
 	{
 		question: "what's the guarantee?",
@@ -22,9 +22,9 @@ export const FAQ: readonly QA[] = [
 			"live in production by day 10, or the remaining payments are free. there's a floor under it too: at the day-5 scope check, if we can both see it won't ship in scope, we stop — you keep everything built and pay only for the time used."
 	},
 	{
-		question: "what's the free teardown?",
+		question: "what's the teardown?",
 		answer:
-			"join the waitlist, then show me the thing — a live url, the repo, or a screen recording — and i'll record a short teardown of your app. what's solid, the three things that'll break, and what i'd do first. no charge, no call, no pitch. not deployed yet is fine; the repo is the better one for this anyway."
+			"$5,000, credited in full against the sprint. i read the whole thing — repo, live url, or a screen recording — and write up what's solid, exactly what breaks and in what order, and what i'd do first. it's also how you move now instead of waiting for the next seat. you keep the writeup whether or not we work together, and i'll tell you if you don't need me."
 	},
 	{
 		question: 'how long does it take?',

--- a/src/lib/content/offer.ts
+++ b/src/lib/content/offer.ts
@@ -208,7 +208,7 @@ export const grandSlam: GrandSlamOffer = {
 		buildLabel: 'what did you build?',
 		buildPlaceholder: 'a demo of… it works, but…',
 		button: 'get on the list →',
-		reward: `the seat's booked out? good sign. if you'd rather not wait, the teardown is how you move now: $${site.teardown.priceUSD.toLocaleString('en-US')}, ${site.teardown.creditNote}. i read the whole codebase and tell you exactly what breaks, in what order, and what i'd do first. you get the writeup whether or not we ever work together.`
+		reward: `the seat's booked out? good sign. if you'd rather not wait, the teardown is how you move now: $${site.teardown.priceUSD.toLocaleString('en-US')}, ${site.teardown.creditNote}. i read the whole thing and tell you exactly what breaks, in what order, and what i'd do first. you get the writeup whether or not we ever work together.`
 	}
 }
 

--- a/src/lib/content/offer.ts
+++ b/src/lib/content/offer.ts
@@ -37,7 +37,7 @@ export const grandSlam: GrandSlamOffer = {
 					{
 						line: 'architecture teardown + premortem',
 						sub: 'exactly what will break, and why',
-						valueUSD: 3000
+						valueUSD: 5000
 					},
 					{
 						line: 'the rebuild',
@@ -208,8 +208,7 @@ export const grandSlam: GrandSlamOffer = {
 		buildLabel: 'what did you build?',
 		buildPlaceholder: 'a demo of… it works, but…',
 		button: 'get on the list →',
-		reward:
-			"the seat's booked out? good sign. while you wait, show me what you've built — url, repo, or a screen recording — and you get a free teardown of your app. what's solid, the three things that'll break, and what i'd do first. no pitch attached."
+		reward: `the seat's booked out? good sign. if you'd rather not wait, the teardown is how you move now: $${site.teardown.priceUSD.toLocaleString('en-US')}, ${site.teardown.creditNote}. i read the whole codebase and tell you exactly what breaks, in what order, and what i'd do first. you get the writeup whether or not we ever work together.`
 	}
 }
 

--- a/src/lib/content/site.ts
+++ b/src/lib/content/site.ts
@@ -31,6 +31,12 @@ export const site: Site = {
 		cadence: '1 client a month, by appointment.',
 		paymentPlan: '4 weekly payments of $2,500'
 	},
+	teardown: {
+		name: 'teardown',
+		longName: 'the teardown',
+		priceUSD: 5000,
+		creditNote: 'credited in full against the sprint'
+	},
 	process: [
 		{ label: 'wk 1 · day 0', body: 'a 30-minute call. we figure out the thing.' },
 		{
@@ -72,7 +78,7 @@ export const calEvent: CalEvent = {
 		{
 			label: 'where are you in the process?',
 			type: 'select',
-			options: ['on the waitlist', 'got my free teardown — ready to talk', 'just found sixtom'],
+			options: ['on the waitlist', 'did the teardown — ready to talk', 'just found sixtom'],
 			required: true
 		}
 	]

--- a/src/lib/content/site.ts
+++ b/src/lib/content/site.ts
@@ -32,7 +32,6 @@ export const site: Site = {
 		paymentPlan: '4 weekly payments of $2,500'
 	},
 	teardown: {
-		name: 'teardown',
 		longName: 'the teardown',
 		priceUSD: 5000,
 		creditNote: 'credited in full against the sprint'

--- a/src/lib/content/types.ts
+++ b/src/lib/content/types.ts
@@ -41,6 +41,13 @@ export interface Testimonial {
 	attribution: string
 }
 
+export interface Teardown {
+	name: string
+	longName: string
+	priceUSD: number
+	creditNote: string
+}
+
 export interface Site {
 	siteUrl: string
 	bookingUrl: string
@@ -48,6 +55,7 @@ export interface Site {
 	tagline: string
 	operator: Operator
 	sprint: Offer
+	teardown: Teardown
 	process: readonly ProcessStep[]
 	testimonial: Testimonial
 }

--- a/src/lib/content/types.ts
+++ b/src/lib/content/types.ts
@@ -42,7 +42,6 @@ export interface Testimonial {
 }
 
 export interface Teardown {
-	name: string
 	longName: string
 	priceUSD: number
 	creditNote: string

--- a/src/lib/seo/jsonld.test.ts
+++ b/src/lib/seo/jsonld.test.ts
@@ -45,7 +45,7 @@ describe('JSON-LD generators', () => {
 		expect(ld.publisher['@id']).toBe(PERSON_ID)
 	})
 
-	it('serviceJsonLd sells exactly the two live offers: sprint + free teardown', () => {
+	it('serviceJsonLd sells exactly the two live offers: sprint + teardown', () => {
 		const ld = serviceJsonLd()
 		expect(ld['@context']).toBe('https://schema.org')
 		expect(ld['@type']).toBe('Service')
@@ -60,8 +60,8 @@ describe('JSON-LD generators', () => {
 		// closed intro must not leak into machine surfaces
 		expect(ld.offers[0]?.description).not.toContain('7500')
 		expect(ld.offers[0]?.description).not.toContain('7,500')
-		expect(ld.offers[1]?.name).toBe('free teardown')
-		expect(ld.offers[1]?.price).toBe('0')
+		expect(ld.offers[1]?.name).toBe(site.teardown.longName)
+		expect(ld.offers[1]?.price).toBe(String(site.teardown.priceUSD))
 		expect(ld.offers[1]?.availability).toBe('https://schema.org/InStock')
 		expect(ld.offers[1]?.url).toBe(`${site.siteUrl}/notify`)
 	})

--- a/src/lib/seo/jsonld.ts
+++ b/src/lib/seo/jsonld.ts
@@ -142,10 +142,9 @@ export function serviceJsonLd(): ServiceLd {
 			},
 			{
 				'@type': 'Offer',
-				name: 'free teardown',
-				description:
-					"a free teardown of your app — what's solid, the three things that'll break, and what i'd do first. join the waitlist, then show me the thing: a live url, the repo, or a screen recording.",
-				price: '0',
+				name: site.teardown.longName,
+				description: `a paid teardown of your app, ${site.teardown.creditNote} — what's solid, exactly what breaks and in what order, and what i'd do first. send the repo, a live url, or a screen recording.`,
+				price: String(site.teardown.priceUSD),
 				priceCurrency: 'USD',
 				availability: 'https://schema.org/InStock',
 				url: `${site.siteUrl}/notify`

--- a/src/lib/server/contact-form.test.ts
+++ b/src/lib/server/contact-form.test.ts
@@ -165,10 +165,10 @@ describe('processSubmission — protection layers', () => {
 			return sendMail.mock.calls.map(([mail]) => mail)
 		}
 
-		it('sends the teardown claim rather than the generic contact ack', async () => {
+		it('sends the waitlist confirmation rather than the generic contact ack', async () => {
 			await processSubmission(makeFormData({ name: 'Waitlist signup' }), mockEvent(), 'waitlist')
 			const toVisitor = sentMail().find((m) => m.to === 'real@example.com')
-			expect(toVisitor?.subject).toContain('teardown')
+			expect(toVisitor?.subject).toContain('on the list')
 			// the ask is the whole gate: no reply, no work
 			expect(toVisitor?.text).toContain('reply')
 			expect(toVisitor?.text).not.toContain('Contact form submission received')

--- a/src/lib/server/contact-form.ts
+++ b/src/lib/server/contact-form.ts
@@ -109,11 +109,10 @@ function getTransporter(): Transporter {
  */
 export type SubmissionKind = 'waitlist' | 'contact'
 
-// The teardown is promised on the site but cannot be recorded without seeing
-// the app, which the form deliberately does not collect. Asking in the reply is
-// the gate: bots fill forms and never answer email, so a signup that never
-// replies costs a database row and nothing else. The reply is the signal that
-// someone actually wants the thing.
+// The reply is still the gate, but the teardown behind it is now paid, so the
+// ask has changed shape: the reply qualifies, the price qualifies harder. Bots
+// fill forms and never answer email, so a signup that never replies costs a
+// database row and nothing else.
 //
 // The ask is three options on purpose. This audience vibe-coded something that
 // half-works, so a large share of them have no public URL to paste — localhost,
@@ -130,11 +129,13 @@ const WAITLIST_BODY = [
 	'',
 	'one seat a month, by appointment. i tell you straight when the next one opens.',
 	'',
-	"the teardown: show me the thing and i'll record you a short one. what's solid,",
-	"the three things that'll break, and what i'd do first. no charge, no call, no pitch.",
+	`if you'd rather not wait, the teardown is how you move now: $${site.teardown.priceUSD.toLocaleString('en-US')},`,
+	`${site.teardown.creditNote}. i read the whole thing and write up what's solid,`,
+	"exactly what breaks and in what order, and what i'd do first. you keep the",
+	"writeup either way, and i'll tell you if you don't need me.",
 	'',
-	'reply with whatever lets me see it — a live url, the repo, or a 3-minute screen',
-	"recording. if it isn't deployed yet, the repo is the better one for this anyway.",
+	'either way — reply with whatever lets me see it: a live url, the repo, or a',
+	"3-minute screen recording. if it isn't deployed yet, the repo is better anyway.",
 	'',
 	'in the meantime, what it costs you to leave it as it is:',
 	`${site.siteUrl}/tax`,

--- a/src/lib/server/contact-form.ts
+++ b/src/lib/server/contact-form.ts
@@ -206,7 +206,7 @@ export async function processSubmission(
 			? {
 					from: env.SMTP_EMAIL,
 					to: email,
-					subject: 'your teardown - show me the thing',
+					subject: "you're on the list - show me the thing",
 					text: WAITLIST_BODY
 				}
 			: {

--- a/src/routes/faq/+page.svelte
+++ b/src/routes/faq/+page.svelte
@@ -13,7 +13,7 @@
 	<title>faq | SIXTOM</title>
 	<meta
 		name="description"
-		content="what sixtom costs, how the two-week sprint and the day-10 guarantee work, and how to get the free teardown."
+		content="what sixtom costs, how the two-week sprint and the day-10 guarantee work, and what the teardown is."
 	/>
 	<meta property="og:title" content="faq | SIXTOM" />
 	<meta

--- a/src/routes/notify/+page.svelte
+++ b/src/routes/notify/+page.svelte
@@ -21,7 +21,7 @@
 	<title>waitlist | SIXTOM</title>
 	<meta
 		name="description"
-		content="one client a month. join the waitlist — and get a free teardown of your app while you wait."
+		content="one client a month. join the waitlist — or start with a paid teardown and move now."
 	/>
 </svelte:head>
 

--- a/src/routes/sitemap.xml/+server.ts
+++ b/src/routes/sitemap.xml/+server.ts
@@ -13,7 +13,7 @@ interface SitemapUrl {
 export function GET(): Response {
 	const today = new Date().toISOString().slice(0, 10)
 	// Indexable routes only — /book (noindex,nofollow) is deliberately excluded.
-	// /notify is the waitlist + free-teardown offer URL (schema points at it),
+	// /notify is the waitlist + teardown offer URL (schema points at it),
 	// indexable since the grand-slam migration. Writeups derive from LOG_ENTRIES
 	// so new ones appear automatically, stamped with their real publish date.
 	const urls: SitemapUrl[] = [

--- a/src/routes/terms/+page.svelte
+++ b/src/routes/terms/+page.svelte
@@ -6,7 +6,7 @@
 	<title>terms | SIXTOM</title>
 	<meta
 		name="description"
-		content="how engagement with sixtom works. plain-English terms for the sprint, the day-10 guarantee, and the free teardown."
+		content="how engagement with sixtom works. plain-English terms for the sprint, the day-10 guarantee, and the teardown."
 	/>
 </svelte:head>
 
@@ -44,10 +44,12 @@
 			</section>
 
 			<section>
-				<h2 class="text-fg text-xl font-semibold tracking-tight">the free teardown</h2>
+				<h2 class="text-fg text-xl font-semibold tracking-tight">the teardown</h2>
 				<p class="mt-3">
-					the teardown is free, carries no obligation on either side, and i may decline to record
-					one if your project isn't a fit.
+					$5,000, paid up front, credited in full against the sprint if you book one within 90 days.
+					you get the written findings either way and you own them. it carries no obligation on
+					either side — i may decline if your project isn't a fit, and if i decline after you've
+					paid, you get all of it back.
 				</p>
 			</section>
 

--- a/src/routes/terms/+page.svelte
+++ b/src/routes/terms/+page.svelte
@@ -1,5 +1,8 @@
 <script lang="ts">
 	import SiteFooter from '$lib/components/SiteFooter.svelte'
+	import { site } from '$lib/content'
+
+	const teardownPrice = `$${site.teardown.priceUSD.toLocaleString('en-US')}`
 </script>
 
 <svelte:head>
@@ -46,10 +49,10 @@
 			<section>
 				<h2 class="text-fg text-xl font-semibold tracking-tight">the teardown</h2>
 				<p class="mt-3">
-					$5,000, paid up front, credited in full against the sprint if you book one within 90 days.
-					you get the written findings either way and you own them. it carries no obligation on
-					either side — i may decline if your project isn't a fit, and if i decline after you've
-					paid, you get all of it back.
+					{teardownPrice}, paid up front, credited in full against the sprint if you book one within
+					90 days. you get the written findings either way and you own them. it carries no
+					obligation on either side — i may decline if your project isn't a fit, and if i decline
+					after you've paid, you get all of it back.
 				</p>
 			</section>
 

--- a/static/llms-full.txt
+++ b/static/llms-full.txt
@@ -16,7 +16,7 @@ i rebuild it the way i'd build it for myself — the architecture, the security,
 
 ### the foundation
 
-- architecture teardown + premortem — exactly what will break, and why — $3,000
+- architecture teardown + premortem — exactly what will break, and why — $5,000
 - the rebuild — your product, standing on foundations that hold — core
 - security review on every commit — nothing ships that i haven't read — $2,000
 - automated test suite — so it stays fixed after i leave — $2,500
@@ -49,7 +49,7 @@ straight with you: search and answer-engines pay off over months, not days. the 
 - the 90-day growth map — the highest-impact moves, in order — $1,500
 - the runbook + Loom library — so you're never dependent on me again — $1,500
 
-**total value: $28,500+. you pay: $10,000 fixed, or 4 weekly payments of $2,500.** (the $7,500 first-3 intro is closed.)
+**total value: $30,500+. you pay: $10,000 fixed, or 4 weekly payments of $2,500.** (the $7,500 first-3 intro is closed.)
 
 a dev shop quotes $50k and three months. a senior engineer runs $200k a year. this is two weeks, ten grand, and you own all of it.
 
@@ -59,9 +59,9 @@ live in production by day 10, or the remaining payments are free.
 
 and there's a floor under it: day 5, we both look at it. if we can both see it won't ship in scope, we stop there — you keep everything we built and pay only for the time used. the risk is mine to carry, not yours.
 
-## the free teardown
+## the teardown
 
-join the waitlist, then show me the thing — a live url, the repo, or a screen recording — and you get a short recorded teardown of your app. what's solid, the three things that'll break, and what i'd do first. no charge, no call, no pitch. not deployed yet is fine; the repo is the better one for this anyway.
+$5,000, credited in full against the sprint. i read the whole thing — repo, live url, or a screen recording — and write up what's solid, exactly what breaks and in what order, and what i'd do first. it's also how you move now instead of waiting for the next seat. you keep the writeup whether or not we work together, and i'll tell you if you don't need me.
 
 ## who it's for
 
@@ -86,15 +86,15 @@ you (or your AI) got something to a working demo. i take it from there to produc
 
 **how much does it cost?**
 
-$10,000 flat, or 4 weekly payments of $2,500. that price buys the whole ledger on the home page — over $28,500 of itemized work. (the $7,500 first-3 intro is closed.)
+$10,000 flat, or 4 weekly payments of $2,500. that price buys the whole ledger on the home page — over $30,500 of itemized work. (the $7,500 first-3 intro is closed.)
 
 **what's the guarantee?**
 
 live in production by day 10, or the remaining payments are free. there's a floor under it too: at the day-5 scope check, if we can both see it won't ship in scope, we stop — you keep everything built and pay only for the time used.
 
-**what's the free teardown?**
+**what's the teardown?**
 
-join the waitlist, then show me the thing — a live url, the repo, or a screen recording — and i'll record a short teardown of your app. what's solid, the three things that'll break, and what i'd do first. no charge, no call, no pitch. not deployed yet is fine; the repo is the better one for this anyway.
+$5,000, credited in full against the sprint. i read the whole thing — repo, live url, or a screen recording — and write up what's solid, exactly what breaks and in what order, and what i'd do first. it's also how you move now instead of waiting for the next seat. you keep the writeup whether or not we work together, and i'll tell you if you don't need me.
 
 **how long does it take?**
 
@@ -142,7 +142,7 @@ Salvatore D'Angelo. lead engineer at Made In Cookware — multi-million visitors
 
 ## how to engage
 
-- **join the waitlist:** https://sixtom.com/notify — one seat a month; waitlist members get the free teardown while they wait.
+- **join the waitlist:** https://sixtom.com/notify — one seat a month; or take the teardown to move now instead of waiting.
 - **book the intro call:** https://sixtom.com/book — 3 quick steps, then the booking link.
 - **FAQ:** https://sixtom.com/faq — straight answers on price, the day-10 guarantee, timeline, and who's behind it.
 - **the vibe-code tax calculator:** https://sixtom.com/tax — a quick estimate of what the gap is costing you per year. no email.

--- a/static/llms.txt
+++ b/static/llms.txt
@@ -27,7 +27,7 @@ you vibe-coded something to a working demo. it has real users, or paying ones. i
 ## pricing
 
 - sprint: $10,000 USD fixed, or 4 weekly payments of $2,500. 1 client a month, by appointment. (the $7,500 first-3 intro is closed.)
-- teardown: $5,000 USD, credited in full against the sprint. enquire via https://sixtom.com/notify.
+- teardown: $5,000 USD, credited in full against the sprint. via the waitlist at https://sixtom.com/notify.
 
 ## who i am
 

--- a/static/llms.txt
+++ b/static/llms.txt
@@ -4,8 +4,8 @@
 
 ## what i do
 
-- **the production sprint — $10,000.** two weeks. i rebuild your AI-built demo on foundations that hold: architecture teardown + premortem, security review on every commit, automated test suite, performance to 100s, accessibility pass, analytics + observability, CRO-ready pages + A/B scaffold, technical SEO foundation, AEO/GEO foundation, infra cost audit, conversion copy pass, and a brand kit with 1-of-1 art — plus an AI leverage session, a 90-day growth map, and a runbook + Loom library by day 30. total itemized value $28,500+. live on day 10 — you own 100% of it.
-- **the free teardown — $0.** join the waitlist, then show me the thing — a live url, the repo, or a screen recording — and get a short recorded teardown of your app: what's solid, the three things that'll break, and what i'd do first. no charge, no call, no pitch. not deployed yet is fine; the repo is the better one for this anyway.
+- **the production sprint — $10,000.** two weeks. i rebuild your AI-built demo on foundations that hold: architecture teardown + premortem, security review on every commit, automated test suite, performance to 100s, accessibility pass, analytics + observability, CRO-ready pages + A/B scaffold, technical SEO foundation, AEO/GEO foundation, infra cost audit, conversion copy pass, and a brand kit with 1-of-1 art — plus an AI leverage session, a 90-day growth map, and a runbook + Loom library by day 30. total itemized value $30,500+. live on day 10 — you own 100% of it.
+- **the teardown — $5,000, credited in full against the sprint.** i read the whole thing — repo, live url, or a screen recording — and write up what's solid, exactly what breaks and in what order, and what i'd do first. it's also how you move now instead of waiting for the next seat. you keep the writeup whether or not we work together.
 
 ## the guarantee
 
@@ -27,7 +27,7 @@ you vibe-coded something to a working demo. it has real users, or paying ones. i
 ## pricing
 
 - sprint: $10,000 USD fixed, or 4 weekly payments of $2,500. 1 client a month, by appointment. (the $7,500 first-3 intro is closed.)
-- free teardown: $0, via the waitlist at https://sixtom.com/notify.
+- teardown: $5,000 USD, credited in full against the sprint. enquire via https://sixtom.com/notify.
 
 ## who i am
 
@@ -35,7 +35,7 @@ Salvatore D'Angelo. lead engineer at Made In Cookware (multi-million visitors a 
 
 ## how to engage
 
-- [join the waitlist](https://sixtom.com/notify): one seat a month — waitlist members get the free teardown while they wait.
+- [join the waitlist](https://sixtom.com/notify): one seat a month — or take the teardown to move now instead of waiting.
 - [book the intro call](https://sixtom.com/book): 3 quick steps, then the booking link.
 - [FAQ](https://sixtom.com/faq): straight answers — price, the day-10 guarantee, timeline, who's behind it.
 - [the vibe-code tax calculator](https://sixtom.com/tax): what the gap is costing you per year. no email.


### PR DESCRIPTION
The free teardown was the wrong front door: it attracted people with nothing to spend, and delivering it cost hours that don't exist. Payment qualifies harder than the reply-gate did, and a price makes the diagnosis read as professional work rather than a sample.

**$5,000, credited in full against the sprint** (90-day window), so a serious buyer pays nothing extra to move now instead of waiting for the next seat.

The ledger's `architecture teardown + premortem` line moves $3,000 → $5,000 so the standalone price and its itemized value agree. Ledger total $28,500 → $30,500.

### Migrated as one train
Per the coherence rule — prod never shows a mixed offer:

- `site.ts` — new `teardown` block (price + credit note); Cal.com intake option
- `offer.ts` — ledger line, close reward copy
- `faq.ts` — the teardown Q&A, ledger total
- `jsonld.ts` — Service offer #2 now $5,000, driven off `site.teardown`
- `llms.txt` / `llms-full.txt` — offer, pricing and engagement sections
- `contact-form.ts` — waitlist email; reply still qualifies, price qualifies harder
- `terms` — paid terms, refund if declined, 90-day credit window
- `Hero.svelte` — CTA label (umami event name unchanged)
- `sitemap` comment

### Gate
`format` · `lint` · `check` (0 errors) · `test:unit` 57/57 · `build` all green. Verified against a live preview: rendered JSON-LD emits `the teardown / 5000 USD`, and zero "free teardown" strings remain on any surface.

Top-level meta and the OG card sell the sprint, not the teardown, so they're untouched and still accurate.