### PR TITLE
fix: the hero hook wrapped to four fragments on every phone

### DIFF
--- a/e2e/hero-responsive.spec.ts
+++ b/e2e/hero-responsive.spec.ts
@@ -1,0 +1,25 @@
+import { expect, test } from '@playwright/test'
+
+// The hero's two beats ARE the hook — if either wraps, it renders as four
+// orphaned fragments and the structure is lost. The mobile type scale is tuned
+// to the narrowest supported viewport against the current headline, so editing
+// grandSlam.headline can silently break it. 320px is the narrowest phone we
+// support; if this fails after a copy change, lower the mobile clamp rather
+// than accepting the wrap.
+test.describe('hero headline', () => {
+	test.use({ viewport: { width: 320, height: 568 } })
+
+	test('each beat stays on one line at 320px', async ({ page }) => {
+		await page.goto('/')
+		const linesPerBeat = await page.evaluate(() =>
+			[...document.querySelectorAll('h1 > span')].map((el) => {
+				const range = document.createRange()
+				range.selectNodeContents(el)
+				return range.getClientRects().length
+			})
+		)
+
+		expect(linesPerBeat).toHaveLength(2)
+		expect(linesPerBeat).toEqual([1, 1])
+	})
+})

--- a/e2e/hero-responsive.spec.ts
+++ b/e2e/hero-responsive.spec.ts
@@ -11,6 +11,9 @@ test.describe('hero headline', () => {
 
 	test('each beat stays on one line at 320px', async ({ page }) => {
 		await page.goto('/')
+		// The assertion is a text-metric measurement, so it is only meaningful once
+		// the real face is swapped in — against the fallback it measures nothing.
+		await page.evaluate(() => document.fonts.ready)
 		const linesPerBeat = await page.evaluate(() =>
 			[...document.querySelectorAll('h1 > span')].map((el) => {
 				const range = document.createRange()

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -6,15 +6,13 @@ import globals from 'globals'
 import ts from 'typescript-eslint'
 
 // Files outside the tsconfig's include glob (root configs, e2e specs) that
-// still need type-aware lint. Keep under 8 entries; tseslint warns above that.
+// still need type-aware lint. Globbed, not enumerated: tseslint warns past 8
+// entries, and a per-spec list silently fails every new e2e file.
 const ALLOW_DEFAULT_PROJECT = [
 	'eslint.config.js',
 	'svelte.config.js',
 	'playwright.config.ts',
-	'e2e/constants.ts',
-	'e2e/hero-responsive.spec.ts',
-	'e2e/notify-form.spec.ts',
-	'e2e/visual-theme.spec.ts'
+	'e2e/*.ts'
 ]
 
 export default defineConfig(

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -12,6 +12,7 @@ const ALLOW_DEFAULT_PROJECT = [
 	'svelte.config.js',
 	'playwright.config.ts',
 	'e2e/constants.ts',
+	'e2e/hero-responsive.spec.ts',
 	'e2e/notify-form.spec.ts',
 	'e2e/visual-theme.spec.ts'
 ]

--- a/src/lib/components/Hero.svelte
+++ b/src/lib/components/Hero.svelte
@@ -31,11 +31,8 @@
 
 	<div class="relative mx-auto w-full max-w-6xl px-6 py-12 text-left md:py-20 md:text-center">
 		<p class="eyebrow text-fg-muted text-xs md:text-sm">{grandSlam.chip}</p>
-		<!-- Two viewport-width curves, not one. The single clamp's 2.5rem floor
-		     outran every phone (40px at 320-412px), so both beats wrapped and the
-		     hook read as four orphaned fragments instead of two. 8.6vw is the
-		     measured ceiling that keeps the longest beat on one line down to 320px;
-		     md+ keeps the original curve untouched. -->
+		<!-- 8.6vw is the measured ceiling that keeps each beat on one line at 320px;
+		     a floor above ~1.6rem wins on phones and re-wraps them. -->
 		<h1
 			class="text-fg mt-6 text-[clamp(1.6rem,8.6vw,5.75rem)] leading-[1.04] font-bold tracking-tight md:text-[clamp(2.5rem,9.5vw,5.75rem)]"
 		>
@@ -64,16 +61,12 @@
 			</a>
 		</div>
 		<ul
-			class="mt-10 grid list-none grid-cols-[repeat(3,auto)] justify-between gap-x-3 p-0 md:mt-12 md:flex md:flex-wrap md:justify-center md:gap-x-10"
+			class="mt-10 flex list-none justify-between gap-x-2 gap-y-4 p-0 md:mt-12 md:flex-wrap md:justify-center md:gap-x-10"
 		>
 			{#each grandSlam.stats as stat (stat.label)}
 				<li>
-					<p class="text-fg text-sm font-bold tabular-nums md:text-xl">{stat.value}</p>
-					<p
-						class="text-fg-subtle text-[0.625rem] tracking-wider uppercase md:text-xs md:tracking-widest"
-					>
-						{stat.label}
-					</p>
+					<p class="text-fg text-base font-bold tabular-nums md:text-xl">{stat.value}</p>
+					<p class="text-fg-subtle text-xs uppercase md:tracking-widest">{stat.label}</p>
 				</li>
 			{/each}
 		</ul>

--- a/src/lib/components/Hero.svelte
+++ b/src/lib/components/Hero.svelte
@@ -63,11 +63,17 @@
 				or get a free teardown
 			</a>
 		</div>
-		<ul class="mt-10 flex list-none flex-wrap gap-x-10 gap-y-4 p-0 md:mt-12 md:justify-center">
+		<ul
+			class="mt-10 grid list-none grid-cols-[repeat(3,auto)] justify-between gap-x-3 p-0 md:mt-12 md:flex md:flex-wrap md:justify-center md:gap-x-10"
+		>
 			{#each grandSlam.stats as stat (stat.label)}
 				<li>
-					<p class="text-fg text-lg font-bold tabular-nums md:text-xl">{stat.value}</p>
-					<p class="text-fg-subtle text-xs tracking-widest uppercase">{stat.label}</p>
+					<p class="text-fg text-sm font-bold tabular-nums md:text-xl">{stat.value}</p>
+					<p
+						class="text-fg-subtle text-[0.625rem] tracking-wider uppercase md:text-xs md:tracking-widest"
+					>
+						{stat.label}
+					</p>
 				</li>
 			{/each}
 		</ul>

--- a/src/lib/components/Hero.svelte
+++ b/src/lib/components/Hero.svelte
@@ -29,10 +29,15 @@
 		></div>
 	</div>
 
-	<div class="relative mx-auto w-full max-w-6xl px-6 py-16 text-left md:py-20 md:text-center">
+	<div class="relative mx-auto w-full max-w-6xl px-6 py-12 text-left md:py-20 md:text-center">
 		<p class="eyebrow text-fg-muted text-xs md:text-sm">{grandSlam.chip}</p>
+		<!-- Two viewport-width curves, not one. The single clamp's 2.5rem floor
+		     outran every phone (40px at 320-412px), so both beats wrapped and the
+		     hook read as four orphaned fragments instead of two. 8.6vw is the
+		     measured ceiling that keeps the longest beat on one line down to 320px;
+		     md+ keeps the original curve untouched. -->
 		<h1
-			class="text-fg mt-6 text-[clamp(2.5rem,9.5vw,5.75rem)] leading-[1.04] font-bold tracking-tight"
+			class="text-fg mt-6 text-[clamp(1.6rem,8.6vw,5.75rem)] leading-[1.04] font-bold tracking-tight md:text-[clamp(2.5rem,9.5vw,5.75rem)]"
 		>
 			<span class="block text-balance">{beatOne}</span>
 			<span class="block text-balance">{beatTwo}</span>
@@ -42,7 +47,7 @@
 		<p class="text-fg-muted mx-auto mt-8 max-w-3xl text-base leading-relaxed md:text-lg">
 			{grandSlam.lead}
 		</p>
-		<div class="mt-12 flex flex-col items-start gap-4 md:items-center">
+		<div class="mt-10 flex flex-col items-start gap-4 md:mt-12 md:items-center">
 			<a
 				href="#waitlist"
 				data-umami-event="cta_hero_waitlist"
@@ -58,7 +63,7 @@
 				or get a free teardown
 			</a>
 		</div>
-		<ul class="mt-12 flex list-none flex-wrap gap-x-10 gap-y-4 p-0 md:justify-center">
+		<ul class="mt-10 flex list-none flex-wrap gap-x-10 gap-y-4 p-0 md:mt-12 md:justify-center">
 			{#each grandSlam.stats as stat (stat.label)}
 				<li>
 					<p class="text-fg text-lg font-bold tabular-nums md:text-xl">{stat.value}</p>

--- a/src/lib/components/Hero.svelte
+++ b/src/lib/components/Hero.svelte
@@ -61,7 +61,7 @@
 			</a>
 		</div>
 		<ul
-			class="mt-10 flex list-none justify-between gap-x-2 gap-y-4 p-0 md:mt-12 md:flex-wrap md:justify-center md:gap-x-10"
+			class="mt-10 flex list-none flex-wrap justify-between gap-x-2 gap-y-4 p-0 md:mt-12 md:justify-center md:gap-x-10"
 		>
 			{#each grandSlam.stats as stat (stat.label)}
 				<li>


### PR DESCRIPTION
Reported from a live iPhone: the hero "looks fucked in mobile."

### Cause
The h1 used a single `clamp(2.5rem, 9.5vw, 5.75rem)` for all widths. At phone widths 9.5vw is only ~37px, so **the 2.5rem floor won and the type sat flat at 40px from 320px up** — it never scaled down. Both beats wrapped, so the hook rendered as four orphaned lines with the breaks in the wrong places:

```
everyone saw        →   everyone saw the demo
the demo                nobody's seen it since
nobody's
seen it since
```

The two-beat structure that makes the hook land was invisible.

### Fix
Measured rather than guessed — binary-searched the largest font size keeping the longest beat on one line:

| device | width | max single-line |
| --- | --- | --- |
| iPhone SE | 320px | 27.8px = **8.69vw** |
| iPhone 13 | 390px | 34.9px = **8.95vw** |
| Pixel 7 | 412px | 37.1px = **9.00vw** |

`8.6vw` clears all three. **`md:` keeps the original 9.5vw curve**, so desktop is unchanged — verified 72.96px @ 768, capped 92px @ 1024/1440, beats 1 line each.

### Knock-on
h1 height drops **166px → 70px**, which pulls the stat row back inside the fold on iPhone 13 (**750 → 622** against a 664 viewport) — it was previously clipped mid-word behind Safari's chrome. Trimmed mobile-only vertical rhythm to widen that clearance; `md:` spacing untouched.

### Gate
`format` · `lint` · `check` (0 errors) · `test:unit` 57/57 · `build` green. Verified by screenshot at iPhone 13 and SE.

Independent of #173 — different lines in `Hero.svelte`, merges either order.