### PR TITLE
feat: credit claim discloses its terms + one meta set per page

### DIFF
--- a/e2e/credit-terms.spec.ts
+++ b/e2e/credit-terms.spec.ts
@@ -1,0 +1,35 @@
+import { expect, test } from '@playwright/test'
+
+// The credit claim on the home page is unqualified ("credited in full against
+// the sprint") while /terms bounds it to 90 days, so the disclosure is what
+// keeps the marketing line honest. The home route ships no client JS, so it
+// leans entirely on the native popover — if that ever regresses to needing
+// script, the condition silently disappears for the visitor.
+test.describe('teardown credit terms disclosure', () => {
+	test.use({ javaScriptEnabled: false })
+
+	test('discloses the 90-day condition and links to terms, without JS', async ({ page }) => {
+		await page.goto('/')
+		const trigger = page.locator('button[popovertarget="credit-terms"]')
+		const panel = page.locator('#credit-terms')
+
+		await expect(panel).toBeHidden()
+
+		await trigger.click()
+		await expect(panel).toBeVisible()
+		await expect(panel).toContainText('90 days')
+		await expect(panel.locator('a')).toHaveAttribute('href', '/terms')
+
+		await page.keyboard.press('Escape')
+		await expect(panel).toBeHidden()
+	})
+
+	test('the trigger names itself as a terms disclosure', async ({ page }) => {
+		await page.goto('/')
+		// The visible phrase must stay inside the accessible name (WCAG 2.5.3),
+		// with the screen-reader-only suffix explaining what activating it does.
+		await expect(page.locator('button[popovertarget="credit-terms"]')).toHaveAccessibleName(
+			/credited in full against the sprint.*see terms/
+		)
+	})
+})

--- a/e2e/credit-terms.spec.ts
+++ b/e2e/credit-terms.spec.ts
@@ -1,34 +1,44 @@
-import { expect, test } from '@playwright/test'
+import { expect, test, type Page } from '@playwright/test'
 
 // The credit claim on the home page is unqualified ("credited in full against
 // the sprint") while /terms bounds it to 90 days, so the disclosure is what
 // keeps the marketing line honest. The home route ships no client JS, so it
 // leans entirely on the native popover — if that ever regresses to needing
 // script, the condition silently disappears for the visitor.
+// Selected by role and accessible name, not by id — the panel id is generated
+// per instance, and this is what a user actually perceives.
+const trigger = (page: Page) =>
+	page.getByRole('button', { name: /credited in full against the sprint/ })
+const panel = (page: Page) => page.getByText(/credited against the sprint if you book one/)
+
 test.describe('teardown credit terms disclosure', () => {
 	test.use({ javaScriptEnabled: false })
 
-	test('discloses the 90-day condition and links to terms, without JS', async ({ page }) => {
-		await page.goto('/')
-		const trigger = page.locator('button[popovertarget="credit-terms"]')
-		const panel = page.locator('#credit-terms')
+	for (const route of ['/', '/notify']) {
+		test(`${route} discloses the 90-day condition and links to terms, without JS`, async ({
+			page
+		}) => {
+			await page.goto(route)
+			await expect(panel(page)).toBeHidden()
 
-		await expect(panel).toBeHidden()
+			await trigger(page).click()
+			await expect(panel(page)).toBeVisible()
+			await expect(panel(page)).toContainText('90 days')
+			await expect(page.getByRole('link', { name: /read the full terms/ })).toHaveAttribute(
+				'href',
+				'/terms'
+			)
 
-		await trigger.click()
-		await expect(panel).toBeVisible()
-		await expect(panel).toContainText('90 days')
-		await expect(panel.locator('a')).toHaveAttribute('href', '/terms')
-
-		await page.keyboard.press('Escape')
-		await expect(panel).toBeHidden()
-	})
+			await page.keyboard.press('Escape')
+			await expect(panel(page)).toBeHidden()
+		})
+	}
 
 	test('the trigger names itself as a terms disclosure', async ({ page }) => {
 		await page.goto('/')
 		// The visible phrase must stay inside the accessible name (WCAG 2.5.3),
 		// with the screen-reader-only suffix explaining what activating it does.
-		await expect(page.locator('button[popovertarget="credit-terms"]')).toHaveAccessibleName(
+		await expect(trigger(page)).toHaveAccessibleName(
 			/credited in full against the sprint.*see terms/
 		)
 	})

--- a/src/app.html
+++ b/src/app.html
@@ -7,11 +7,12 @@
 		<meta name="author" content="Salvatore D'Angelo" />
 		<meta name="format-detection" content="telephone=no" />
 
-		<title>SIXTOM — everyone saw the demo. nobody's seen it since.</title>
-		<meta
-			name="description"
-			content="the production sprint: live in production on day 10 — and you own every line of it. $10,000 flat, 1 client a month."
-		/>
+		<!-- Title, description and the og/twitter title+description pairs are the
+		     HOME page's copy, so they live in src/routes/+page.svelte. Kept here
+		     they were emitted on every route, and each route that set its own then
+		     rendered two - with this one first, which is the one crawlers take.
+		     Only genuinely global tags (card type, image) belong in this file. -->
+
 		<!-- Canonical URL is set dynamically per-route in src/routes/+layout.svelte
 		     using $app/state's page.url.pathname; do not hardcode here to avoid
 		     duplicate canonical tags on non-home routes. -->
@@ -36,11 +37,6 @@
 			crossorigin
 		/>
 
-		<meta property="og:title" content="SIXTOM — everyone saw the demo. nobody's seen it since." />
-		<meta
-			property="og:description"
-			content="live in production on day 10 — and you own every line of it. $10,000 flat, 1 client a month."
-		/>
 		<meta property="og:type" content="website" />
 		<!-- og:url lives in +layout.svelte (per-route, alongside canonical) — a
 		     static one here would duplicate it and scrapers take the first. -->
@@ -53,11 +49,6 @@
 		/>
 
 		<meta name="twitter:card" content="summary_large_image" />
-		<meta name="twitter:title" content="SIXTOM — everyone saw the demo. nobody's seen it since." />
-		<meta
-			name="twitter:description"
-			content="live in production on day 10 — and you own every line of it. $10,000 flat, 1 client a month."
-		/>
 		<meta name="twitter:image" content="https://sixtom.com/og.png" />
 		<meta
 			name="twitter:image:alt"

--- a/src/lib/components/PageMeta.svelte
+++ b/src/lib/components/PageMeta.svelte
@@ -1,0 +1,21 @@
+<script lang="ts">
+	// One title and one description per page, emitted once each into the tags
+	// that need them. Hand-written heads had every route repeating both strings
+	// across the plain/og/twitter variants, which is how og and twitter drift
+	// apart. app.html keeps only the tags that are genuinely global (card type,
+	// image, og:type) — anything page-specific there lands on every route.
+	let {
+		title,
+		description,
+		socialDescription = description
+	}: { title: string; description: string; socialDescription?: string } = $props()
+</script>
+
+<svelte:head>
+	<title>{title}</title>
+	<meta name="description" content={description} />
+	<meta property="og:title" content={title} />
+	<meta property="og:description" content={socialDescription} />
+	<meta name="twitter:title" content={title} />
+	<meta name="twitter:description" content={socialDescription} />
+</svelte:head>

--- a/src/lib/components/TeardownReward.svelte
+++ b/src/lib/components/TeardownReward.svelte
@@ -9,7 +9,9 @@
 	let { class: className = '' }: { class?: string } = $props()
 
 	const { close } = grandSlam
-	const PANEL_ID = 'credit-terms'
+	// Rendered on both / and /notify; a literal id would collide the moment two
+	// instances shared a page.
+	const PANEL_ID = $props.id()
 </script>
 
 <p class={className}>

--- a/src/lib/components/TeardownReward.svelte
+++ b/src/lib/components/TeardownReward.svelte
@@ -1,0 +1,37 @@
+<script lang="ts">
+	import { grandSlam, site } from '$lib/content'
+
+	// The home page ships zero client JS (csr = false), so the disclosure is the
+	// native popover: popovertarget needs no script, and the platform supplies
+	// Esc, light-dismiss and focus handling. Browsers without it render the panel
+	// inline instead of hiding it, which is the right way to fail for a term the
+	// buyer is entitled to read.
+	let { class: className = '' }: { class?: string } = $props()
+
+	const { close } = grandSlam
+	const PANEL_ID = 'credit-terms'
+</script>
+
+<p class={className}>
+	{close.rewardBefore}
+	<button
+		type="button"
+		popovertarget={PANEL_ID}
+		class="text-fg hover:decoration-accent focus-visible:ring-accent cursor-pointer rounded-sm underline decoration-dotted underline-offset-4 focus-visible:ring-2 focus-visible:outline-none"
+	>
+		{site.teardown.creditNote}<span class="sr-only">&nbsp;— see terms</span>
+	</button>{close.rewardAfter}
+</p>
+
+<div
+	id={PANEL_ID}
+	popover
+	class="border-border bg-surface text-fg-muted m-auto w-[calc(100vw-3rem)] max-w-sm rounded-lg border p-5 text-base leading-relaxed shadow-xl backdrop:bg-black/60"
+>
+	<p>{close.creditTerms}</p>
+	<a
+		href="/terms"
+		data-umami-event="reward_terms_link"
+		class="text-fg mt-4 inline-block text-sm underline underline-offset-4">read the full terms →</a
+	>
+</div>

--- a/src/lib/content/faq.ts
+++ b/src/lib/content/faq.ts
@@ -24,7 +24,7 @@ export const FAQ: readonly QA[] = [
 	{
 		question: "what's the teardown?",
 		answer:
-			"$5,000, credited in full against the sprint. i read the whole thing — repo, live url, or a screen recording — and write up what's solid, exactly what breaks and in what order, and what i'd do first. it's also how you move now instead of waiting for the next seat. you keep the writeup whether or not we work together, and i'll tell you if you don't need me."
+			"$5,000, credited in full against the sprint if you book one within 90 days. i read the whole thing — repo, live url, or a screen recording — and write up what's solid, exactly what breaks and in what order, and what i'd do first. it's also how you move now instead of waiting for the next seat. you keep the writeup whether or not we work together, and i'll tell you if you don't need me."
 	},
 	{
 		question: 'how long does it take?',

--- a/src/lib/content/offer.ts
+++ b/src/lib/content/offer.ts
@@ -208,7 +208,11 @@ export const grandSlam: GrandSlamOffer = {
 		buildLabel: 'what did you build?',
 		buildPlaceholder: 'a demo of… it works, but…',
 		button: 'get on the list →',
-		reward: `the seat's booked out? good sign. if you'd rather not wait, the teardown is how you move now: $${site.teardown.priceUSD.toLocaleString('en-US')}, ${site.teardown.creditNote}. i read the whole thing and tell you exactly what breaks, in what order, and what i'd do first. you get the writeup whether or not we ever work together.`
+		// Split around site.teardown.creditNote so the claim can carry its own
+		// condition inline — the unqualified version outruns what /terms actually says.
+		rewardBefore: `the seat's booked out? good sign. if you'd rather not wait, the teardown is how you move now: $${site.teardown.priceUSD.toLocaleString('en-US')},`,
+		rewardAfter: `. i read the whole thing and tell you exactly what breaks, in what order, and what i'd do first. you get the writeup whether or not we ever work together.`,
+		creditTerms: `paid up front. credited against the sprint if you book one within 90 days — and if i decline your project after you've paid, you get all of it back.`
 	}
 }
 

--- a/src/lib/content/types.ts
+++ b/src/lib/content/types.ts
@@ -137,6 +137,8 @@ export interface GrandSlamOffer {
 		buildLabel: string
 		buildPlaceholder: string
 		button: string
-		reward: string
+		rewardBefore: string
+		rewardAfter: string
+		creditTerms: string
 	}
 }

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -10,27 +10,24 @@
 		'text-fg mt-2 text-3xl leading-tight font-bold tracking-tight text-balance md:text-5xl'
 	const bodyClass = 'text-fg-muted mt-6 max-w-2xl text-base leading-relaxed md:text-lg'
 	const usd = (n: number) => `$${n.toLocaleString('en-US')}`
+
+	// One string, three tags: og and twitter drift apart the moment they are
+	// edited separately.
+	const socialDescription =
+		'live in production on day 10 — and you own every line of it. $10,000 flat, 1 client a month.'
+	const pageTitle = `SIXTOM — ${o.headline}`
 </script>
 
 <svelte:head>
 	<!-- Moved out of app.html: kept there, these were emitted on every route and
 	     every route setting its own then rendered two. Title derives from the
 	     headline so the hook and the SERP entry cannot drift apart. -->
-	<title>SIXTOM — {o.headline}</title>
-	<meta
-		name="description"
-		content="the production sprint: live in production on day 10 — and you own every line of it. $10,000 flat, 1 client a month."
-	/>
-	<meta property="og:title" content="SIXTOM — {o.headline}" />
-	<meta
-		property="og:description"
-		content="live in production on day 10 — and you own every line of it. $10,000 flat, 1 client a month."
-	/>
-	<meta name="twitter:title" content="SIXTOM — {o.headline}" />
-	<meta
-		name="twitter:description"
-		content="live in production on day 10 — and you own every line of it. $10,000 flat, 1 client a month."
-	/>
+	<title>{pageTitle}</title>
+	<meta name="description" content="the production sprint: {socialDescription}" />
+	<meta property="og:title" content={pageTitle} />
+	<meta property="og:description" content={socialDescription} />
+	<meta name="twitter:title" content={pageTitle} />
+	<meta name="twitter:description" content={socialDescription} />
 </svelte:head>
 
 <Hero />

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -12,6 +12,27 @@
 	const usd = (n: number) => `$${n.toLocaleString('en-US')}`
 </script>
 
+<svelte:head>
+	<!-- Moved out of app.html: kept there, these were emitted on every route and
+	     every route setting its own then rendered two. Title derives from the
+	     headline so the hook and the SERP entry cannot drift apart. -->
+	<title>SIXTOM — {o.headline}</title>
+	<meta
+		name="description"
+		content="the production sprint: live in production on day 10 — and you own every line of it. $10,000 flat, 1 client a month."
+	/>
+	<meta property="og:title" content="SIXTOM — {o.headline}" />
+	<meta
+		property="og:description"
+		content="live in production on day 10 — and you own every line of it. $10,000 flat, 1 client a month."
+	/>
+	<meta name="twitter:title" content="SIXTOM — {o.headline}" />
+	<meta
+		name="twitter:description"
+		content="live in production on day 10 — and you own every line of it. $10,000 flat, 1 client a month."
+	/>
+</svelte:head>
+
 <Hero />
 
 <!-- the wall -->

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import Hero from '$lib/components/Hero.svelte'
 	import SiteFooter from '$lib/components/SiteFooter.svelte'
+	import TeardownReward from '$lib/components/TeardownReward.svelte'
 	import { site, grandSlam, LEDGER_TOTAL_USD } from '$lib/content'
 
 	const o = grandSlam
@@ -236,7 +237,7 @@
 			</button>
 		</form>
 
-		<p class="text-fg-muted mt-8 max-w-xl text-base leading-relaxed">{o.close.reward}</p>
+		<TeardownReward class="text-fg-muted mt-8 max-w-xl text-base leading-relaxed" />
 	</div>
 </section>
 

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -3,6 +3,7 @@
 	import SiteFooter from '$lib/components/SiteFooter.svelte'
 	import TeardownReward from '$lib/components/TeardownReward.svelte'
 	import { site, grandSlam, LEDGER_TOTAL_USD } from '$lib/content'
+	import PageMeta from '$lib/components/PageMeta.svelte'
 
 	const o = grandSlam
 	const eyebrowClass = 'eyebrow text-sm'
@@ -18,17 +19,11 @@
 	const pageTitle = `SIXTOM — ${o.headline}`
 </script>
 
-<svelte:head>
-	<!-- Moved out of app.html: kept there, these were emitted on every route and
-	     every route setting its own then rendered two. Title derives from the
-	     headline so the hook and the SERP entry cannot drift apart. -->
-	<title>{pageTitle}</title>
-	<meta name="description" content="the production sprint: {socialDescription}" />
-	<meta property="og:title" content={pageTitle} />
-	<meta property="og:description" content={socialDescription} />
-	<meta name="twitter:title" content={pageTitle} />
-	<meta name="twitter:description" content={socialDescription} />
-</svelte:head>
+<PageMeta
+	title={pageTitle}
+	description="the production sprint: {socialDescription}"
+	{socialDescription}
+/>
 
 <Hero />
 

--- a/src/routes/accessibility/+page.svelte
+++ b/src/routes/accessibility/+page.svelte
@@ -1,20 +1,13 @@
 <script lang="ts">
 	import SiteFooter from '$lib/components/SiteFooter.svelte'
 	import { site } from '$lib/content'
+	import PageMeta from '$lib/components/PageMeta.svelte'
 </script>
 
-<svelte:head>
-	<title>accessibility | SIXTOM</title>
-	<meta
-		name="description"
-		content="what sixtom does to stay usable for everyone, how it's checked, and how to report a problem."
-	/>
-	<meta property="og:title" content="accessibility | SIXTOM" />
-	<meta
-		property="og:description"
-		content="what sixtom does to stay usable for everyone, how it's checked, and how to report a problem."
-	/>
-</svelte:head>
+<PageMeta
+	title="accessibility | SIXTOM"
+	description="what sixtom does to stay usable for everyone, how it's checked, and how to report a problem."
+/>
 
 <div class="bg-surface flex min-h-svh flex-col">
 	<div class="mx-auto w-full max-w-3xl flex-1 px-6 py-20">

--- a/src/routes/accessibility/+page.svelte
+++ b/src/routes/accessibility/+page.svelte
@@ -9,6 +9,11 @@
 		name="description"
 		content="what sixtom does to stay usable for everyone, how it's checked, and how to report a problem."
 	/>
+	<meta property="og:title" content="accessibility | SIXTOM" />
+	<meta
+		property="og:description"
+		content="what sixtom does to stay usable for everyone, how it's checked, and how to report a problem."
+	/>
 </svelte:head>
 
 <div class="bg-surface flex min-h-svh flex-col">

--- a/src/routes/book/+page.svelte
+++ b/src/routes/book/+page.svelte
@@ -54,6 +54,11 @@
 		name="description"
 		content="see if the sprint is a fit. 3 quick steps, then the booking link."
 	/>
+	<meta property="og:title" content="book | SIXTOM" />
+	<meta
+		property="og:description"
+		content="see if the sprint is a fit. 3 quick steps, then the booking link."
+	/>
 </svelte:head>
 
 <div class="bg-surface min-h-screen">

--- a/src/routes/book/+page.svelte
+++ b/src/routes/book/+page.svelte
@@ -2,6 +2,7 @@
 	import { enhance } from '$app/forms'
 	import type { ActionData } from './$types'
 	import { STAGE_OPTIONS, BUDGET_OPTIONS, DISQUALIFY_STAGE } from './options'
+	import PageMeta from '$lib/components/PageMeta.svelte'
 
 	let { form }: { form: ActionData } = $props()
 
@@ -47,18 +48,13 @@
 	const stepHeadClass = 'text-fg mt-2 text-2xl font-semibold tracking-tight md:text-3xl'
 </script>
 
+<PageMeta
+	title="book | SIXTOM"
+	description="see if the sprint is a fit. 3 quick steps, then the booking link."
+/>
+
 <svelte:head>
-	<title>book | SIXTOM</title>
 	<meta name="robots" content="noindex, nofollow" />
-	<meta
-		name="description"
-		content="see if the sprint is a fit. 3 quick steps, then the booking link."
-	/>
-	<meta property="og:title" content="book | SIXTOM" />
-	<meta
-		property="og:description"
-		content="see if the sprint is a fit. 3 quick steps, then the booking link."
-	/>
 </svelte:head>
 
 <div class="bg-surface min-h-screen">

--- a/src/routes/faq/+page.svelte
+++ b/src/routes/faq/+page.svelte
@@ -20,7 +20,6 @@
 		property="og:description"
 		content="what sixtom costs, how the sprint and the day-10 guarantee work."
 	/>
-	<meta property="og:type" content="website" />
 	<!-- eslint-disable-next-line svelte/no-at-html-tags -- safe: JSON.stringify of typed in-repo content -->
 	{@html faqLd}
 </svelte:head>

--- a/src/routes/faq/+page.svelte
+++ b/src/routes/faq/+page.svelte
@@ -3,23 +3,20 @@
 	import { faqPageJsonLd, renderJsonLd } from '$lib/seo/jsonld'
 	import BookCta from '$lib/components/BookCta.svelte'
 	import SiteFooter from '$lib/components/SiteFooter.svelte'
+	import PageMeta from '$lib/components/PageMeta.svelte'
 
 	// Visible FAQ + matching FAQPage schema (engines require the answer text be on
 	// the page, which it is). Questions/answers live in src/lib/content/faq.ts.
 	const faqLd = renderJsonLd(faqPageJsonLd(FAQ, `${site.siteUrl}/faq`))
 </script>
 
+<PageMeta
+	title="faq | SIXTOM"
+	description="what sixtom costs, how the two-week sprint and the day-10 guarantee work, and what the teardown is."
+	socialDescription="what sixtom costs, how the sprint and the day-10 guarantee work."
+/>
+
 <svelte:head>
-	<title>faq | SIXTOM</title>
-	<meta
-		name="description"
-		content="what sixtom costs, how the two-week sprint and the day-10 guarantee work, and what the teardown is."
-	/>
-	<meta property="og:title" content="faq | SIXTOM" />
-	<meta
-		property="og:description"
-		content="what sixtom costs, how the sprint and the day-10 guarantee work."
-	/>
 	<!-- eslint-disable-next-line svelte/no-at-html-tags -- safe: JSON.stringify of typed in-repo content -->
 	{@html faqLd}
 </svelte:head>

--- a/src/routes/log/+page.svelte
+++ b/src/routes/log/+page.svelte
@@ -2,6 +2,7 @@
 	import { LOG_ENTRIES } from '$lib/log'
 	import { blogJsonLd, renderJsonLd } from '$lib/seo/jsonld'
 	import SiteFooter from '$lib/components/SiteFooter.svelte'
+	import PageMeta from '$lib/components/PageMeta.svelte'
 
 	const blogDescription =
 		'case studies and build notes from the work — what i shipped, why, and what the numbers showed.'
@@ -25,11 +26,9 @@
 	const entries = [...LOG_ENTRIES].sort((a, b) => b.date.localeCompare(a.date))
 </script>
 
+<PageMeta title="log | SIXTOM" description={blogDescription} />
+
 <svelte:head>
-	<title>log | SIXTOM</title>
-	<meta name="description" content={blogDescription} />
-	<meta property="og:title" content="log | SIXTOM" />
-	<meta property="og:description" content={blogDescription} />
 	<!-- eslint-disable-next-line svelte/no-at-html-tags -- safe: JSON.stringify of typed in-repo content -->
 	{@html blogLd}
 </svelte:head>

--- a/src/routes/log/+page.svelte
+++ b/src/routes/log/+page.svelte
@@ -30,7 +30,6 @@
 	<meta name="description" content={blogDescription} />
 	<meta property="og:title" content="log | SIXTOM" />
 	<meta property="og:description" content={blogDescription} />
-	<meta property="og:type" content="website" />
 	<!-- eslint-disable-next-line svelte/no-at-html-tags -- safe: JSON.stringify of typed in-repo content -->
 	{@html blogLd}
 </svelte:head>

--- a/src/routes/notify/+page.svelte
+++ b/src/routes/notify/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { enhance } from '$app/forms'
 	import SiteFooter from '$lib/components/SiteFooter.svelte'
+	import TeardownReward from '$lib/components/TeardownReward.svelte'
 	import { grandSlam } from '$lib/content'
 	import type { ActionData } from './$types'
 
@@ -40,7 +41,7 @@
 		<div class="mx-auto w-full max-w-2xl">
 			<p class="eyebrow text-sm">{close.scarcity}</p>
 			<h1 class="text-fg mt-2 text-3xl font-bold tracking-tight md:text-5xl">{close.heading}</h1>
-			<p class="text-fg-muted mt-6 text-lg leading-relaxed">{close.reward}</p>
+			<TeardownReward class="text-fg-muted mt-6 text-lg leading-relaxed" />
 
 			<form
 				method="post"

--- a/src/routes/notify/+page.svelte
+++ b/src/routes/notify/+page.svelte
@@ -24,6 +24,11 @@
 		name="description"
 		content="one client a month. join the waitlist — or start with a paid teardown and move now."
 	/>
+	<meta property="og:title" content="waitlist | SIXTOM" />
+	<meta
+		property="og:description"
+		content="one client a month. join the waitlist — or start with a paid teardown and move now."
+	/>
 </svelte:head>
 
 <div class="bg-surface flex min-h-screen flex-col">

--- a/src/routes/notify/+page.svelte
+++ b/src/routes/notify/+page.svelte
@@ -4,6 +4,7 @@
 	import TeardownReward from '$lib/components/TeardownReward.svelte'
 	import { grandSlam } from '$lib/content'
 	import type { ActionData } from './$types'
+	import PageMeta from '$lib/components/PageMeta.svelte'
 
 	let { form }: { form: ActionData } = $props()
 
@@ -18,18 +19,10 @@
 	})
 </script>
 
-<svelte:head>
-	<title>waitlist | SIXTOM</title>
-	<meta
-		name="description"
-		content="one client a month. join the waitlist — or start with a paid teardown and move now."
-	/>
-	<meta property="og:title" content="waitlist | SIXTOM" />
-	<meta
-		property="og:description"
-		content="one client a month. join the waitlist — or start with a paid teardown and move now."
-	/>
-</svelte:head>
+<PageMeta
+	title="waitlist | SIXTOM"
+	description="one client a month. join the waitlist — or start with a paid teardown and move now."
+/>
 
 <div class="bg-surface flex min-h-screen flex-col">
 	<div class="mx-auto w-full max-w-2xl px-6 pt-12">

--- a/src/routes/privacy/+page.svelte
+++ b/src/routes/privacy/+page.svelte
@@ -8,6 +8,11 @@
 		name="description"
 		content="what sixtom collects, what it doesn't, and how to get it deleted."
 	/>
+	<meta property="og:title" content="privacy | SIXTOM" />
+	<meta
+		property="og:description"
+		content="what sixtom collects, what it doesn't, and how to get it deleted."
+	/>
 </svelte:head>
 
 <div class="bg-surface flex min-h-svh flex-col">

--- a/src/routes/privacy/+page.svelte
+++ b/src/routes/privacy/+page.svelte
@@ -1,19 +1,12 @@
 <script lang="ts">
 	import SiteFooter from '$lib/components/SiteFooter.svelte'
+	import PageMeta from '$lib/components/PageMeta.svelte'
 </script>
 
-<svelte:head>
-	<title>privacy | SIXTOM</title>
-	<meta
-		name="description"
-		content="what sixtom collects, what it doesn't, and how to get it deleted."
-	/>
-	<meta property="og:title" content="privacy | SIXTOM" />
-	<meta
-		property="og:description"
-		content="what sixtom collects, what it doesn't, and how to get it deleted."
-	/>
-</svelte:head>
+<PageMeta
+	title="privacy | SIXTOM"
+	description="what sixtom collects, what it doesn't, and how to get it deleted."
+/>
 
 <div class="bg-surface flex min-h-svh flex-col">
 	<div class="mx-auto w-full max-w-3xl flex-1 px-6 py-20">

--- a/src/routes/tax/+page.svelte
+++ b/src/routes/tax/+page.svelte
@@ -14,7 +14,6 @@
 		property="og:description"
 		content="how much your vibe-coded prototype is costing you per year."
 	/>
-	<meta property="og:type" content="website" />
 </svelte:head>
 
 <div class="bg-surface flex min-h-screen flex-col">

--- a/src/routes/tax/+page.svelte
+++ b/src/routes/tax/+page.svelte
@@ -1,20 +1,14 @@
 <script lang="ts">
 	import VibeTaxCalculator from '$lib/components/VibeTaxCalculator.svelte'
 	import SiteFooter from '$lib/components/SiteFooter.svelte'
+	import PageMeta from '$lib/components/PageMeta.svelte'
 </script>
 
-<svelte:head>
-	<title>vibe-code tax | SIXTOM</title>
-	<meta
-		name="description"
-		content="how much your vibe-coded prototype is costing you per year. 3 inputs, instant number, no email."
-	/>
-	<meta property="og:title" content="vibe-code tax | SIXTOM" />
-	<meta
-		property="og:description"
-		content="how much your vibe-coded prototype is costing you per year."
-	/>
-</svelte:head>
+<PageMeta
+	title="vibe-code tax | SIXTOM"
+	description="how much your vibe-coded prototype is costing you per year. 3 inputs, instant number, no email."
+	socialDescription="how much your vibe-coded prototype is costing you per year."
+/>
 
 <div class="bg-surface flex min-h-screen flex-col">
 	<div class="mx-auto w-full max-w-3xl px-6 pt-12">

--- a/src/routes/terms/+page.svelte
+++ b/src/routes/terms/+page.svelte
@@ -11,6 +11,11 @@
 		name="description"
 		content="how engagement with sixtom works. plain-English terms for the sprint, the day-10 guarantee, and the teardown."
 	/>
+	<meta property="og:title" content="terms | SIXTOM" />
+	<meta
+		property="og:description"
+		content="how engagement with sixtom works. plain-English terms for the sprint, the day-10 guarantee, and the teardown."
+	/>
 </svelte:head>
 
 <div class="bg-surface flex min-h-svh flex-col">

--- a/src/routes/terms/+page.svelte
+++ b/src/routes/terms/+page.svelte
@@ -1,22 +1,15 @@
 <script lang="ts">
 	import SiteFooter from '$lib/components/SiteFooter.svelte'
 	import { site } from '$lib/content'
+	import PageMeta from '$lib/components/PageMeta.svelte'
 
 	const teardownPrice = `$${site.teardown.priceUSD.toLocaleString('en-US')}`
 </script>
 
-<svelte:head>
-	<title>terms | SIXTOM</title>
-	<meta
-		name="description"
-		content="how engagement with sixtom works. plain-English terms for the sprint, the day-10 guarantee, and the teardown."
-	/>
-	<meta property="og:title" content="terms | SIXTOM" />
-	<meta
-		property="og:description"
-		content="how engagement with sixtom works. plain-English terms for the sprint, the day-10 guarantee, and the teardown."
-	/>
-</svelte:head>
+<PageMeta
+	title="terms | SIXTOM"
+	description="how engagement with sixtom works. plain-English terms for the sprint, the day-10 guarantee, and the teardown."
+/>
 
 <div class="bg-surface flex min-h-svh flex-col">
 	<div class="mx-auto w-full max-w-3xl flex-1 px-6 py-20">

--- a/static/llms-full.txt
+++ b/static/llms-full.txt
@@ -61,7 +61,7 @@ and there's a floor under it: day 5, we both look at it. if we can both see it w
 
 ## the teardown
 
-$5,000, credited in full against the sprint. i read the whole thing — repo, live url, or a screen recording — and write up what's solid, exactly what breaks and in what order, and what i'd do first. it's also how you move now instead of waiting for the next seat. you keep the writeup whether or not we work together, and i'll tell you if you don't need me.
+$5,000, credited in full against the sprint if you book one within 90 days. i read the whole thing — repo, live url, or a screen recording — and write up what's solid, exactly what breaks and in what order, and what i'd do first. it's also how you move now instead of waiting for the next seat. you keep the writeup whether or not we work together, and i'll tell you if you don't need me.
 
 ## who it's for
 
@@ -94,7 +94,7 @@ live in production by day 10, or the remaining payments are free. there's a floo
 
 **what's the teardown?**
 
-$5,000, credited in full against the sprint. i read the whole thing — repo, live url, or a screen recording — and write up what's solid, exactly what breaks and in what order, and what i'd do first. it's also how you move now instead of waiting for the next seat. you keep the writeup whether or not we work together, and i'll tell you if you don't need me.
+$5,000, credited in full against the sprint if you book one within 90 days. i read the whole thing — repo, live url, or a screen recording — and write up what's solid, exactly what breaks and in what order, and what i'd do first. it's also how you move now instead of waiting for the next seat. you keep the writeup whether or not we work together, and i'll tell you if you don't need me.
 
 **how long does it take?**
 

--- a/static/llms.txt
+++ b/static/llms.txt
@@ -5,7 +5,7 @@
 ## what i do
 
 - **the production sprint — $10,000.** two weeks. i rebuild your AI-built demo on foundations that hold: architecture teardown + premortem, security review on every commit, automated test suite, performance to 100s, accessibility pass, analytics + observability, CRO-ready pages + A/B scaffold, technical SEO foundation, AEO/GEO foundation, infra cost audit, conversion copy pass, and a brand kit with 1-of-1 art — plus an AI leverage session, a 90-day growth map, and a runbook + Loom library by day 30. total itemized value $30,500+. live on day 10 — you own 100% of it.
-- **the teardown — $5,000, credited in full against the sprint.** i read the whole thing — repo, live url, or a screen recording — and write up what's solid, exactly what breaks and in what order, and what i'd do first. it's also how you move now instead of waiting for the next seat. you keep the writeup whether or not we work together.
+- **the teardown — $5,000, credited in full against the sprint if you book one within 90 days.** i read the whole thing — repo, live url, or a screen recording — and write up what's solid, exactly what breaks and in what order, and what i'd do first. it's also how you move now instead of waiting for the next seat. you keep the writeup whether or not we work together.
 
 ## the guarantee
 
@@ -27,7 +27,7 @@ you vibe-coded something to a working demo. it has real users, or paying ones. i
 ## pricing
 
 - sprint: $10,000 USD fixed, or 4 weekly payments of $2,500. 1 client a month, by appointment. (the $7,500 first-3 intro is closed.)
-- teardown: $5,000 USD, credited in full against the sprint. via the waitlist at https://sixtom.com/notify.
+- teardown: $5,000 USD, credited in full against the sprint if you book one within 90 days. via the waitlist at https://sixtom.com/notify.
 
 ## who i am
 


### PR DESCRIPTION
Two things: the tooltip you asked for, and what auditing every surface for copy consistency turned up.

## The disclosure

The close copy promised the teardown is "credited in full against the sprint" with no bound, while `/terms` limits it to booking within 90 days. The phrase is now a disclosure trigger showing the condition plus a link to full terms.

**Native `popover` + `popovertarget`, because the home route is `csr = false`.** Fully declarative — no script — and the platform supplies Esc, light-dismiss, focus handling and the `::backdrop` overlay.

Verified **with JavaScript disabled**: opens on click, discloses the 90-day condition, `Escape` closes, `Tab` reaches the terms link, and `::backdrop` computes to black at 60%. Browsers without `popover` render the panel inline instead of hiding it — the right way to fail for a term the buyer is entitled to read.

- `close.reward` splits into `rewardBefore`/`rewardAfter` around `site.teardown.creditNote`, so the phrase, the JSON-LD offer and the waitlist email keep one source
- Shared component — `/notify` renders the same copy
- Panel insets by the page gutter (24px), measured at 320/390/412px
- axe clean with the panel open; accessible name keeps the visible phrase (WCAG 2.5.3)

## The audit — two real defects

**Duplicate head tags on eight routes.** `app.html` carried the *home page's* title, description and og/twitter title+description, so every route emitted those **and** its own — two `<meta name="description">` tags, with app.html's first, which is the one crawlers take. **Every per-route description was being silently overridden.** `og:type` duplicated the same way on the three routes that set it.

Home copy moved to the home route; `app.html` keeps only genuinely global tags. Verified exactly one of each across all nine routes.

**An unbounded credit claim on `/faq`** — promised the credit with no condition while `/terms` bounds it. Propagated to the FAQ answer and both llms files, which the repo requires to stay content-identical.

Also gave the five routes lacking them an og title/description pair.

## Gates

Copy audit **0 findings** across 9 routes + `llms.txt` + `llms-full.txt` + JSON-LD · journeys 3/3 · axe clean · Lighthouse 100/100/100/100 mobile, no floor breaches · format/lint/check/58 tests/build green.

Two new e2e specs pin the disclosure (JS-disabled path and accessible name).

Pre-existing and untouched: the stale visual snapshot baseline, and the 119px reflow overflow at 200% zoom from the ledger's `shrink-0` price cells — both identical on `main`.