### PR TITLE
fix(analytics): stop counting honeypot fakes as notify signups

### DIFF
--- a/src/lib/components/umami-events.test.ts
+++ b/src/lib/components/umami-events.test.ts
@@ -68,8 +68,29 @@ describe('Umami CRO event instrumentation', () => {
 		expect(contents).toContain('data-umami-event={event}')
 	})
 
-	it('fires "notify_signup_success" server-side from the notify action', () => {
+	it('fires "notify_signup_success" only for signups that reach the list', () => {
 		const contents = readFileSync(resolve(ROUTES_DIR, 'notify/+page.server.ts'), 'utf-8')
-		expect(contents).toContain("fireServerEvent('notify_signup_success'")
+		// Presence is not enough — it was present before and still wrong. The
+		// event has to sit inside the same guard as the listmonk write, or
+		// honeypot/time-trap fakes (ok + suspicious, silent 200 by design) get
+		// counted as signups: 41 events against 3 subscribers over 30d.
+		const guardStart = contents.indexOf('if (!result.suspicious')
+		expect(guardStart, 'suspicious guard not found').toBeGreaterThan(-1)
+		// Walk to the guard's OWN closing brace. Slicing to the `return`
+		// instead looks equivalent and is not: it also swallows everything
+		// between the closing brace and the return, which is exactly where the
+		// bug used to live, so that version of this test passed on the bug.
+		let depth = 0
+		let guardEnd = contents.indexOf('{', guardStart)
+		for (let i = guardEnd; i < contents.length; i++) {
+			if (contents[i] === '{') depth++
+			else if (contents[i] === '}' && --depth === 0) {
+				guardEnd = i
+				break
+			}
+		}
+		const guarded = contents.slice(guardStart, guardEnd)
+		expect(guarded).toContain('subscribeToList(')
+		expect(guarded).toContain("fireServerEvent('notify_signup_success'")
 	})
 })

--- a/src/routes/notify/+page.server.ts
+++ b/src/routes/notify/+page.server.ts
@@ -29,10 +29,16 @@ export const actions = {
 			// `suspicious`, so it would otherwise flow straight into listmonk.
 			const testEmail = (env['CONTACT_FORM_TEST_EMAIL'] ?? '').trim()
 			const isTestEmail = testEmail !== '' && email === testEmail
+			// The analytics event belongs INSIDE this guard, with the list write.
+			// Outside it, honeypot and time-trap fakes — which return ok+suspicious
+			// on purpose, so bots never learn they were caught — counted as signups:
+			// 41 notify_signup_success events over 30d against 3 real subscribers.
+			// The event and the list have to mean the same thing or the brief
+			// reports a conversion rate that never happened.
 			if (!result.suspicious && email && !isTestEmail) {
 				await subscribeToList(email, SIXTOM_LIST_UUID)
+				fireServerEvent('notify_signup_success', event.request)
 			}
-			fireServerEvent('notify_signup_success', event.request)
 			return { status: 'success' as const, message: result.message }
 		}
 


### PR DESCRIPTION
## The number that prompted this

Over 30d umami recorded **41 `notify_signup_success` events against 3 real subscribers** on the sixtom list. Over 90d: **127 events from 122 visitors** — roughly one "signup" per visitor.

The monday brief reports that as its headline pipeline metric, so sixtom has been reading as a near-100% converting funnel made almost entirely of bots.

## Cause

`processSubmission` returns `ok: true` with `suspicious: true` for honeypot (`company` filled) and time-trap (submitted too fast) hits — a silent 200 by design, so bots never learn they were caught. The listmonk write is guarded against those. The analytics event was not:

```ts
if (!result.suspicious && email && !isTestEmail) {
    await subscribeToList(email, SIXTOM_LIST_UUID)   // humans only
}
fireServerEvent('notify_signup_success', event.request)   // everyone
```

Moved inside the guard. The event and the list now mean the same thing, which is the only way the ratio between them is worth reading.

## On the test

The existing test asserted the call was *present* — it was present, and wrong. Rewritten to assert it sits inside the guard, and **verified by mutation**: hoisting the call back out now fails.

Worth noting, because I got it wrong first: the obvious assertion (slice from the guard to the `return`) still passed on the bug, since the bug lived between the closing brace and the return. The test now walks to the guard's own matching brace.

## Not covered here

`cta_notify_submit` shows 85 events over 90d but 1 over 30d, which is a suspicious divergence from its pair — worth a look separately, but it's client-side and a different mechanism.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RTiERua29bY5kUf62uQkhh